### PR TITLE
Update installation docs to put version constraint in quotes

### DIFF
--- a/docs/.sections/getting-started/installation.md
+++ b/docs/.sections/getting-started/installation.md
@@ -4,7 +4,7 @@
 Twill is a package for Laravel applications, installable through Composer:
 
 ```bash
-composer require area17/twill:1.2.*
+composer require area17/twill:"1.2.*"
 ```
 
 Twill will automatically register its service provider if you are using Laravel `>=5.5`. 


### PR DESCRIPTION
If user is using zsh, problems like `zsh: no matches found: area17/twill:1.2.*` may occur to any commands with `*` outside of the quote, due to zsh globbing feature.