### PR TITLE
Medias fields support in settings

### DIFF
--- a/frontend/js/components/MediaField.vue
+++ b/frontend/js/components/MediaField.vue
@@ -71,6 +71,7 @@
         <a17-button class="cropper__button" variant="action" @click="$refs[cropModalName].close()">Update</a17-button>
       </a17-cropper>
     </a17-modal>
+    <input :name="'medias[' + name + '][' + index + ']'" type="hidden" :value="JSON.stringify(media)" />
   </div>
 </template>
 

--- a/src/Http/Controllers/Admin/SettingController.php
+++ b/src/Http/Controllers/Admin/SettingController.php
@@ -32,7 +32,7 @@ class SettingController extends Controller
             return redirect()->back();
         }
 
-        $this->settings->update(request()->except('_token'), $section);
+        $this->settings->saveAll(request()->except('_token'), $section);
 
         Event::fire('cms-settings.saved', 'cms-settings.saved');
 

--- a/src/Models/Setting.php
+++ b/src/Models/Setting.php
@@ -3,11 +3,12 @@
 namespace A17\Twill\Models;
 
 use A17\Twill\Models\Behaviors\HasTranslation;
+use A17\Twill\Models\Behaviors\HasMedias;
 use A17\Twill\Models\Model;
 
 class Setting extends Model
 {
-    use HasTranslation;
+    use HasTranslation, HasMedias;
 
     public $useTranslationFallback = true;
 

--- a/src/Repositories/Behaviors/HandleMedias.php
+++ b/src/Repositories/Behaviors/HandleMedias.php
@@ -46,10 +46,14 @@ trait HandleMedias
 
         if (isset($fields['medias'])) {
             foreach ($fields['medias'] as $role => $mediasForRole) {
+                
                 if (in_array($role, array_keys($this->model->mediasParams ?? []))
-                    || in_array($role, array_keys(config('twill.block_editor.crops')))) {
+                    || in_array($role, array_keys(config('twill.block_editor.crops')))
+                    || in_array($role, array_keys(config('twill.settings.crops')))) {
+                    
                     collect($mediasForRole)->each(function ($media) use (&$medias, $role) {
                         $customMetadatas = $media['metadatas']['custom'] ?? [];
+                
                         if (isset($media['crops'])) {
                             foreach ($media['crops'] as $cropName => $cropData) {
                                 $medias->push([

--- a/src/Repositories/ModuleRepository.php
+++ b/src/Repositories/ModuleRepository.php
@@ -163,6 +163,17 @@ abstract class ModuleRepository
         return $this->hydrate($object, $fields);
     }
 
+    public function updateOrCreate($attributes, $fields)
+    {
+        $object = $this->model->where($attributes)->first();
+
+        if (!$object) {
+            return $this->create($fields);
+        }
+
+        $this->update($object->id, $fields);
+    }
+
     public function update($id, $fields)
     {
         DB::transaction(function () use ($id, $fields) {

--- a/src/Repositories/SettingRepository.php
+++ b/src/Repositories/SettingRepository.php
@@ -3,9 +3,11 @@
 namespace A17\Twill\Repositories;
 
 use A17\Twill\Models\Setting;
+use A17\Twill\Repositories\Behaviors\HandleMedias;
 
-class SettingRepository
+class SettingRepository extends ModuleRepository
 {
+    use HandleMedias;
 
     public function __construct(Setting $model)
     {
@@ -21,28 +23,35 @@ class SettingRepository
 
     public function getFormFields($section = null)
     {
-        return $this->model->when($section, function ($query) use ($section) {
+        $settings = $this->model->when($section, function ($query) use ($section) {
             $query->where('section', $section);
-        })->with('translations')->get()->mapWithKeys(function ($setting) {
+        })->with('translations', 'medias')->get();
+
+        $medias = $settings->mapWithKeys(function ($setting) {
+            return [$setting->key => parent::getFormFields($setting)['medias'][$setting->key] ?? null];
+        })->filter()->toArray();
+
+        return $settings->mapWithKeys(function ($setting) {
             $settingValue = [];
+            
             foreach ($setting->translations as $translation) {
                 $settingValue[$translation->locale] = $translation->value;
             }
 
-            return [$setting->key => $settingValue];
-        });
+            return [$setting->key => count(getLocales()) > 1 ? $settingValue : $setting->value];
+        })->toArray() + ['medias' => $medias];
     }
 
-    public function update($settingsFields, $section = null)
+    public function saveAll($settingsFields, $section = null)
     {
         $section = $section ? ['section' => $section] : [];
 
-        foreach (collect($settingsFields)->except('active_languages')->filter() as $key => $value) {
+        foreach (collect($settingsFields)->except('active_languages', 'medias', 'mediaMeta')->filter() as $key => $value) {
             foreach (getLocales() as $locale) {
                 array_set(
                     $settingsTranslated,
                     $key . '.' . $locale,
-                    ['value' => $value[$locale]] + ['active' => true]
+                    ['value' => $value[$locale] ?? $value] + ['active' => true]
                 );
             }
         }
@@ -54,5 +63,22 @@ class SettingRepository
         foreach ($settings as $key => $setting) {
             $this->model->updateOrCreate(['key' => $key] + $section, $setting);
         }
+
+        foreach ($settingsFields['medias'] as $role => $mediasList) {            
+            $this->updateOrCreate($section + ['key' => $role], $section + [
+                'key' => $role,
+                'medias' => [
+                    $role => collect($settingsFields['medias'][$role])->map(function ($media) {
+                        return json_decode($media, true);
+                    })->values()->filter()->toArray()
+                ]
+            ]);
+        }
     }
+
+    public function getCrops($role)
+    {
+        return config('twill.settings.crops')[$role];
+    }
+    
 }

--- a/views/layouts/form.blade.php
+++ b/views/layouts/form.blade.php
@@ -165,7 +165,7 @@
     window.STORE.parentId = {{ $item->parent_id ?? 0 }}
     window.STORE.parents = {!! json_encode($parents ?? [])  !!}
 
-    window.STORE.medias.crops = {!! json_encode(($item->mediasParams ?? []) + config('twill.block_editor.crops')) !!}
+    window.STORE.medias.crops = {!! json_encode(($item->mediasParams ?? []) + config('twill.block_editor.crops') + (config('twill.settings.crops') ?? [])) !!}
     window.STORE.medias.selected = {}
 
     window.STORE.browser = {}


### PR DESCRIPTION
Medias fields can now be used in settings pages, with cropping parameters provided in `twill.settings.crops`, exactly like for blocks.