### PR TITLE
Fixed the Undefined index error reported in #292

### DIFF
--- a/src/Repositories/Behaviors/HandleBlocks.php
+++ b/src/Repositories/Behaviors/HandleBlocks.php
@@ -126,9 +126,10 @@ trait HandleBlocks
 
                 if ($isInRepeater) {
                     $fields['blocksRepeaters']["blocks-{$block->parent_id}_{$block->child_key}"][] = $blockItem + [
-                        'max' => $blockTypeConfig['max'],
                         'trigger' => $blockTypeConfig['trigger'],
-                    ];
+                    ] + (isset($blockTypeConfig['max']) ? [
+                        'max' => $blockTypeConfig['max']
+                    ] : []);
                 } else {
                     $fields['blocks'][] = $blockItem + [
                         'icon' => $blockTypeConfig['icon'],


### PR DESCRIPTION
This PR added a defensive check on the max index of blockTypeConfig to prevent the error `Undefined index max` from happening.