### PR TITLE
Unwrap HTML tags in slugify filter

### DIFF
--- a/frontend/js/utils/filters.js
+++ b/frontend/js/utils/filters.js
@@ -7,6 +7,7 @@ const filters = {
     const p = new RegExp(a.split('').join('|'), 'g')
 
     return value.toString().toLowerCase().trim()
+      .replace(/<\/?[^>]+(>|$)/g, '') // Unwrap HTML tags
       .replace(/\s+/g, '-') // Replace spaces with -
       .replace(p, c =>
         b.charAt(a.indexOf(c))) // Replace special chars


### PR DESCRIPTION
Fixes #7. This makes it so that if you include simple HTML tags in your titles, they will be unwrapped when the titles are transformed into permalink suggestions. This is non-DOM solution for speed.

I do have an alternative solution that uses the DOM:

```javascript
  slugify: function (value) {
    const a = 'àáäâèéëêìíïîòóöôùúüûñçßÿœæŕśńṕẃǵǹḿǘẍźḧ·/_,:;' + 'ąàáäâãåæćęęèéëêìíïîłńòóöôõøśùúüûñçżź'
    const b = 'aaaaeeeeiiiioooouuuuncsyoarsnpwgnmuxzh------' + 'aaaaaaaaceeeeeeiiiilnoooooosuuuunczz'
    const p = new RegExp(a.split('').join('|'), 'g')

    // Perform preliminary normalization
    value = value.toString().toLowerCase().trim()

    // Strip (unwrap) HTML tags using DOM
    const div = document.createElement('div')
    div.innerHTML = value
    value = div.innerText

    // Preform regex replacement
    return value
      .replace(/\s+/g, '-') // Replace spaces with -
      .replace(p, c =>
        b.charAt(a.indexOf(c))) // Replace special chars
      .replace(/&/g, '-and-') // Replace & with 'and'
      .replace(/[^\w-]+/g, '') // Remove all non-word chars
      .replace(/--+/g, '-') // Replace multiple - with single -
  },
```

I know it's generally considered bad practice to parse HTML using regex due to the myriad of edge-cases, but I thought that it might be the more appropriate method in this specific situation.

Even in the case of our website, it's rare for titles to include HTML, and the HTML that will be entered is quite limited. Since the permalink is meant to update as the user types, I feel that speed should be a priority over correctness, and AFAIK, regex is faster than DOM.