### PR TITLE
check database connection before twill:install

### DIFF
--- a/src/Commands/Install.php
+++ b/src/Commands/Install.php
@@ -4,6 +4,7 @@ namespace A17\Twill\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Facades\DB;
 
 class Install extends Command
 {
@@ -22,6 +23,14 @@ class Install extends Command
 
     public function handle()
     {
+        //check the database connection before installing
+        try {
+            DB::connection()->getPdo();
+        } catch (\Exception $e) {
+            $this->error('Could not connect to the database, please check your configuration:' . "\n" . $e);
+            return;
+        }
+
         $this->addRoutesFile();
         $this->publishMigrations();
         $this->call('migrate');


### PR DESCRIPTION
The twill:install command entails database connected, however, if the user failed to do that, this command will still try to migrate the database and incur errors. In that case, rerun the command can't fix the error, users may have to removed all migrated tables manually and run the command again. 

This commit will do the database check before running php artisan twill:install to prevent this.