### PR TITLE
removed cartalyst/tags note from documentation

### DIFF
--- a/docs/.sections/getting-started/installation.md
+++ b/docs/.sections/getting-started/installation.md
@@ -9,8 +9,6 @@ composer require area17/twill:1.2.*
 
 Twill will automatically register its service provider if you are using Laravel `>=5.5`. 
 
-If you are using Laravel `5.7`, one of Twill's dependencies, [cartalyst/tags](https://github.com/cartalyst/tags), does not support it yet. We have an issue open with them and a [fork](https://github.com/area17/tags) available for you in the meantime. Add the following to your `composer.json` file so that Twill can install our fork until further notice:
-
 ```json
 "repositories": [
   {


### PR DESCRIPTION
Cartalyst/tags supported Laravel 5.7. Removed note in docs related to the issue.