### PR TITLE
Add param to pass the type from PHP into Vue component

### DIFF
--- a/views/partials/form/_files.blade.php
+++ b/views/partials/form/_files.blade.php
@@ -1,4 +1,5 @@
 @php
+    $type = $type ?? 'file';
     $max = $max ?? 1;
     $note = $note ?? 'Add' . ($max > 1 ? " up to $max files" : ' one file');
     $itemLabel = $itemLabel ?? strtolower($label);
@@ -7,6 +8,7 @@
 <a17-locale
     type="a17-filefield"
     :attributes="{
+        type: '{{ $type }}',
         label: '{{ $label }}',
         itemLabel: '{{ $itemLabel }}',
         @include('twill::partials.form.utils._field_name', ['asAttributes' => true])

--- a/views/partials/form/_medias.blade.php
+++ b/views/partials/form/_medias.blade.php
@@ -1,4 +1,5 @@
 @php
+    $type = $type ?? 'image';
     $max = $max ?? 1;
     $required = $required ?? false;
     $note = $note ?? '';
@@ -11,6 +12,7 @@
     @if($max > 1 || $max == 0)
         <a17-slideshow
             @include('twill::partials.form.utils._field_name')
+            type="{{ $type }}"
             :max="{{ $max }}"
             crop-context="{{ $name }}"
             @if ($required) :required="true" @endif
@@ -21,6 +23,7 @@
     @else
         <a17-mediafield
             @include('twill::partials.form.utils._field_name')
+            type="{{ $type }}"
             crop-context="{{ $name }}"
             @if ($required) :required="true" @endif
             @if (!$withAddInfo) :with-add-info="false" @endif


### PR DESCRIPTION
If other than default type is desired to be changed in files/medias form fields the type parameter must be passed into component blade.