### PR TITLE
Changed & for ? in parameter from thumbnail url

### DIFF
--- a/frontend/js/components/MediaField.vue
+++ b/frontend/js/components/MediaField.vue
@@ -462,7 +462,7 @@
 
           // try to load the media thumbnail
           let append = '?';
-          if (this.media.thumbnai.indexOf('?') > -1) {
+          if (this.media.thumbnail.indexOf('?') > -1) {
             append = '&';
           }
           this.img.src = this.media.thumbnail + append + 'no-cache'

--- a/frontend/js/components/MediaField.vue
+++ b/frontend/js/components/MediaField.vue
@@ -461,7 +461,7 @@
           })
 
           // try to load the media thumbnail
-          this.img.src = this.media.thumbnail + '&no-cache'
+          this.img.src = this.media.thumbnail + '?no-cache'
         })
       },
       showDefaultThumbnail: function () {


### PR DESCRIPTION
When using images from amazon, or trough varnish, or local images with `&no-cache` will resolve in a xml's or 404 not found request:

```
https://s3-eu-west-1.amazonaws.com/tpd/logos-domain/4a3199790000640005044e8e/255x0.png&no-cache
```

```
https://s3-eu-west-1.amazonaws.com/tpd/logos-domain/4a3199790000640005044e8e/255x0.png?no-cache
```

This will result in errors in you're console:

![aaaa](https://user-images.githubusercontent.com/7221583/57383038-5ec92700-71ae-11e9-87ce-1039845d26f3.png)

Found by @dravenshorst