### PR TITLE
Fix namespace

### DIFF
--- a/src/Commands/ModuleMake.php
+++ b/src/Commands/ModuleMake.php
@@ -109,44 +109,44 @@ class ModuleMake extends Command
 
     private function createModels($modelName = 'Item', $translatable = false, $sluggable = false, $sortable = false, $revisionable = false, $activeTraits = [])
     {
-        if (!$this->files->isDirectory(app_path('Models'))) {
-            $this->files->makeDirectory(app_path('Models'));
+        if (!$this->files->isDirectory(twill_path('Models'))) {
+            $this->files->makeDirectory(twill_path('Models'));
         }
 
         if ($translatable) {
-            if (!$this->files->isDirectory(app_path('Models/Translations'))) {
-                $this->files->makeDirectory(app_path('Models/Translations'));
+            if (!$this->files->isDirectory(twill_path('Models/Translations'))) {
+                $this->files->makeDirectory(twill_path('Models/Translations'));
             }
 
             $modelTranslationClassName = $modelName . 'Translation';
 
             $stub = str_replace('{{modelTranslationClassName}}', $modelTranslationClassName, $this->files->get(__DIR__ . '/stubs/model_translation.stub'));
 
-            $this->files->put(app_path('Models/Translations/' . $modelTranslationClassName . '.php'), $stub);
+            $this->files->put(twill_path('Models/Translations/' . $modelTranslationClassName . '.php'), $stub);
         }
 
         if ($sluggable) {
-            if (!$this->files->isDirectory(app_path('Models/Slugs'))) {
-                $this->files->makeDirectory(app_path('Models/Slugs'));
+            if (!$this->files->isDirectory(twill_path('Models/Slugs'))) {
+                $this->files->makeDirectory(twill_path('Models/Slugs'));
             }
 
             $modelSlugClassName = $modelName . 'Slug';
 
             $stub = str_replace(['{{modelSlugClassName}}', '{{modelName}}'], [$modelSlugClassName, Str::snake($modelName)], $this->files->get(__DIR__ . '/stubs/model_slug.stub'));
 
-            $this->files->put(app_path('Models/Slugs/' . $modelSlugClassName . '.php'), $stub);
+            $this->files->put(twill_path('Models/Slugs/' . $modelSlugClassName . '.php'), $stub);
         }
 
         if ($revisionable) {
-            if (!$this->files->isDirectory(app_path('Models/Revisions'))) {
-                $this->files->makeDirectory(app_path('Models/Revisions'));
+            if (!$this->files->isDirectory(twill_path('Models/Revisions'))) {
+                $this->files->makeDirectory(twill_path('Models/Revisions'));
             }
 
             $modelRevisionClassName = $modelName . 'Revision';
 
             $stub = str_replace(['{{modelRevisionClassName}}', '{{modelName}}'], [$modelRevisionClassName, Str::snake($modelName)], $this->files->get(__DIR__ . '/stubs/model_revision.stub'));
 
-            $this->files->put(app_path('Models/Revisions/' . $modelRevisionClassName . '.php'), $stub);
+            $this->files->put(twill_path('Models/Revisions/' . $modelRevisionClassName . '.php'), $stub);
         }
 
         $modelClassName = $modelName;
@@ -171,15 +171,15 @@ class ModuleMake extends Command
 
         $stub = str_replace(['{{modelClassName}}', '{{modelTraits}}', '{{modelImports}}', '{{modelImplements}}'], [$modelClassName, $activeModelTraitsString, $activeModelTraitsImports, $activeModelImplements], $this->files->get(__DIR__ . '/stubs/model.stub'));
 
-        $this->files->put(app_path('Models/' . $modelClassName . '.php'), $stub);
+        $this->files->put(twill_path('Models/' . $modelClassName . '.php'), $stub);
 
         $this->info("Models created successfully! Fill your fillables!");
     }
 
     private function createRepository($modelName = 'Item', $activeTraits = [])
     {
-        if (!$this->files->isDirectory(app_path('Repositories'))) {
-            $this->files->makeDirectory(app_path('Repositories'));
+        if (!$this->files->isDirectory(twill_path('Repositories'))) {
+            $this->files->makeDirectory(twill_path('Repositories'));
         }
 
         $repositoryClassName = $modelName . 'Repository';
@@ -198,15 +198,15 @@ class ModuleMake extends Command
 
         $stub = str_replace(['{{repositoryClassName}}', '{{modelName}}', '{{repositoryTraits}}', '{{repositoryImports}}'], [$repositoryClassName, $modelName, $activeRepositoryTraitsString, $activeRepositoryTraitsImports], $this->files->get(__DIR__ . '/stubs/repository.stub'));
 
-        $this->files->put(app_path('Repositories/' . $repositoryClassName . '.php'), $stub);
+        $this->files->put(twill_path('Repositories/' . $repositoryClassName . '.php'), $stub);
 
         $this->info("Repository created successfully! Control all the things!");
     }
 
     private function createController($moduleName = 'items', $modelName = 'Item')
     {
-        if (!$this->files->isDirectory(app_path('Http/Controllers/Admin'))) {
-            $this->files->makeDirectory(app_path('Http/Controllers/Admin'));
+        if (!$this->files->isDirectory(twill_path('Http/Controllers/Admin'))) {
+            $this->files->makeDirectory(twill_path('Http/Controllers/Admin'));
         }
 
         $controllerClassName = $modelName . 'Controller';
@@ -217,22 +217,22 @@ class ModuleMake extends Command
             $this->files->get(__DIR__ . '/stubs/controller.stub')
         );
 
-        $this->files->put(app_path('Http/Controllers/Admin/' . $controllerClassName . '.php'), $stub);
+        $this->files->put(twill_path('Http/Controllers/Admin/' . $controllerClassName . '.php'), $stub);
 
         $this->info("Controller created successfully! Define your index/browser/form endpoints options!");
     }
 
     private function createRequest($modelName = 'Item')
     {
-        if (!$this->files->isDirectory(app_path('Http/Requests/Admin'))) {
-            $this->files->makeDirectory(app_path('Http/Requests/Admin'), 0755, true);
+        if (!$this->files->isDirectory(twill_path('Http/Requests/Admin'))) {
+            $this->files->makeDirectory(twill_path('Http/Requests/Admin'), 0755, true);
         }
 
         $requestClassName = $modelName . 'Request';
 
         $stub = str_replace('{{requestClassName}}', $requestClassName, $this->files->get(__DIR__ . '/stubs/request.stub'));
 
-        $this->files->put(app_path('Http/Requests/Admin/' . $requestClassName . '.php'), $stub);
+        $this->files->put(twill_path('Http/Requests/Admin/' . $requestClassName . '.php'), $stub);
 
         $this->info("Form request created successfully! Add some validation rules!");
     }

--- a/src/Helpers/helpers.php
+++ b/src/Helpers/helpers.php
@@ -64,3 +64,27 @@ if (!function_exists('fireCmsEvent')) {
         Event::$method($eventName, [$eventName, $input]);
     }
 }
+
+if (!function_exists('twill_path')) {
+    function twill_path($path = '')
+    {
+        // Split to separate root namespace
+        preg_match('/(\w*)\W?(.*)/', config('twill.namespace'), $matches);
+
+        // Namespace App is unchanged in config?
+        if ($matches[0] === 'App') {
+            return app_path($path);
+        }
+
+        // If it it still starts with App, use the left part, otherwise use the whole namespace
+        // This can be a problem for those using a completely different app path for the application
+        $left = ($matches[1] === 'App' ? $matches[2] : $matches[0]);
+
+        // Join, fix slashes for the current operating system, and return path
+        return app_path(str_replace(
+            '\\',
+            DIRECTORY_SEPARATOR,
+            $left . (filled($path) ? '\\' . $path : '')
+        ));
+    }
+}

--- a/src/Models/Behaviors/HasRevisions.php
+++ b/src/Models/Behaviors/HasRevisions.php
@@ -6,7 +6,7 @@ trait HasRevisions
 {
     public function revisions()
     {
-        return $this->hasMany("App\Models\Revisions\\" . class_basename($this) . "Revision")->orderBy('created_at', 'desc');
+        return $this->hasMany(config('twill.namespace') . "\Models\Revisions\\" . class_basename($this) . "Revision")->orderBy('created_at', 'desc');
     }
 
     public function scopeMine($query)

--- a/src/Models/Behaviors/HasSlug.php
+++ b/src/Models/Behaviors/HasSlug.php
@@ -25,12 +25,14 @@ trait HasSlug
 
     public function slugs()
     {
-        return $this->hasMany("App\Models\Slugs\\" . $this->getSlugClassName());
+        return $this->hasMany(
+            config('twill.namespace') . "\Models\Slugs\\" . $this->getSlugClassName()
+        );
     }
 
     public function getSlugClass()
     {
-        $slugClassName = "App\Models\Slugs\\" . $this->getSlugClassName();
+        $slugClassName = config('twill.namespace') . "\Models\Slugs\\" . $this->getSlugClassName();
         return new $slugClassName;
     }
 

--- a/src/Models/Behaviors/HasTranslation.php
+++ b/src/Models/Behaviors/HasTranslation.php
@@ -10,7 +10,7 @@ trait HasTranslation
 
     public function getTranslationModelNameDefault()
     {
-        return "App\Models\Translations\\" . class_basename($this) . 'Translation';
+        return config('twill.namespace') . "\Models\Translations\\" . class_basename($this) . 'Translation';
     }
 
     public function scopeWithActiveTranslations($query, $locale = null)


### PR DESCRIPTION
Had two problems setting a new namespace for Twill (`App\Admin`):

1. It could not find some classes anymore, because they were hardcoded.
2. When making a new module it did not respect the new namespace path.

This PR fixes both.