### PR TITLE
Fix local media/file library issues

### DIFF
--- a/config/disks.php
+++ b/config/disks.php
@@ -1,12 +1,32 @@
 <?php
 
+$localRootPrefix = storage_path('app/public/');
+$localUrlPrefix = env('APP_URL') . '/storage/';
+
+$mediaLocalConfig = [
+    'driver' => 'local',
+    'visibility' => 'public',
+    'root' => $localRootPrefix . trim(config('twill.media_library.local_path'), '/ '),
+    'url' => $localUrlPrefix . trim(config('twill.media_library.local_path'), '/ '),
+];
+
+$fileLocalConfig = [
+    'driver' => 'local',
+    'visibility' => 'public',
+    'root' => $localRootPrefix . trim(config('twill.file_library.local_path'), '/ '),
+    'url' => $localUrlPrefix . trim(config('twill.file_library.local_path'), '/ '),
+];
+
+$s3Config = [
+    'driver' => 's3',
+    'key' => env('S3_KEY', env('AWS_KEY', env('AWS_ACCESS_KEY_ID'))),
+    'secret' => env('S3_SECRET', env('AWS_SECRET', env('AWS_SECRET_ACCESS_KEY'))),
+    'region' => env('S3_REGION', env('AWS_REGION', env('AWS_DEFAULT_REGION', 'us-east-1'))),
+    'bucket' => env('S3_BUCKET', env('AWS_BUCKET')),
+    'use_https' => env('S3_UPLOADER_USE_HTTPS', env('S3_USE_HTTPS', env('AWS_USE_HTTPS', true))),
+];
+
 return [
-    'libraries' => [
-        'driver' => 's3',
-        'key' => env('S3_KEY', env('AWS_KEY', env('AWS_ACCESS_KEY_ID'))),
-        'secret' => env('S3_SECRET', env('AWS_SECRET', env('AWS_SECRET_ACCESS_KEY'))),
-        'region' => env('S3_REGION', env('AWS_REGION', env('AWS_DEFAULT_REGION', 'us-east-1'))),
-        'bucket' => env('S3_BUCKET', env('AWS_BUCKET')),
-        'use_https' => env('S3_UPLOADER_USE_HTTPS', env('S3_USE_HTTPS', env('AWS_USE_HTTPS', true))),
-    ],
+    config('twill.media_library.disk') => config('twill.media_library.endpoint_type') === 'local' ? $mediaLocalConfig : $s3Config,
+    config('twill.file_library.disk') => config('twill.file_library.endpoint_type') === 'local' ? $fileLocalConfig : $s3Config,
 ];

