### PR TITLE
Prepend the extra_js section in layout/form.blade.php

### DIFF
--- a/views/layouts/form.blade.php
+++ b/views/layouts/form.blade.php
@@ -183,8 +183,8 @@
     }
 @stop
 
-@push('extra_js')
+@prepend('extra_js')
     <script src="{{ mix('/assets/admin/js/manifest.js') }}"></script>
     <script src="{{ mix('/assets/admin/js/vendor.js') }}"></script>
     <script src="{{ mix('/assets/admin/js/main-form.js') }}"></script>
-@endpush
+@endprepend


### PR DESCRIPTION
This commit changed the way `extra_js` was included in layout/form.blade.php, from `push` to `prepend`, thus user then could be able to access the variable exposed from the js bundle.