### PR TITLE
add wide modal option to browser formfield

### DIFF
--- a/frontend/js/components/BrowserField.vue
+++ b/frontend/js/components/BrowserField.vue
@@ -52,6 +52,10 @@
       max: {
         type: Number,
         default: 10
+      },
+      wide: {
+        type: Boolean,
+        default: false
       }
     },
     data: function () {
@@ -115,7 +119,11 @@
         this.$store.commit(BROWSER.UPDATE_BROWSER_ENDPOINT, this.endpoint)
         this.$store.commit(BROWSER.UPDATE_BROWSER_MAX, this.remainingItems)
         this.$store.commit(BROWSER.UPDATE_BROWSER_TITLE, this.browserTitle)
-        this.$root.$refs.browser.open()
+        if (this.wide) {
+          this.$root.$refs.browserWide.open()
+        } else {
+          this.$root.$refs.browser.open()
+        }
       }
     },
     beforeDestroy: function () {

--- a/views/layouts/form.blade.php
+++ b/views/layouts/form.blade.php
@@ -71,6 +71,9 @@
     <a17-modal class="modal--browser" ref="browser" mode="medium" :force-close="true">
         <a17-browser></a17-browser>
     </a17-modal>
+    <a17-modal class="modal--browser" ref="browserWide" mode="wide" :force-close="true">
+        <a17-browser></a17-browser>
+    </a17-modal>
     <a17-editor v-if="editor" ref="editor" bg-color="{{ config('twill.block_editor.background_color') ?? '#FFFFFF' }}"></a17-editor>
     <a17-previewer ref="preview"></a17-previewer>
     <a17-dialog ref="warningContentEditor" modal-title="Delete content" confirm-label="Delete">

--- a/views/partials/form/_browser.blade.php
+++ b/views/partials/form/_browser.blade.php
@@ -6,6 +6,7 @@
     $note = $note ?? 'Add' . ($max > 1 ? " up to $max ". strtolower($label) : ' one ' . str_singular(strtolower($label)));
     $itemLabel = $itemLabel ?? strtolower($label);
     $sortable = $sortable ?? true;
+    $wide = $wide ?? false;
 @endphp
 
 <a17-inputframe label="{{ $label }}" name="browsers.{{ $name }}">
@@ -13,6 +14,7 @@
         @include('twill::partials.form.utils._field_name')
         item-label="{{ $itemLabel }}"
         :max="{{ $max }}"
+        :wide = " {{ json_encode($wide) }} "
         endpoint="{{ $endpoint }}"
         modal-title="Attach {{ strtolower($label) }}"
         :draggable="{{ json_encode($sortable) }}"


### PR DESCRIPTION
Added a new boolean option "wide" on the `@formField('browser')` to open a wide browser,  use it simply like `@formField('browser', ['wide' => true])`