### PR TITLE
add dynamic title option for repeater items

### DIFF
--- a/frontend/js/components/Repeater.vue
+++ b/frontend/js/components/Repeater.vue
@@ -77,7 +77,22 @@
       blocks: {
         get () {
           if (this.savedBlocks.hasOwnProperty(this.name)) {
-            return this.savedBlocks[this.name] || []
+            const blocks = this.savedBlocks[this.name]
+            if (blocks && blocks.length > 0) {
+              const repeaterName = this.name.replace(/(blocks-\d+_)/, '')
+              const titleFieldToMap = this.$store.state.repeaters.availableRepeaters[repeaterName] && this.$store.state.repeaters.availableRepeaters[repeaterName].titleField ? this.$store.state.repeaters.availableRepeaters[repeaterName].titleField : null
+              if (titleFieldToMap) {
+                return blocks.map(block => {
+                  const titleField = this.$store.state.form.fields.find(field => field.name === `blocks[${block.id}][${titleFieldToMap}]`)
+                  if (titleField && titleField.value) block.title = titleField.value
+                  return block
+                })
+              } else {
+                return blocks
+              }
+            } else {
+              return []
+            }
           } else {
             return []
           }


### PR DESCRIPTION
Add option to set title of repeater item (block) dynamically based on a field inside repeater item.

![capture](https://user-images.githubusercontent.com/5628018/50973867-3c6a1a00-14ea-11e9-91d9-99ced47d240d.PNG)

Use by setting a ```titleField``` in repeater array in ```cofig/twill.php```:
```php
return [
    "block_editor" => [
        'blocks' => [...],
        ...
        'repeaters' => [
            'accordion_item' => [
                'title' => 'Accordion Item',
                'titleField' => 'title', // name of field inside repeater item that will be used instead of default 'title' 
                'trigger' => 'Add accordion item',
                'component' => 'a17-block-accordion_item',
                'max' => 10,
            ],
        ],
        ...
    ]
];
``` 
