### PR TITLE
Fix assets directory cannot locate error during twill setup stage

### DIFF
--- a/src/Commands/Setup.php
+++ b/src/Commands/Setup.php
@@ -9,13 +9,12 @@ class Setup extends Command
 {
     protected $signature = 'twill:setup';
 
-    protected $description = 'Setup Twill superadmin and publish assets/configs';
+    protected $description = 'Setup Twill superadmin and publish configs';
 
     public function handle()
     {
         $this->publishMigrations();
         $this->call('migrate');
-        $this->publishAssets();
         $this->publishConfig();
         $this->createSuperAdmin();
     }
@@ -48,14 +47,6 @@ class Setup extends Command
     private function createSuperAdmin()
     {
         $this->call('twill:superadmin');
-    }
-
-    private function publishAssets()
-    {
-        $this->call('vendor:publish', [
-            '--provider' => 'A17\Twill\TwillServiceProvider',
-            '--tag' => 'assets',
-        ]);
     }
 
     private function publishConfig()

--- a/src/TwillServiceProvider.php
+++ b/src/TwillServiceProvider.php
@@ -46,7 +46,6 @@ class TwillServiceProvider extends ServiceProvider
 
         $this->publishConfigs();
         $this->publishMigrations();
-        $this->publishPublicAssets();
 
         $this->registerCommands();
 
@@ -222,10 +221,6 @@ class TwillServiceProvider extends ServiceProvider
         require_once __DIR__ . '/Helpers/helpers.php';
     }
 
-    private function publishPublicAssets()
-    {
-        $this->publishes([__DIR__ . '/../assets' => public_path('assets')], 'assets');
-    }
 
     private function includeView($view, $expression)
     {


### PR DESCRIPTION
References: #25 

This PR fixed this problem by removing all publishAssets operations from the ServiceProvider as well as the Setup command, cause assets has been compiled by the project using twill instead.