--- a/config/file-library.php
+++ b/config/file-library.php
@@ -18,10 +18,10 @@ return [
     | - 'A17\Twill\Services\FileLibrary\Disk'
     |
      */
-    'disk' => 'libraries',
+    'disk' => 'file_library',
     'endpoint_type' => env('FILE_LIBRARY_ENDPOINT_TYPE', 's3'),
     'cascade_delete' => env('FILE_LIBRARY_CASCADE_DELETE', false),
-    'local_path' => env('FILE_LIBRARY_LOCAL_PATH'),
+    'local_path' => env('FILE_LIBRARY_LOCAL_PATH', 'libraries'),
     'file_service' => env('FILE_LIBRARY_FILE_SERVICE', 'A17\Twill\Services\FileLibrary\Disk'),
     'acl' => env('FILE_LIBRARY_ACL', 'public-read'),
     'filesize_limit' => env('FILE_LIBRARY_FILESIZE_LIMIT', 50),

--- a/config/media-library.php
+++ b/config/media-library.php
@@ -19,10 +19,10 @@ return [
     | - 'A17\Twill\Services\MediaLibrary\Local'
     |
      */
-    'disk' => 'libraries',
+    'disk' => 'media_library',
     'endpoint_type' => env('MEDIA_LIBRARY_ENDPOINT_TYPE', 's3'),
     'cascade_delete' => env('MEDIA_LIBRARY_CASCADE_DELETE', false),
-    'local_path' => env('MEDIA_LIBRARY_LOCAL_PATH'),
+    'local_path' => env('MEDIA_LIBRARY_LOCAL_PATH', 'libraries'),
     'image_service' => env('MEDIA_LIBRARY_IMAGE_SERVICE', 'A17\Twill\Services\MediaLibrary\Imgix'),
     'acl' => env('MEDIA_LIBRARY_ACL', 'private'),
     'filesize_limit' => env('MEDIA_LIBRARY_FILESIZE_LIMIT', 50),

--- a/src/Http/Controllers/Admin/FileLibraryController.php
+++ b/src/Http/Controllers/Admin/FileLibraryController.php
@@ -104,9 +104,10 @@ class FileLibraryController extends ModuleController implements SignS3UploadList
         $filename = $request->input('qqfilename');
         $cleanFilename = preg_replace("/\s+/i", "-", $filename);
 
-        $fileDirectory = public_path(config('twill.file_library.local_path') . $request->input('unique_folder_name'));
+        $fileDirectory = $request->input('unique_folder_name');
+        $disk = config('twill.file_library.disk');
 
-        $request->file('qqfile')->move($fileDirectory, $cleanFilename);
+        $request->file('qqfile')->storeAs($fileDirectory, $cleanFilename, $disk);
 
         $fields = [
             'uuid' => $request->input('unique_folder_name') . '/' . $cleanFilename,

--- a/src/Http/Controllers/Admin/MediaLibraryController.php
+++ b/src/Http/Controllers/Admin/MediaLibraryController.php
@@ -8,6 +8,7 @@ use A17\Twill\Services\Uploader\SignS3UploadListener;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Http\Request;
 use Input;
+use Illuminate\Support\Facades\Storage;
 
 class MediaLibraryController extends ModuleController implements SignS3UploadListener
 {
@@ -117,14 +118,18 @@ class MediaLibraryController extends ModuleController implements SignS3UploadLis
 
         $filename = sanitizeFilename($originalFilename);
 
-        $fileDirectory = public_path(config('twill.media_library.local_path') . $request->input('unique_folder_name'));
+        $fileDirectory =  $request->input('unique_folder_name');
 
-        $request->file('qqfile')->move($fileDirectory, $filename);
+        $disk = config('twill.media_library.disk');
 
-        list($w, $h) = getimagesize($fileDirectory . '/' . $filename);
+        $request->file('qqfile')->storeAs($fileDirectory, $filename, $disk);
+
+        $filePath = Storage::disk($disk)->path($fileDirectory . '/' . $filename);
+
+        list($w, $h) = getimagesize($filePath);
 
         $fields = [
-            'uuid' => config('twill.media_library.local_path') . $request->input('unique_folder_name') . '/' . $filename,
+            'uuid' => $request->input('unique_folder_name') . '/' . $filename,
             'filename' => $originalFilename,
             'width' => $w,
             'height' => $h,

--- a/src/Repositories/FileRepository.php
+++ b/src/Repositories/FileRepository.php
@@ -21,15 +21,11 @@ class FileRepository extends ModuleRepository
         return parent::filter($query, $scopes);
     }
 
-    public function delete($id)
+    public function afterDelete($object)
     {
-        if (($object = $this->model->find($id)) != null) {
-            if ($object->canDeleteSafely()) {
-                $storageId = $object->uuid;
-                if ($object->delete() && config('twill.file_library.cascade_delete')) {
-                    Storage::disk(config('twill.file_library.disk'))->delete($storageId);
-                }
-            }
+        $storageId = $object->uuid;
+        if (config('twill.file_library.cascade_delete')) {
+            Storage::disk(config('twill.file_library.disk'))->delete($storageId);
         }
     }
 

--- a/src/Repositories/MediaRepository.php
+++ b/src/Repositories/MediaRepository.php
@@ -22,19 +22,12 @@ class MediaRepository extends ModuleRepository
         return parent::filter($query, $scopes);
     }
 
-    public function delete($id)
+    public function afterDelete($object)
     {
-        if (($object = $this->model->find($id)) != null) {
-            if ($object->canDeleteSafely()) {
-                $storageId = $object->uuid;
-                if ($object->delete() && config('twill.media_library.cascade_delete')) {
-                    Storage::disk(config('twill.media_library.disk'))->delete($storageId);
-                }
-                return true;
-            }
+        $storageId = $object->uuid;
+        if (config('twill.media_library.cascade_delete')) {
+            Storage::disk(config('twill.media_library.disk'))->delete($storageId);
         }
-
-        return false;
     }
 
     public function prepareFieldsBeforeCreate($fields)

--- a/src/Services/MediaLibrary/Local.php
+++ b/src/Services/MediaLibrary/Local.php
@@ -2,6 +2,9 @@
 
 namespace A17\Twill\Services\MediaLibrary;
 
+use Illuminate\Support\Facades\Storage;
+
+
 class Local implements ImageServiceInterface
 {
     use ImageServiceDefaults;
@@ -38,7 +41,7 @@ class Local implements ImageServiceInterface
 
     public function getRawUrl($id)
     {
-        return '/' . $id;
+        return Storage::disk(config('twill.media_library.disk'))->url($id);
     }
 
     public function getDimensions($id)

--- a/src/TwillServiceProvider.php
+++ b/src/TwillServiceProvider.php
@@ -157,7 +157,6 @@ class TwillServiceProvider extends ServiceProvider
     private function mergeConfigs()
     {
         $this->mergeConfigFrom(__DIR__ . '/../config/twill.php', 'twill');
-        $this->mergeConfigFrom(__DIR__ . '/../config/disks.php', 'filesystems.disks');
         $this->mergeConfigFrom(__DIR__ . '/../config/frontend.php', 'twill.frontend');
         $this->mergeConfigFrom(__DIR__ . '/../config/debug.php', 'twill.debug');
         $this->mergeConfigFrom(__DIR__ . '/../config/seo.php', 'twill.seo');
@@ -168,6 +167,7 @@ class TwillServiceProvider extends ServiceProvider
         $this->mergeConfigFrom(__DIR__ . '/../config/file-library.php', 'twill.file_library');
         $this->mergeConfigFrom(__DIR__ . '/../config/cloudfront.php', 'services');
         $this->mergeConfigFrom(__DIR__ . '/../config/dashboard.php', 'twill.dashboard');
+        $this->mergeConfigFrom(__DIR__ . '/../config/disks.php', 'filesystems.disks');
     }
 
     private function publishMigrations()


### PR DESCRIPTION
Currently, File/Media Library stores the images under the public folder using a local path provided by the user config. However, when trying to delete the images (when using the cascade config) or when trying to get an uploaded file's size, it uses Laravel's Filesystem API (which uses a predefined storage location locally). 
This causes multiple issues such as #79 and #97 

This PR attempts to fix these issues by using Laravel's Filesystem API even when storing local files, and also providing disks configuration for both media/files depending on the user's chosen `endpoint_type` config.

Another issue that is being fixed is the cascade delete option when bulk deleting library assets, I did some refactoring in  **FileRepository**, **MediaRepository** and **ModuleRepository** (which should also solve an unrelated issue and make delete events trigger for other bulk deleted models).

Since we are now using Laravel's storage to store files locally, users would need to run `php artisan storage:link`.

And finally, the `local_path` config is now optional and is relative to the storage's public root path.

Please let me know if there are any issues or modifications that should be made, thanks.