### PR TITLE
add option to prefix s3 uploads

### DIFF
--- a/config/disks.php
+++ b/config/disks.php
@@ -7,6 +7,7 @@ return [
         'secret' => env('S3_SECRET', env('AWS_SECRET', env('AWS_SECRET_ACCESS_KEY'))),
         'region' => env('S3_REGION', env('AWS_REGION', env('AWS_DEFAULT_REGION', 'us-east-1'))),
         'bucket' => env('S3_BUCKET', env('AWS_BUCKET')),
+        'root' => env('S3_ROOT', env('AWS_ROOT')),
         'use_https' => env('S3_UPLOADER_USE_HTTPS', env('S3_USE_HTTPS', env('AWS_USE_HTTPS', true))),
     ],
 ];

--- a/frontend/js/components/media-library/Uploader.vue
+++ b/frontend/js/components/media-library/Uploader.vue
@@ -151,7 +151,7 @@
       _onSubmitCallback (id, name) {
         this.$emit('clear')
         // each upload session will add upload files with original filenames in a folder named using a uuid
-        this.unique_folder_name = this.unique_folder_name || qq.getUniqueId()
+        this.unique_folder_name = this.uploaderConfig.endpointRoot + (this.unique_folder_name || qq.getUniqueId())
         this._uploader.methods.setParams({ unique_folder_name: this.unique_folder_name }, id)
 
         // determine the image dimensions and add it to params sent on upload success

--- a/src/Http/ViewComposers/FilesUploaderConfig.php
+++ b/src/Http/ViewComposers/FilesUploaderConfig.php
@@ -19,6 +19,7 @@ class FilesUploaderConfig
             'signatureEndpoint' => route('admin.file-library.sign-s3-upload'),
             'endpointBucket' => config('filesystems.disks.' . $libraryDisk . '.bucket', 'none'),
             'endpointRegion' => config('filesystems.disks.' . $libraryDisk . '.region', 'none'),
+            'endpointRoot' => config('filesystems.disks.' . $libraryDisk . '.root', ''),
             'accessKey' => config('filesystems.disks.' . $libraryDisk . '.key', 'none'),
             'csrfToken' => csrf_token(),
             'acl' => config('twill.file_library.acl'),

--- a/src/Http/ViewComposers/MediasUploaderConfig.php
+++ b/src/Http/ViewComposers/MediasUploaderConfig.php
@@ -19,6 +19,7 @@ class MediasUploaderConfig
             'signatureEndpoint' => route('admin.media-library.sign-s3-upload'),
             'endpointBucket' => config('filesystems.disks.' . $libraryDisk . '.bucket', 'none'),
             'endpointRegion' => config('filesystems.disks.' . $libraryDisk . '.region', 'none'),
+            'endpointRoot' => config('filesystems.disks.' . $libraryDisk . '.root', ''),
             'accessKey' => config('filesystems.disks.' . $libraryDisk . '.key', 'none'),
             'csrfToken' => csrf_token(),
             'acl' => config('twill.media_library.acl'),


### PR DESCRIPTION
By default twill upload files to s3 in a flat manner, this PR adds an env var called: `S3_ROOT=` that is used to prefix the destination path:

before:

`4a38573e-04fe-40d2-892b-e0a42af55a61/image.png`

after:

```
S3_ROOT=uploads/
uploads/4a38573e-04fe-40d2-892b-e0a42af55a61/image.png
```

closes #288 