### PR TITLE
Invert arguments when calling first() passing an anonymous function

### DIFF
--- a/src/Models/Behaviors/HasFiles.php
+++ b/src/Models/Behaviors/HasFiles.php
@@ -51,7 +51,7 @@ trait HasFiles
     {
         $locale = $locale ?? app()->getLocale();
 
-        return $this->files->first(function ($key, $file) use ($role, $locale) {
+        return $this->files->first(function ($file, $key) use ($role, $locale) {
             return $file->pivot->role === $role && $file->pivot->locale === $locale;
         });
     }


### PR DESCRIPTION
The purpose of this commit is to fix `fileObject`. Parameters were passed using the wrong order.