### PR TITLE
Fixed the "offset 'en'" error while updating a setting form which include translate disabled field

### DIFF
--- a/frontend/js/mixins/formStore.js
+++ b/frontend/js/mixins/formStore.js
@@ -91,7 +91,12 @@ export default {
       if (this.locale) {
         this[this.inStore] = fieldInStore[0].value[this.locale.value]
       } else {
-        this[this.inStore] = fieldInStore[0].value
+        // avoid displaying [object object] as string on field˝
+        if (typeof fieldInStore[0].value === 'object') {
+          this[this.inStore] = Object.values(fieldInStore[0].value)[0]
+        } else {
+          this[this.inStore] = fieldInStore[0].value
+        }
       }
     } else if (this.hasDefaultStore) {
       // init value with the one present into the component itself

--- a/src/Http/Controllers/Admin/SettingController.php
+++ b/src/Http/Controllers/Admin/SettingController.php
@@ -32,7 +32,8 @@ class SettingController extends Controller
             return redirect()->back();
         }
 
-        $this->settings->update(request()->except('_token'), $section);
+        $settingFields = collect(request()->except('_token'))->except('active_languages')->filter();
+        $this->settings->update($settingFields, $section);
 
         Event::fire('cms-settings.saved', 'cms-settings.saved');
 

--- a/src/Repositories/SettingRepository.php
+++ b/src/Repositories/SettingRepository.php
@@ -37,18 +37,22 @@ class SettingRepository
     {
         $section = $section ? ['section' => $section] : [];
 
-        foreach (collect($settingsFields)->except('active_languages')->filter() as $key => $value) {
-            foreach (getLocales() as $locale) {
-                array_set(
-                    $settingsTranslated,
-                    $key . '.' . $locale,
-                    ['value' => $value[$locale]] + ['active' => true]
-                );
+        foreach ($settingsFields as $key => $value) {
+            // field translation is disabled
+            if (is_string($value)) {
+                array_set($settings, $key, ['key' => $key] + $section + ['value' => $value]);
+            } else {
+                foreach (getLocales() as $locale) {
+                    array_set(
+                        $settingsTranslated,
+                        $key . '.' . $locale,
+                        ['value' => $value[$locale]] + ['active' => true]
+                    );
+                }
+                foreach ($settingsTranslated as $key => $values) {
+                    array_set($settings, $key, ['key' => $key] + $section + $values);
+                }
             }
-        }
-
-        foreach ($settingsTranslated as $key => $values) {
-            array_set($settings, $key, ['key' => $key] + $section + $values);
         }
 
         foreach ($settings as $key => $setting) {


### PR DESCRIPTION
This PR include the following two commits,
The first commit fixed the error happened when update the setting, by improving the setting update strategy.
The second commit changed A17TextField's value render strategy by converting the passed value to a reasonable string, avoid the situation that in some cases, it will display "[object object]", not only in this case, but also may happen elsewhere. 