### PR TITLE
 Add PHPDoc (docblocks) with param and return types to all PHP methods and classes

### DIFF
--- a/migrations/create_files_tables.php
+++ b/migrations/create_files_tables.php
@@ -5,6 +5,11 @@ use Illuminate\Database\Schema\Blueprint;
 
 class CreateFilesTables extends Migration
 {
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
     public function up()
     {
         Schema::create('files', function (Blueprint $table) {
@@ -30,6 +35,11 @@ class CreateFilesTables extends Migration
         });
     }
 
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
     public function down()
     {
         Schema::dropIfExists('fileables');

--- a/migrations/create_medias_tables.php
+++ b/migrations/create_medias_tables.php
@@ -5,6 +5,11 @@ use Illuminate\Database\Schema\Blueprint;
 
 class CreateMediasTables extends Migration
 {
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
     public function up()
     {
         Schema::create('medias', function (Blueprint $table) {
@@ -40,6 +45,11 @@ class CreateMediasTables extends Migration
         });
     }
 
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
     public function down()
     {
         Schema::dropIfExists('mediables');

--- a/migrations/create_settings_table.php
+++ b/migrations/create_settings_table.php
@@ -6,6 +6,11 @@ use Illuminate\Support\Facades\Schema;
 
 class CreateSettingsTable extends Migration
 {
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
     public function up()
     {
         Schema::create('settings', function (Blueprint $table) {
@@ -22,6 +27,11 @@ class CreateSettingsTable extends Migration
         });
     }
 
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
     public function down()
     {
         Schema::dropIfExists('setting_translations');

--- a/migrations/create_tags_tables.php
+++ b/migrations/create_tags_tables.php
@@ -6,6 +6,11 @@ use Illuminate\Support\Facades\Schema;
 
 class CreateTagsTables extends Migration
 {
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
     public function up()
     {
         Schema::create('tagged', function (Blueprint $table) {
@@ -25,6 +30,11 @@ class CreateTagsTables extends Migration
         });
     }
 
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
     public function down()
     {
         Schema::dropIfExists('tagged');

--- a/migrations/create_twill_users_tables.php
+++ b/migrations/create_twill_users_tables.php
@@ -5,6 +5,11 @@ use Illuminate\Database\Schema\Blueprint;
 
 class CreateTwillUsersTables extends Migration
 {
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
     public function up()
     {
         Schema::create(config('twill.users_table', 'twill_users'), function (Blueprint $table) {
@@ -25,6 +30,11 @@ class CreateTwillUsersTables extends Migration
         });
     }
 
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
     public function down()
     {
         Schema::dropIfExists(config('twill.password_resets_table', 'twill_password_resets'));

--- a/src/AuthServiceProvider.php
+++ b/src/AuthServiceProvider.php
@@ -11,6 +11,11 @@ class AuthServiceProvider extends ServiceProvider
 {
     const SUPERADMIN = 'SUPERADMIN';
 
+    /**
+     * Bootstraps the package services.
+     *
+     * @return void
+     */
     public function boot()
     {
         Gate::before(function ($user, $ability) {

--- a/src/Commands/Build.php
+++ b/src/Commands/Build.php
@@ -8,10 +8,25 @@ use Symfony\Component\Process\Process;
 
 class Build extends Command
 {
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
     protected $signature = 'twill:build';
 
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
     protected $description = "Build Twill assets (experimental)";
 
+    /**
+     * Executes the console command.
+     *
+     * @return mixed
+     */
     public function handle()
     {
         $progressBar = $this->output->createProgressBar(4);
@@ -47,6 +62,9 @@ class Build extends Command
         $progressBar->finish();
     }
 
+    /**
+     * @return void
+     */
     private function npmInstall()
     {
         $npmInstallProcess = new Process(['npm', 'ci'], base_path('vendor/area17/twill'));
@@ -54,6 +72,9 @@ class Build extends Command
         $npmInstallProcess->mustRun();
     }
 
+    /**
+     * @return void
+     */
     private function npmBuild()
     {
         $npmBuildProcess = new Process(['npm', 'run', 'prod'], base_path('vendor/area17/twill'));
@@ -61,6 +82,9 @@ class Build extends Command
         $npmBuildProcess->mustRun();
     }
 
+    /**
+     * @return void
+     */
     private function copyBlocks()
     {
         $localCustomBlocksPath = resource_path('assets/js/blocks');

--- a/src/Commands/CreateSuperAdmin.php
+++ b/src/Commands/CreateSuperAdmin.php
@@ -8,8 +8,18 @@ use Validator;
 
 class CreateSuperAdmin extends Command
 {
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
     protected $signature = 'twill:superadmin';
 
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
     protected $description = "Create the superadmin account";
 
     /**

--- a/src/Commands/GenerateBlocks.php
+++ b/src/Commands/GenerateBlocks.php
@@ -7,10 +7,25 @@ use Illuminate\Console\Command;
 
 class GenerateBlocks extends Command
 {
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
     protected $signature = 'twill:blocks';
 
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
     protected $description = "Generate blocks as single file Vue components from blade views";
 
+    /**
+     * Executes the console command.
+     *
+     * @return mixed
+     */
     public function handle()
     {
         $this->info("Starting to scan block views directory...");
@@ -33,6 +48,12 @@ class GenerateBlocks extends Command
         $this->info("All blocks have been generated!");
     }
 
+    /**
+     * Sanitizes the given HTML code by removing redundant spaces and comments.
+     *
+     * @param string $html
+     * @return string
+     */
     private function sanitize($html)
     {
         $search = array(

--- a/src/Commands/Install.php
+++ b/src/Commands/Install.php
@@ -8,12 +8,28 @@ use Illuminate\Support\Facades\DB;
 
 class Install extends Command
 {
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
     protected $signature = 'twill:install';
 
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
     protected $description = 'Install Twill into your Laravel application';
 
+    /**
+     * @var Filesystem
+     */
     protected $files;
 
+    /**
+     * @param Filesystem $files
+     */
     public function __construct(Filesystem $files)
     {
         parent::__construct();
@@ -21,6 +37,12 @@ class Install extends Command
         $this->files = $files;
     }
 
+    /**
+     * Executes the console command.
+     *
+     * @return void
+     * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
+     */
     public function handle()
     {
         //check the database connection before installing
@@ -40,6 +62,12 @@ class Install extends Command
         $this->info('All good!');
     }
 
+    /**
+     * Creates the default `admin.php` route configuration file.
+     *
+     * @return void
+     * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
+     */
     private function addRoutesFile()
     {
         $routesPath = base_path('routes');
@@ -54,6 +82,11 @@ class Install extends Command
         }
     }
 
+    /**
+     * Publishes the previously created package migration files.
+     *
+     * @return void
+     */
     private function publishMigrations()
     {
         $this->call('vendor:publish', [
@@ -69,11 +102,21 @@ class Install extends Command
         }
     }
 
+    /**
+     * Calls the command responsible for creation of the default superadmin user.
+     *
+     * @return void
+     */
     private function createSuperAdmin()
     {
         $this->call('twill:superadmin');
     }
 
+    /**
+     * Publishes the previosly created package configuration files.
+     *
+     * @return void
+     */
     private function publishConfig()
     {
         $this->call('vendor:publish', [
@@ -82,6 +125,11 @@ class Install extends Command
         ]);
     }
 
+    /**
+     * Publishes the package frontend assets.
+     *
+     * @return void
+     */
     private function publishAssets()
     {
         $this->call('vendor:publish', [

--- a/src/Commands/ModuleMake.php
+++ b/src/Commands/ModuleMake.php
@@ -9,6 +9,11 @@ use Illuminate\Support\Str;
 
 class ModuleMake extends Command
 {
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
     protected $signature = 'twill:module {moduleName}
         {--B|hasBlocks}
         {--T|hasTranslation}
@@ -18,16 +23,37 @@ class ModuleMake extends Command
         {--P|hasPosition}
         {--R|hasRevisions}';
 
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
     protected $description = 'Create a new CMS Module';
 
+    /**
+     * @var Filesystem
+     */
     protected $files;
 
+    /**
+     * @var Composer
+     */
     protected $composer;
 
+    /**
+     * @var string[]
+     */
     protected $modelTraits;
 
+    /**
+     * @var string[]
+     */
     protected $repositoryTraits;
 
+    /**
+     * @param Filesystem $files
+     * @param Composer $composer
+     */
     public function __construct(Filesystem $files, Composer $composer)
     {
         parent::__construct();
@@ -39,6 +65,11 @@ class ModuleMake extends Command
         $this->repositoryTraits = ['HandleBlocks', 'HandleTranslations', 'HandleSlugs', 'HandleMedias', 'HandleFiles', 'HandleRevisions'];
     }
 
+    /**
+     * Executes the console command.
+     *
+     * @return mixed
+     */
     public function handle()
     {
         $moduleName = $this->argument('moduleName');
@@ -80,6 +111,13 @@ class ModuleMake extends Command
         $this->composer->dumpAutoloads();
     }
 
+    /**
+     * Creates a new module tables database migration file.
+     *
+     * @param string $moduleName
+     * @return void
+     * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
+     */
     private function createMigration($moduleName = 'items')
     {
         $table = Str::snake($moduleName);
@@ -107,6 +145,17 @@ class ModuleMake extends Command
         }
     }
 
+    /**
+     * Creates new model class files for the given model name and traits.
+     *
+     * @param string $modelName
+     * @param bool $translatable
+     * @param bool $sluggable
+     * @param bool $sortable
+     * @param bool $revisionable
+     * @param array $activeTraits
+     * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
+     */
     private function createModels($modelName = 'Item', $translatable = false, $sluggable = false, $sortable = false, $revisionable = false, $activeTraits = [])
     {
         if (!$this->files->isDirectory(twill_path('Models'))) {
@@ -176,6 +225,14 @@ class ModuleMake extends Command
         $this->info("Models created successfully! Fill your fillables!");
     }
 
+    /**
+     * Creates new repository class file for the given model name.
+     *
+     * @param string $modelName
+     * @param array $activeTraits
+     * @return void
+     * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
+     */
     private function createRepository($modelName = 'Item', $activeTraits = [])
     {
         if (!$this->files->isDirectory(twill_path('Repositories'))) {
@@ -203,6 +260,14 @@ class ModuleMake extends Command
         $this->info("Repository created successfully! Control all the things!");
     }
 
+    /**
+     * Create a new controller class file for the given module name and model name.
+     *
+     * @param string $moduleName
+     * @param string $modelName
+     * @return void
+     * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
+     */
     private function createController($moduleName = 'items', $modelName = 'Item')
     {
         if (!$this->files->isDirectory(twill_path('Http/Controllers/Admin'))) {
@@ -222,6 +287,13 @@ class ModuleMake extends Command
         $this->info("Controller created successfully! Define your index/browser/form endpoints options!");
     }
 
+    /**
+     * Creates a new request class file for the given model name.
+     *
+     * @param string $modelName
+     * @return void
+     * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
+     */
     private function createRequest($modelName = 'Item')
     {
         if (!$this->files->isDirectory(twill_path('Http/Requests/Admin'))) {
@@ -237,6 +309,14 @@ class ModuleMake extends Command
         $this->info("Form request created successfully! Add some validation rules!");
     }
 
+    /**
+     * Creates appropriate module view files for displaying in the CMS.
+     *
+     * @param string $moduleName
+     * @param bool $translatable
+     * @return void
+     * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
+     */
     private function createViews($moduleName = 'items', $translatable = false)
     {
         $viewsPath = config('view.paths')[0] . '/admin/' . $moduleName;

--- a/src/Commands/RefreshLQIP.php
+++ b/src/Commands/RefreshLQIP.php
@@ -9,8 +9,18 @@ use ImageService;
 
 class RefreshLQIP extends Command
 {
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
     protected $signature = 'twill:lqip {--all=0}';
 
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
     protected $description = 'Refresh Low Quality Image Placeholders.';
 
     // TODO: document this and actually think about moving to queuable job after content type updates

--- a/src/Exceptions/Handler.php
+++ b/src/Exceptions/Handler.php
@@ -14,6 +14,11 @@ use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class Handler extends ExceptionHandler
 {
+    /**
+     * Exceptions excluded from reporting.
+     *
+     * @var string[]
+     */
     protected $dontReport = [
         AuthorizationException::class,
         HttpException::class,
@@ -21,13 +26,26 @@ class Handler extends ExceptionHandler
         ValidationException::class,
     ];
 
+    /**
+     * @var bool
+     */
     protected $isJsonOutputFormat = false;
 
+    /**
+     * @param Exception $e
+     * @return mixed
+     * @throws Exception
+     */
     public function report(Exception $e)
     {
         return parent::report($e);
     }
 
+    /**
+     * @param \Illuminate\Http\Request $request
+     * @param Exception $e
+     * @return \Illuminate\Contracts\Routing\ResponseFactory|\Illuminate\Http\JsonResponse|\Illuminate\Http\RedirectResponse|\Illuminate\Http\Response|string|Response
+     */
     public function render($request, Exception $e)
     {
         $e = $this->prepareException($e);
@@ -63,6 +81,11 @@ class Handler extends ExceptionHandler
         return $this->renderHttpExceptionWithView($request, $e);
     }
 
+    /**
+     * @param \Illuminate\Http\Request $request
+     * @param \Exception $e
+     * @return \Illuminate\Http\Response|Response
+     */
     public function renderHttpExceptionWithView($request, $e)
     {
         if (config('app.debug')) {
@@ -92,6 +115,10 @@ class Handler extends ExceptionHandler
         return parent::render($request, $e);
     }
 
+    /**
+     * @param Exception $e
+     * @return \Illuminate\Contracts\Routing\ResponseFactory|\Illuminate\Http\Response|array
+     */
     protected function renderExceptionWithWhoops(Exception $e)
     {
         $this->unsetSensitiveData();
@@ -130,6 +157,8 @@ class Handler extends ExceptionHandler
 
     /**
      * Don't ever display sensitive data in Whoops pages.
+     *
+     * @return void
      */
     protected function unsetSensitiveData()
     {
@@ -140,6 +169,11 @@ class Handler extends ExceptionHandler
         $_ENV = [];
     }
 
+    /**
+     * @param \Illuminate\Http\Request $request
+     * @param AuthenticationException $exception
+     * @return \Illuminate\Http\JsonResponse|\Illuminate\Http\RedirectResponse
+     */
     protected function handleUnauthenticated($request, AuthenticationException $exception)
     {
         if ($request->expectsJson()) {
@@ -149,6 +183,11 @@ class Handler extends ExceptionHandler
         return redirect()->guest(route('admin.login'));
     }
 
+    /**
+     * @param \Illuminate\Http\Request $request
+     * @param ValidationException $exception
+     * @return \Illuminate\Http\JsonResponse
+     */
     protected function invalidJson($request, ValidationException $exception)
     {
         return response()->json($exception->errors(), $exception->status);

--- a/src/Helpers/frontend_helpers.php
+++ b/src/Helpers/frontend_helpers.php
@@ -1,6 +1,10 @@
 <?php
 
 if (!function_exists('revAsset')) {
+    /**
+     * @param string $file
+     * @return string
+     */
     function revAsset($file)
     {
         if (!app()->environment('local', 'development')) {
@@ -25,6 +29,10 @@ if (!function_exists('revAsset')) {
 if (!function_exists('icon')) {
     /**
      * ARIA roles memo: 'presentation' means merely decoration. Otherwise, use role="img".
+     *
+     * @param string $name
+     * @param array $opts
+     * @return string
      */
     function icon($name, $opts = [])
     {

--- a/src/Helpers/helpers.php
+++ b/src/Helpers/helpers.php
@@ -4,6 +4,10 @@
 // dd'ing during AJAX requests (see Symfony dumper issue in Chrome > 60:
 // https://github.com/symfony/symfony/issues/24688)
 if (!function_exists('ddd')) {
+    /**
+     * @param mixed ...$args
+     * @return void
+     */
     function ddd(...$args)
     {
         http_response_code(500);
@@ -12,6 +16,11 @@ if (!function_exists('ddd')) {
 }
 
 if (!function_exists('classUsesDeep')) {
+    /**
+     * @param mixed $class
+     * @param bool $autoload
+     * @return array
+     */
     function classUsesDeep($class, $autoload = true)
     {
         $traits = [];
@@ -38,6 +47,11 @@ if (!function_exists('classUsesDeep')) {
 }
 
 if (!function_exists('classHasTrait')) {
+    /**
+     * @param mixed $class
+     * @param string $trait
+     * @return bool
+     */
     function classHasTrait($class, $trait)
     {
         $traits = classUsesDeep($class);
@@ -51,6 +65,11 @@ if (!function_exists('classHasTrait')) {
 }
 
 if (!function_exists('getFormFieldsValue')) {
+    /**
+     * @param array $formFields
+     * @param string $name
+     * @return mixed
+     */
     function getFormFieldsValue($formFields, $name)
     {
         return array_get($formFields, str_replace(']', '', str_replace('[', '.', $name)), '');
@@ -58,6 +77,11 @@ if (!function_exists('getFormFieldsValue')) {
 }
 
 if (!function_exists('fireCmsEvent')) {
+    /**
+     * @param string $eventName
+     * @param array $input
+     * @return void
+     */
     function fireCmsEvent($eventName, $input = [])
     {
         $method = method_exists(\Illuminate\Events\Dispatcher::class, 'dispatch') ? 'dispatch' : 'fire';
@@ -66,6 +90,10 @@ if (!function_exists('fireCmsEvent')) {
 }
 
 if (!function_exists('twill_path')) {
+    /**
+     * @param string $path
+     * @return string
+     */
     function twill_path($path = '')
     {
         // Split to separate root namespace

--- a/src/Helpers/i18n_helpers.php
+++ b/src/Helpers/i18n_helpers.php
@@ -1,6 +1,9 @@
 <?php
 
 if (!function_exists('getLocales')) {
+    /**
+     * @return string[]
+     */
     function getLocales()
     {
         return config('translatable.locales') ?? [config('app.locale')];
@@ -8,6 +11,11 @@ if (!function_exists('getLocales')) {
 }
 
 if (!function_exists('getLanguagesForVueStore')) {
+    /**
+     * @param array $form_fields
+     * @param bool $translate
+     * @return array
+     */
     function getLanguagesForVueStore($form_fields = [], $translate = true)
     {
         $manageMultipleLanguages = count(getLocales()) > 1;
@@ -45,6 +53,10 @@ if (!function_exists('getLanguagesForVueStore')) {
 }
 
 if (!function_exists('getLanguageLabelFromLocaleCode')) {
+    /**
+     * @param string $code
+     * @return string
+     */
     function getLanguageLabelFromLocaleCode($code)
     {
         $codeToLanguageMappings = [
@@ -69,7 +81,7 @@ if (!function_exists('getLanguageLabelFromLocaleCode')) {
 
 /**
  * Converts camelCase string to have spaces between each.
- * @param $camelCaseString
+ * @param string $camelCaseString
  * @return string (ex.: camel case string)
  */
 if (!function_exists('camelCaseToWords')) {

--- a/src/Helpers/media_library_helpers.php
+++ b/src/Helpers/media_library_helpers.php
@@ -1,6 +1,10 @@
 <?php
 
 if (!function_exists('s3Enpoint')) {
+    /**
+     * @param string $disk
+     * @return string
+     */
     function s3Endpoint($disk = 'libraries')
     {
         $scheme = config("filesystems.disks.{$disk}.use_https") ? 'https://' : '';
@@ -10,6 +14,10 @@ if (!function_exists('s3Enpoint')) {
 }
 
 if (!function_exists('bytesToHuman')) {
+    /**
+     * @param float $bytes
+     * @return string
+     */
     function bytesToHuman($bytes)
     {
         $units = ['B', 'Kb', 'Mb', 'Gb', 'Tb', 'Pb'];
@@ -23,6 +31,10 @@ if (!function_exists('bytesToHuman')) {
 }
 
 if (!function_exists('replaceAccents')) {
+    /**
+     * @param string $str
+     * @return bool|string
+     */
     function replaceAccents($str)
     {
         return iconv('UTF-8', 'ASCII//TRANSLIT', $str);
@@ -30,6 +42,10 @@ if (!function_exists('replaceAccents')) {
 }
 
 if (!function_exists('sanitizeFilename')) {
+    /**
+     * @param string $filename
+     * @return string
+     */
     function sanitizeFilename($filename)
     {
         $sanitizedFilename = replaceAccents($filename);

--- a/src/Helpers/migrations_helpers.php
+++ b/src/Helpers/migrations_helpers.php
@@ -1,6 +1,14 @@
 <?php
 
 if (!function_exists('createDefaultFields')) {
+    /**
+     * @param \Illuminate\Database\Schema\Blueprint $table
+     * @param bool $softDeletes
+     * @param bool $published
+     * @param bool $publishDates
+     * @param bool $visibility
+     * @return void
+     */
     function createDefaultTableFields($table, $softDeletes = true, $published = true, $publishDates = false, $visibility = false)
     {
         $table->increments('id');
@@ -27,6 +35,12 @@ if (!function_exists('createDefaultFields')) {
 }
 
 if (!function_exists('createDefaultTranslationsTableFields')) {
+    /**
+     * @param \Illuminate\Database\Schema\Blueprint $table
+     * @param string $tableNameSingular
+     * @param string|null $tableNamePlural
+     * @return void
+     */
     function createDefaultTranslationsTableFields($table, $tableNameSingular, $tableNamePlural = null)
     {
         if (!$tableNamePlural) {
@@ -45,6 +59,12 @@ if (!function_exists('createDefaultTranslationsTableFields')) {
 }
 
 if (!function_exists('createDefaultSlugsTableFields')) {
+    /**
+     * @param \Illuminate\Database\Schema\Blueprint $table
+     * @param string $tableNameSingular
+     * @param string|null $tableNamePlural
+     * @return void
+     */
     function createDefaultSlugsTableFields($table, $tableNameSingular, $tableNamePlural = null)
     {
         if (!$tableNamePlural) {
@@ -63,6 +83,14 @@ if (!function_exists('createDefaultSlugsTableFields')) {
 }
 
 if (!function_exists('createDefaultRelationshipTableFields')) {
+    /**
+     * @param \Illuminate\Database\Schema\Blueprint $table
+     * @param string $table1NameSingular
+     * @param string $table2NameSingular
+     * @param string|null $table1NamePlural
+     * @param string|null $table2NamePlural
+     * @return void
+     */
     function createDefaultRelationshipTableFields($table, $table1NameSingular, $table2NameSingular, $table1NamePlural = null, $table2NamePlural = null)
     {
         if (!$table1NamePlural) {
@@ -81,6 +109,12 @@ if (!function_exists('createDefaultRelationshipTableFields')) {
 }
 
 if (!function_exists('createDefaultRevisionsTableFields')) {
+    /**
+     * @param \Illuminate\Database\Schema\Blueprint $table
+     * @param string $tableNameSingular
+     * @param string|null $tableNamePlural
+     * @return void
+     */
     function createDefaultRevisionsTableFields($table, $tableNameSingular, $tableNamePlural = null)
     {
         if (!$tableNamePlural) {

--- a/src/Helpers/routes_helpers.php
+++ b/src/Helpers/routes_helpers.php
@@ -1,6 +1,14 @@
 <?php
 
 if (!function_exists('moduleRoute')) {
+    /**
+     * @param string $moduleName
+     * @param string $prefix
+     * @param string $action
+     * @param array $parameters
+     * @param bool $absolute
+     * @return string
+     */
     function moduleRoute($moduleName, $prefix, $action, $parameters = [], $absolute = true)
     {
         $routeName = 'admin.' . ($prefix ? $prefix . '.' : '') . camel_case($moduleName) . '.' . $action;
@@ -9,6 +17,12 @@ if (!function_exists('moduleRoute')) {
 }
 
 if (!function_exists('getNavigationUrl')) {
+    /**
+     * @param array $element
+     * @param string $key
+     * @param string|null $prefix
+     * @return string
+     */
     function getNavigationUrl($element, $key, $prefix = null)
     {
         $isModule = $element['module'] ?? false;
@@ -26,6 +40,12 @@ if (!function_exists('getNavigationUrl')) {
 }
 
 if (!function_exists('isActiveNavigation')) {
+    /**
+     * @param array $navigationElement
+     * @param string $navigationKey
+     * @param string $activeNavigationKey
+     * @return bool
+     */
     function isActiveNavigation($navigationElement, $navigationKey, $activeNavigationKey)
     {
         $keysAreMatching = isset($activeNavigationKey) && $navigationKey === $activeNavigationKey;

--- a/src/Http/Controllers/Admin/BlocksController.php
+++ b/src/Http/Controllers/Admin/BlocksController.php
@@ -6,6 +6,12 @@ use A17\Twill\Repositories\BlockRepository;
 
 class BlocksController extends Controller
 {
+    /**
+     * Generates an HTML preview of all blocks defined in the configuration.
+     *
+     * @param BlockRepository $blockRepository
+     * @return string
+     */
     public function preview(BlockRepository $blockRepository)
     {
         $blocksCollection = collect();
@@ -79,6 +85,12 @@ class BlocksController extends Controller
         return html_entity_decode($view);
     }
 
+    /**
+     * Generates a view name for the given block type.
+     *
+     * @param string $blockType
+     * @return string
+     */
     private function getBlockView($blockType)
     {
         $view = config('twill.block_editor.block_views_path') . '.' . $blockType;
@@ -91,5 +103,4 @@ class BlocksController extends Controller
 
         return $view;
     }
-
 }

--- a/src/Http/Controllers/Admin/Controller.php
+++ b/src/Http/Controllers/Admin/Controller.php
@@ -18,14 +18,18 @@ class Controller extends BaseController
         if (config('twill.bind_exception_handler', true)) {
             app()->singleton(ExceptionHandler::class, TwillHandler::class);
         }
-
     }
 
+    /**
+     * Attempts to unset the given middleware.
+     *
+     * @param string $middleware
+     * @return void
+     */
     public function removeMiddleware($middleware)
     {
         if (($key = array_search($middleware, array_pluck($this->middleware, 'middleware'))) !== false) {
             unset($this->middleware[$key]);
         }
-
     }
 }

--- a/src/Http/Controllers/Admin/DashboardController.php
+++ b/src/Http/Controllers/Admin/DashboardController.php
@@ -10,6 +10,11 @@ use Spatie\Analytics\Period;
 
 class DashboardController extends Controller
 {
+    /**
+     * Displays the Twill dashboard index.
+     *
+     * @return \Illuminate\View\View
+     */
     public function index()
     {
         $modules = collect(config('twill.dashboard.modules'));
@@ -46,6 +51,9 @@ class DashboardController extends Controller
         ]);
     }
 
+    /**
+     * @return array
+     */
     public function search()
     {
         $modules = collect(config('twill.dashboard.modules'));
@@ -79,6 +87,9 @@ class DashboardController extends Controller
         })->collapse()->values();
     }
 
+    /**
+     * @return array
+     */
     private function getAllActivities()
     {
         return Activity::take(20)->latest()->get()->map(function ($activity) {
@@ -86,6 +97,9 @@ class DashboardController extends Controller
         })->filter()->values();
     }
 
+    /**
+     * @return array
+     */
     private function getLoggedInUserActivities()
     {
         return Activity::where('causer_id', auth('twill_users')->user()->id)->take(20)->latest()->get()->map(function ($activity) {
@@ -93,6 +107,10 @@ class DashboardController extends Controller
         })->filter()->values();
     }
 
+    /**
+     * @param \Spatie\Activitylog\Models\Activity $activity
+     * @return array|null
+     */
     private function formatActivity($activity)
     {
         $dashboardModule = config('twill.dashboard.modules.' . $activity->subject_type);
@@ -117,6 +135,9 @@ class DashboardController extends Controller
         ] : []);
     }
 
+    /**
+     * @return array|\Illuminate\Support\Collection
+     */
     private function getFacts()
     {
         try {
@@ -170,6 +191,11 @@ class DashboardController extends Controller
         });
     }
 
+    /**
+     * @param string $period
+     * @param \Illuminate\Database\Query\Builder $statsByDate
+     * @return array
+     */
     private function getPeriodStats($period, $statsByDate)
     {
         if ($period === 'today') {
@@ -251,6 +277,10 @@ class DashboardController extends Controller
         }
     }
 
+    /**
+     * @param int $count
+     * @return string
+     */
     private function formatStat($count)
     {
         if ($count >= 1000) {
@@ -260,6 +290,10 @@ class DashboardController extends Controller
         return $count;
     }
 
+    /**
+     * @param array $modules
+     * @return array
+     */
     private function getShortcuts($modules)
     {
         return $modules->filter(function ($module) {
@@ -295,6 +329,10 @@ class DashboardController extends Controller
         })->values();
     }
 
+    /**
+     * @param array $modules
+     * @return array
+     */
     private function getDrafts($modules)
     {
         return $modules->filter(function ($module) {
@@ -314,6 +352,10 @@ class DashboardController extends Controller
         })->collapse()->values();
     }
 
+    /**
+     * @param string $module
+     * @return \A17\Twill\Repositories\ModuleRepository
+     */
     private function getRepository($module)
     {
         return app(config('twill.namespace') . "\Repositories\\" . ucfirst(str_singular($module)) . "Repository");

--- a/src/Http/Controllers/Admin/FeaturedController.php
+++ b/src/Http/Controllers/Admin/FeaturedController.php
@@ -10,6 +10,9 @@ use Event;
 
 class FeaturedController extends Controller
 {
+    /**
+     * @return array|\Illuminate\View\View
+     */
     public function index()
     {
         $featuredSectionKey = request()->segment(count(request()->segments()));
@@ -69,6 +72,11 @@ class FeaturedController extends Controller
         ]);
     }
 
+    /**
+     * @param array $featuredSection
+     * @param string $featuredSectionKey
+     * @return array
+     */
     private function getFeaturedItemsByBucket($featuredSection, $featuredSectionKey)
     {
         $bucketRouteConfig = config('twill.bucketsRoutes') ?? [$featuredSectionKey => 'featured'];
@@ -106,6 +114,11 @@ class FeaturedController extends Controller
         })->values()->toArray();
     }
 
+    /**
+     * @param array $featuredSection
+     * @param mixed|null $search
+     * @return array
+     */
     private function getFeaturedSources($featuredSection, $search = null)
     {
         $fetchedModules = [];
@@ -168,6 +181,9 @@ class FeaturedController extends Controller
         return $featuredSources;
     }
 
+    /**
+     * @return void
+     */
     public function save()
     {
         DB::transaction(function () {
@@ -188,6 +204,10 @@ class FeaturedController extends Controller
         fireCmsEvent('cms-buckets.saved');
     }
 
+    /**
+     * @param string $bucketable
+     * @return \A17\Twill\Repositories\ModuleRepository
+     */
     private function getRepository($bucketable)
     {
         return app(config('twill.namespace') . "\Repositories\\" . ucfirst(str_singular($bucketable)) . "Repository");

--- a/src/Http/Controllers/Admin/FileLibraryController.php
+++ b/src/Http/Controllers/Admin/FileLibraryController.php
@@ -11,23 +11,45 @@ use Input;
 
 class FileLibraryController extends ModuleController implements SignS3UploadListener
 {
+    /**
+     * @var string
+     */
     protected $moduleName = 'files';
 
+    /**
+     * @var string
+     */
     protected $namespace = 'A17\Twill';
 
+    /**
+     * @var array
+     */
     protected $defaultOrders = [
         'id' => 'desc',
     ];
 
+    /**
+     * @var array
+     */
     protected $defaultFilters = [
         'search' => 'search',
         'tag' => 'tag_id',
     ];
 
+    /**
+     * @var int
+     */
     protected $perPage = 40;
 
+    /**
+     * @var string
+     */
     protected $endpointType;
 
+    /**
+     * @param Application $app
+     * @param Request $request
+     */
     public function __construct(Application $app, Request $request)
     {
         parent::__construct($app, $request);
@@ -36,6 +58,10 @@ class FileLibraryController extends ModuleController implements SignS3UploadList
         $this->endpointType = config('twill.file_library.endpoint_type');
     }
 
+    /**
+     * @param int|null $parentModuleId
+     * @return array
+     */
     public function index($parentModuleId = null)
     {
         if (request()->has('except')) {
@@ -45,6 +71,10 @@ class FileLibraryController extends ModuleController implements SignS3UploadList
         return $this->getIndexData($prependScope ?? []);
     }
 
+    /**
+     * @param array $prependScope
+     * @return array
+     */
     public function getIndexData($prependScope = [])
     {
         $scopes = $this->filterScope($prependScope);
@@ -60,6 +90,10 @@ class FileLibraryController extends ModuleController implements SignS3UploadList
         ];
     }
 
+    /**
+     * @param \A17\Twill\Models\File $item
+     * @return array
+     */
     private function buildFile($item)
     {
         return $item->toCmsArray() + [
@@ -73,6 +107,9 @@ class FileLibraryController extends ModuleController implements SignS3UploadList
         ];
     }
 
+    /**
+     * @return array
+     */
     protected function getRequestFilters()
     {
         if (request()->has('search')) {
@@ -86,6 +123,10 @@ class FileLibraryController extends ModuleController implements SignS3UploadList
         return $requestFilters ?? [];
     }
 
+    /**
+     * @param int|null $parentModuleId
+     * @return \Illuminate\Http\JsonResponse
+     */
     public function store($parentModuleId = null)
     {
         $request = app(FileRequest::class);
@@ -99,6 +140,10 @@ class FileLibraryController extends ModuleController implements SignS3UploadList
         return response()->json(['media' => $this->buildFile($file), 'success' => true], 200);
     }
 
+    /**
+     * @param Request $request
+     * @return \A17\Twill\Models\File
+     */
     public function storeFile($request)
     {
         $filename = $request->input('qqfilename');
@@ -117,6 +162,10 @@ class FileLibraryController extends ModuleController implements SignS3UploadList
         return $this->repository->create($fields);
     }
 
+    /**
+     * @param Request $request
+     * @return \A17\Twill\Models\File
+     */
     public function storeReference($request)
     {
         $fields = [
@@ -127,6 +176,9 @@ class FileLibraryController extends ModuleController implements SignS3UploadList
         return $this->repository->create($fields);
     }
 
+    /**
+     * @return \Illuminate\Http\JsonResponse
+     */
     public function singleUpdate()
     {
         $this->repository->update(
@@ -137,6 +189,9 @@ class FileLibraryController extends ModuleController implements SignS3UploadList
         return response()->json([], 200);
     }
 
+    /**
+     * @return \Illuminate\Http\JsonResponse
+     */
     public function bulkUpdate()
     {
         $ids = explode(',', $this->request->input('ids'));
@@ -159,16 +214,28 @@ class FileLibraryController extends ModuleController implements SignS3UploadList
         ], 200);
     }
 
+    /**
+     * @param Request $request
+     * @param SignS3Upload $signS3Upload
+     * @return mixed
+     */
     public function signS3Upload(Request $request, SignS3Upload $signS3Upload)
     {
         return $signS3Upload->fromPolicy($request->getContent(), $this, config('twill.file_library.disk'));
     }
 
+    /**
+     * @param mixed $signedPolicy
+     * @return \Illuminate\Http\JsonResponse
+     */
     public function policyIsSigned($signedPolicy)
     {
         return response()->json($signedPolicy, 200);
     }
 
+    /**
+     * @return \Illuminate\Http\JsonResponse
+     */
     public function policyIsNotValid()
     {
         return response()->json(["invalid" => true], 500);

--- a/src/Http/Controllers/Admin/ForgotPasswordController.php
+++ b/src/Http/Controllers/Admin/ForgotPasswordController.php
@@ -20,11 +20,17 @@ class ForgotPasswordController extends Controller
 
     use SendsPasswordResetEmails;
 
+    /**
+     * @return \Illuminate\Contracts\Auth\PasswordBroker
+     */
     public function broker()
     {
         return Password::broker('twill_users');
     }
 
+    /**
+     * @return \Illuminate\View\View
+     */
     public function showLinkRequestForm()
     {
         return view('twill::auth.passwords.email');

--- a/src/Http/Controllers/Admin/ImpersonateController.php
+++ b/src/Http/Controllers/Admin/ImpersonateController.php
@@ -7,6 +7,11 @@ use Auth;
 
 class ImpersonateController extends Controller
 {
+    /**
+     * @param int $id
+     * @param UserRepository $users
+     * @return \Illuminate\Http\RedirectResponse
+     */
     public function impersonate($id, UserRepository $users)
     {
         if (Auth::guard('twill_users')->user()->can('impersonate')) {
@@ -17,6 +22,9 @@ class ImpersonateController extends Controller
         return back();
     }
 
+    /**
+     * @return \Illuminate\Http\RedirectResponse
+     */
     public function stopImpersonate()
     {
         Auth::guard('twill_users')->user()->stopImpersonating();

--- a/src/Http/Controllers/Admin/LoginController.php
+++ b/src/Http/Controllers/Admin/LoginController.php
@@ -24,21 +24,34 @@ class LoginController extends Controller
 
     use AuthenticatesUsers;
 
+    /**
+     * @return \Illuminate\Contracts\Auth\Guard
+     */
     protected function guard()
     {
         return Auth::guard('twill_users');
     }
 
+    /**
+     * @return \Illuminate\View\View
+     */
     public function showLoginForm()
     {
         return view('twill::auth.login');
     }
 
+    /**
+     * @return \Illuminate\View\View
+     */
     public function showLogin2FaForm()
     {
         return view('twill::auth.2fa');
     }
 
+    /**
+     * @param Request $request
+     * @return \Illuminate\Http\RedirectResponse
+     */
     public function logout(Request $request)
     {
         $this->guard()->logout();
@@ -50,6 +63,11 @@ class LoginController extends Controller
         return redirect(route('admin.login'));
     }
 
+    /**
+     * @param Request $request
+     * @param \Illuminate\Foundation\Auth\User $user
+     * @return \Illuminate\Http\RedirectResponse
+     */
     protected function authenticated(Request $request, $user)
     {
         if ($user->google_2fa_secret && $user->google_2fa_enabled) {
@@ -63,6 +81,13 @@ class LoginController extends Controller
         return redirect()->intended($this->redirectTo);
     }
 
+    /**
+     * @param Request $request
+     * @return \Illuminate\Http\RedirectResponse
+     * @throws \PragmaRX\Google2FA\Exceptions\IncompatibleWithGoogleAuthenticatorException
+     * @throws \PragmaRX\Google2FA\Exceptions\InvalidCharactersException
+     * @throws \PragmaRX\Google2FA\Exceptions\SecretKeyTooShortException
+     */
     public function login2Fa(Request $request)
     {
         $userId = $request->session()->get('2fa:user:id');

--- a/src/Http/Controllers/Admin/MediaLibraryController.php
+++ b/src/Http/Controllers/Admin/MediaLibraryController.php
@@ -11,25 +11,50 @@ use Input;
 
 class MediaLibraryController extends ModuleController implements SignS3UploadListener
 {
+    /**
+     * @var string
+     */
     protected $moduleName = 'medias';
 
+    /**
+     * @var string
+     */
     protected $namespace = 'A17\Twill';
 
+    /**
+     * @var array
+     */
     protected $defaultOrders = [
         'id' => 'desc',
     ];
 
+    /**
+     * @var array
+     */
     protected $defaultFilters = [
         'search' => 'search',
         'tag' => 'tag_id',
     ];
 
+    /**
+     * @var int
+     */
     protected $perPage = 40;
 
+    /**
+     * @var string
+     */
     protected $endpointType;
 
+    /**
+     * @var array
+     */
     protected $customFields;
 
+    /**
+     * @param Application $app
+     * @param Request $request
+     */
     public function __construct(Application $app, Request $request)
     {
         parent::__construct($app, $request);
@@ -39,6 +64,10 @@ class MediaLibraryController extends ModuleController implements SignS3UploadLis
         $this->customFields = config('twill.media_library.extra_metadatas_fields');
     }
 
+    /**
+     * @param int|null $parentModuleId
+     * @return array
+     */
     public function index($parentModuleId = null)
     {
         if (request()->has('except')) {
@@ -48,6 +77,10 @@ class MediaLibraryController extends ModuleController implements SignS3UploadLis
         return $this->getIndexData($prependScope ?? []);
     }
 
+    /**
+     * @param array $prependScope
+     * @return array
+     */
     public function getIndexData($prependScope = [])
     {
         $scopes = $this->filterScope($prependScope);
@@ -63,6 +96,9 @@ class MediaLibraryController extends ModuleController implements SignS3UploadLis
         ];
     }
 
+    /**
+     * @return array
+     */
     protected function getRequestFilters()
     {
         if (request()->has('search')) {
@@ -76,6 +112,10 @@ class MediaLibraryController extends ModuleController implements SignS3UploadLis
         return $requestFilters ?? [];
     }
 
+    /**
+     * @param int|null $parentModuleId
+     * @return \Illuminate\Http\JsonResponse
+     */
     public function store($parentModuleId = null)
     {
         $request = app(MediaRequest::class);
@@ -89,6 +129,10 @@ class MediaLibraryController extends ModuleController implements SignS3UploadLis
         return response()->json(['media' => $media->toCmsArray(), 'success' => true], 200);
     }
 
+    /**
+     * @param Request $request
+     * @return \A17\Twill\Models\Media
+     */
     public function storeFile($request)
     {
         $originalFilename = $request->input('qqfilename');
@@ -111,6 +155,10 @@ class MediaLibraryController extends ModuleController implements SignS3UploadLis
         return $this->repository->create($fields);
     }
 
+    /**
+     * @param Request $request
+     * @return \A17\Twill\Models\Media
+     */
     public function storeReference($request)
     {
         $fields = [
@@ -123,9 +171,11 @@ class MediaLibraryController extends ModuleController implements SignS3UploadLis
         return $this->repository->create($fields);
     }
 
+    /**
+     * @return \Illuminate\Http\JsonResponse
+     */
     public function singleUpdate()
     {
-
         $this->repository->update(
             $this->request->input('id'),
             array_merge([
@@ -140,6 +190,9 @@ class MediaLibraryController extends ModuleController implements SignS3UploadLis
         ], 200);
     }
 
+    /**
+     * @return \Illuminate\Http\JsonResponse
+     */
     public function bulkUpdate()
     {
         $ids = explode(',', $this->request->input('ids'));
@@ -175,21 +228,36 @@ class MediaLibraryController extends ModuleController implements SignS3UploadLis
         ], 200);
     }
 
+    /**
+     * @param Request $request
+     * @param SignS3Upload $signS3Upload
+     * @return mixed
+     */
     public function signS3Upload(Request $request, SignS3Upload $signS3Upload)
     {
         return $signS3Upload->fromPolicy($request->getContent(), $this, config('twill.media_library.disk'));
     }
 
+    /**
+     * @param mixed $signedPolicy
+     * @return \Illuminate\Http\JsonResponse
+     */
     public function policyIsSigned($signedPolicy)
     {
         return response()->json($signedPolicy, 200);
     }
 
+    /**
+     * @return \Illuminate\Http\JsonResponse
+     */
     public function policyIsNotValid()
     {
         return response()->json(["invalid" => true], 500);
     }
 
+    /**
+     * @return \Illuminate\Support\Collection
+     */
     private function getExtraMetadatas()
     {
         return collect($this->customFields)->mapWithKeys(function ($field) {

--- a/src/Http/Controllers/Admin/ModuleController.php
+++ b/src/Http/Controllers/Admin/ModuleController.php
@@ -12,21 +12,40 @@ use Session;
 
 abstract class ModuleController extends Controller
 {
-
+    /**
+     * @var Application
+     */
     protected $app;
 
+    /**
+     * @var Request
+     */
     protected $request;
 
+    /**
+     * @var string
+     */
     protected $routePrefix;
 
+    /**
+     * @var string
+     */
     protected $moduleName;
 
+    /**
+     * @var string
+     */
     protected $modelName;
 
+    /**
+     * @var \A17\Twill\Repositories\ModuleRepository
+     */
     protected $repository;
 
-    /*
-     * Options of the index view
+    /**
+     * Options of the index view.
+     *
+     * @var array
      */
     protected $defaultIndexOptions = [
         'create' => true,
@@ -45,73 +64,108 @@ abstract class ModuleController extends Controller
         'editInModal' => false,
     ];
 
-    /*
+    /**
      * Relations to eager load for the index view
+     *
+     * @var array
      */
     protected $indexWith = [];
 
-    /*
-     * Relations to eager load for the form view
+    /**
+     * Relations to eager load for the form view.
+     *
+     * @var array
      */
     protected $formWith = [];
 
-    /*
-     * Relation count to eager load for the form view
+    /**
+     * Relation count to eager load for the form view.
+     *
+     * @var array
      */
     protected $formWithCount = [];
 
-    /*
-     * Additional filters for the index view
+    /**
+     * Additional filters for the index view.
+     *
      * To automatically have your filter added to the index view use the following convention:
      * suffix the key containing the list of items to show in the filter by 'List' and
      * name it the same as the filter you defined in this array.
+     *
      * Example: 'fCategory' => 'category_id' here and 'fCategoryList' in indexData()
      * By default, this will run a where query on the category_id column with the value
      * of fCategory if found in current request parameters. You can intercept this behavior
      * from your repository in the filter() function.
+     *
+     * @var array
      */
     protected $filters = [];
 
-    /*
-     * Default orders for the index view
+    /**
+     * Default orders for the index view.
+     *
+     * @var array
      */
     protected $defaultOrders = [
         'created_at' => 'desc',
     ];
 
+    /**
+     * @var int
+     */
     protected $perPage = 20;
 
-    /*
-     * Name of the index column to use as name column
+    /**
+     * Name of the index column to use as name column.
+     *
+     * @var string
      */
     protected $titleColumnKey = 'title';
 
-    /*
-     * Attribute to use as title in forms
+    /**
+     * Attribute to use as title in forms.
+     *
+     * @var string
      */
     protected $titleFormKey;
 
-    /*
-     * Feature field name if the controller is using the feature route (defaults to "featured")
+    /**
+     * Feature field name if the controller is using the feature route (defaults to "featured").
+     *
+     * @var string
      */
     protected $featureField = 'featured';
 
-    /*
-     * Indicates if this module is edited through a parent module
+    /**
+     * Indicates if this module is edited through a parent module.
+     *
+     * @var bool
      */
     protected $submodule = false;
+
+    /**
+     * @var int|null
+     */
     protected $submoduleParentId = null;
 
-    /*
-     * Can be used in child classes to disable the content editor (full screen block editor)
+    /**
+     * Can be used in child classes to disable the content editor (full screen block editor).
+     *
+     * @var bool
      */
     protected $disableEditor = false;
 
-    /*
+    /**
      * List of permissions keyed by a request field. Can be used to prevent unauthorized field updates.
+     *
+     * @var array
      */
     protected $fieldsPermissions = [];
 
+    /**
+     * @param Application $app
+     * @param Request $request
+     */
     public function __construct(Application $app, Request $request)
     {
         parent::__construct();
@@ -163,6 +217,9 @@ abstract class ModuleController extends Controller
         }
     }
 
+    /**
+     * @return void
+     */
     protected function setMiddlewarePermission()
     {
         $this->middleware('can:list', ['only' => ['index', 'show']]);
@@ -172,6 +229,10 @@ abstract class ModuleController extends Controller
         $this->middleware('can:delete', ['only' => ['destroy', 'bulkDelete', 'restore', 'bulkRestore', 'restoreRevision']]);
     }
 
+    /**
+     * @param int|null $parentModuleId
+     * @return array|\Illuminate\View\View
+     */
     public function index($parentModuleId = null)
     {
         $this->submodule = isset($parentModuleId);
@@ -200,11 +261,18 @@ abstract class ModuleController extends Controller
         return view($view, $indexData);
     }
 
+    /**
+     * @return \Illuminate\Http\JsonResponse
+     */
     public function browser()
     {
         return response()->json($this->getBrowserData());
     }
 
+    /**
+     * @param int|null $parentModuleId
+     * @return \Illuminate\Http\JsonResponse
+     */
     public function store($parentModuleId = null)
     {
         $input = $this->validateFormRequest()->all();
@@ -230,6 +298,11 @@ abstract class ModuleController extends Controller
         ));
     }
 
+    /**
+     * @param int|$id
+     * @param int|null $submoduleId
+     * @return \Illuminate\Http\RedirectResponse
+     */
     public function show($id, $submoduleId = null)
     {
         if ($this->getIndexOption('editInModal')) {
@@ -239,6 +312,11 @@ abstract class ModuleController extends Controller
         return $this->redirectToForm($submoduleId ?? $id);
     }
 
+    /**
+     * @param int $id
+     * @param int|null $submoduleId
+     * @return \Illuminate\Http\JsonResponse|\Illuminate\Http\RedirectResponse|\Illuminate\View\View
+     */
     public function edit($id, $submoduleId = null)
     {
         $this->submodule = isset($submoduleId);
@@ -263,6 +341,11 @@ abstract class ModuleController extends Controller
         return view($view, $this->form($submoduleId ?? $id));
     }
 
+    /**
+     * @param int $id
+     * @param int|null $submoduleId
+     * @return \Illuminate\Http\JsonResponse
+     */
     public function update($id, $submoduleId = null)
     {
         $this->submodule = isset($submoduleId);
@@ -321,6 +404,10 @@ abstract class ModuleController extends Controller
         }
     }
 
+    /**
+     * @param int $id
+     * @return \Illuminate\View\View
+     */
     public function preview($id)
     {
         if (request()->has('revisionId')) {
@@ -343,6 +430,10 @@ abstract class ModuleController extends Controller
         ]);
     }
 
+    /**
+     * @param int $id
+     * @return \Illuminate\View\View
+     */
     public function restoreRevision($id)
     {
         if (request()->has('revisionId')) {
@@ -371,6 +462,9 @@ abstract class ModuleController extends Controller
         return view($view, $this->form($id, $item));
     }
 
+    /**
+     * @return \Illuminate\Http\JsonResponse
+     */
     public function publish()
     {
         try {
@@ -398,6 +492,9 @@ abstract class ModuleController extends Controller
         );
     }
 
+    /**
+     * @return \Illuminate\Http\JsonResponse
+     */
     public function bulkPublish()
     {
         try {
@@ -419,6 +516,11 @@ abstract class ModuleController extends Controller
         );
     }
 
+    /**
+     * @param int $id
+     * @param int|null $submoduleId
+     * @return \Illuminate\Http\JsonResponse
+     */
     public function destroy($id, $submoduleId = null)
     {
         $item = $this->repository->getById($id);
@@ -431,6 +533,9 @@ abstract class ModuleController extends Controller
         return $this->respondWithError($this->modelTitle . ' was not moved to trash. Something wrong happened!');
     }
 
+    /**
+     * @return \Illuminate\Http\JsonResponse
+     */
     public function bulkDelete()
     {
         if ($this->repository->bulkDelete(explode(',', request('ids')))) {
@@ -441,6 +546,9 @@ abstract class ModuleController extends Controller
         return $this->respondWithError($this->modelTitle . ' items were not moved to trash. Something wrong happened!');
     }
 
+    /**
+     * @return \Illuminate\Http\JsonResponse
+     */
     public function restore()
     {
         if ($this->repository->restore(request('id'))) {
@@ -452,6 +560,9 @@ abstract class ModuleController extends Controller
         return $this->respondWithError($this->modelTitle . ' was not restored. Something wrong happened!');
     }
 
+    /**
+     * @return \Illuminate\Http\JsonResponse
+     */
     public function bulkRestore()
     {
         if ($this->repository->bulkRestore(explode(',', request('ids')))) {
@@ -462,6 +573,9 @@ abstract class ModuleController extends Controller
         return $this->respondWithError($this->modelTitle . ' items were not restored. Something wrong happened!');
     }
 
+    /**
+     * @return \Illuminate\Http\JsonResponse
+     */
     public function feature()
     {
         if (($id = request('id'))) {
@@ -490,6 +604,9 @@ abstract class ModuleController extends Controller
         return $this->respondWithError($this->modelTitle . ' was not featured. Something wrong happened!');
     }
 
+    /**
+     * @return \Illuminate\Http\JsonResponse
+     */
     public function bulkFeature()
     {
         if (($ids = explode(',', request('ids')))) {
@@ -504,6 +621,9 @@ abstract class ModuleController extends Controller
         return $this->respondWithError($this->modelTitle . ' items were not featured. Something wrong happened!');
     }
 
+    /**
+     * @return \Illuminate\Http\JsonResponse
+     */
     public function reorder()
     {
         if (($values = request('ids')) && !empty($values)) {
@@ -515,6 +635,9 @@ abstract class ModuleController extends Controller
         return $this->respondWithError($this->modelTitle . ' order was not changed. Something wrong happened!');
     }
 
+    /**
+     * @return \Illuminate\Http\JsonResponse
+     */
     public function tags()
     {
         $query = $this->request->input('q');
@@ -525,6 +648,10 @@ abstract class ModuleController extends Controller
         })], 200);
     }
 
+    /**
+     * @param array $prependScope
+     * @return array
+     */
     protected function getIndexData($prependScope = [])
     {
         $scopes = $this->filterScope($prependScope);
@@ -559,11 +686,20 @@ abstract class ModuleController extends Controller
         return array_replace_recursive($data + $options, $this->indexData($this->request));
     }
 
+    /**
+     * @param Request $request
+     * @return array
+     */
     protected function indexData($request)
     {
         return [];
     }
 
+    /**
+     * @param array $scopes
+     * @param bool $forcePagination
+     * @return \Illuminate\Database\Eloquent\Collection
+     */
     protected function getIndexItems($scopes = [], $forcePagination = false)
     {
         return $this->transformIndexItems($this->repository->get(
@@ -575,11 +711,19 @@ abstract class ModuleController extends Controller
         ));
     }
 
+    /**
+     * @param \Illuminate\Database\Eloquent\Collection $items
+     * @return \Illuminate\Database\Eloquent\Collection
+     */
     protected function transformIndexItems($items)
     {
         return $items;
     }
 
+    /**
+     * @param \Illuminate\Database\Eloquent\Collection $items
+     * @return array
+     */
     protected function getIndexTableData($items)
     {
         $translated = $this->moduleHas('translations');
@@ -630,11 +774,20 @@ abstract class ModuleController extends Controller
         })->toArray();
     }
 
+    /**
+     * @param \A17\Twill\Models\Model $item
+     * @return array
+     */
     protected function indexItemData($item)
     {
         return [];
     }
 
+    /**
+     * @param \A17\Twill\Models\Model $item
+     * @param array $column
+     * @return array
+     */
     protected function getItemColumnData($item, $column)
     {
         if (isset($column['thumb']) && $column['thumb']) {
@@ -681,6 +834,10 @@ abstract class ModuleController extends Controller
         ];
     }
 
+    /**
+     * @param \Illuminate\Database\Eloquent\Collection $items
+     * @return array
+     */
     protected function getIndexTableColumns($items)
     {
         $tableColumns = [];
@@ -757,6 +914,11 @@ abstract class ModuleController extends Controller
         return $tableColumns;
     }
 
+    /**
+     * @param \Illuminate\Database\Eloquent\Collection $items
+     * @param array $scopes
+     * @return array
+     */
     protected function getIndexTableMainFilters($items, $scopes = [])
     {
         $statusFilters = [];
@@ -802,6 +964,11 @@ abstract class ModuleController extends Controller
         return $statusFilters;
     }
 
+    /**
+     * @param string $moduleName
+     * @param string $routePrefix
+     * @return array
+     */
     protected function getIndexUrls($moduleName, $routePrefix)
     {
         return collect([
@@ -824,6 +991,10 @@ abstract class ModuleController extends Controller
         })->toArray();
     }
 
+    /**
+     * @param string $option
+     * @return bool
+     */
     protected function getIndexOption($option)
     {
         return once(function () use ($option) {
@@ -854,6 +1025,10 @@ abstract class ModuleController extends Controller
         });
     }
 
+    /**
+     * @param array $prependScope
+     * @return array
+     */
     protected function getBrowserData($prependScope = [])
     {
         if (request()->has('except')) {
@@ -867,6 +1042,10 @@ abstract class ModuleController extends Controller
         return array_replace_recursive(['data' => $data], $this->indexData($this->request));
     }
 
+    /**
+     * @param \Illuminate\Database\Eloquent\Collection $items
+     * @return array
+     */
     protected function getBrowserTableData($items)
     {
         $withImage = $this->moduleHas('medias');
@@ -890,11 +1069,19 @@ abstract class ModuleController extends Controller
         })->toArray();
     }
 
+    /**
+     * @param array $scopes
+     * @return \Illuminate\Database\Eloquent\Collection
+     */
     protected function getBrowserItems($scopes = [])
     {
         return $this->getIndexItems($scopes, true);
     }
 
+    /**
+     * @param array $prepend
+     * @return array
+     */
     protected function filterScope($prepend = [])
     {
         $scope = [];
@@ -943,6 +1130,9 @@ abstract class ModuleController extends Controller
         return $prepend + $scope;
     }
 
+    /**
+     * @return array
+     */
     protected function getRequestFilters()
     {
         if (request()->has('search')) {
@@ -952,6 +1142,9 @@ abstract class ModuleController extends Controller
         return json_decode($this->request->get('filter'), true) ?? [];
     }
 
+    /**
+     * @return array
+     */
     protected function orderScope()
     {
         $orders = [];
@@ -974,6 +1167,11 @@ abstract class ModuleController extends Controller
         return $orders + $defaultOrders;
     }
 
+    /**
+     * @param int $id
+     * @param \A17\Twill\Models\Model|null $item
+     * @return array
+     */
     protected function form($id, $item = null)
     {
         $item = $item ?? $this->repository->getById($id, $this->formWith, $this->formWithCount);
@@ -1008,6 +1206,10 @@ abstract class ModuleController extends Controller
         return array_replace_recursive($data, $this->formData($this->request));
     }
 
+    /**
+     * @param int $id
+     * @return array
+     */
     protected function modalFormData($id)
     {
         $item = $this->repository->getById($id, $this->formWith, $this->formWithCount);
@@ -1037,16 +1239,27 @@ abstract class ModuleController extends Controller
         return array_replace_recursive($data, $this->formData($this->request));
     }
 
+    /**
+     * @param Request $request
+     * @return array
+     */
     protected function formData($request)
     {
         return [];
     }
 
+    /**
+     * @param Request $item
+     * @return array
+     */
     protected function previewData($item)
     {
         return [];
     }
 
+    /**
+     * @return \A17\Twill\Http\Requests\Admin\Request
+     */
     protected function validateFormRequest()
     {
         $unauthorizedFields = collect($this->fieldsPermissions)->filter(function ($permission, $field) {
@@ -1060,11 +1273,17 @@ abstract class ModuleController extends Controller
         return $this->app->make("$this->namespace\Http\Requests\Admin\\" . $this->modelName . "Request");
     }
 
+    /**
+     * @return string
+     */
     protected function getNamespace()
     {
         return $this->namespace ?? config('twill.namespace');
     }
 
+    /**
+     * @return string
+     */
     protected function getRoutePrefix()
     {
         if ($this->request->route() != null) {
@@ -1075,31 +1294,49 @@ abstract class ModuleController extends Controller
         return '';
     }
 
+    /**
+     * @return string
+     */
     protected function getModelName()
     {
         return $this->modelName ?? ucfirst(str_singular($this->moduleName));
     }
 
+    /**
+     * @return \A17\Twill\Repositories\ModuleRepository
+     */
     protected function getRepository()
     {
         return $this->app->make("$this->namespace\Repositories\\" . $this->modelName . "Repository");
     }
 
+    /**
+     * @return string
+     */
     protected function getViewPrefix()
     {
         return "admin.$this->moduleName";
     }
 
+    /**
+     * @return string
+     */
     protected function getModelTitle()
     {
         return camelCaseToWords($this->modelName);
     }
 
+    /**
+     * @return string
+     */
     protected function getParentModuleForeignKey()
     {
         return str_singular(explode('.', $this->moduleName)[0]) . '_id';
     }
 
+    /**
+     * @return string
+     */
     protected function getPermalinkBaseUrl()
     {
         return request()->getScheme() . '://' . config('app.url') . '/'
@@ -1109,11 +1346,20 @@ abstract class ModuleController extends Controller
             . (isset($this->permalinkBase) && empty($this->permalinkBase) ? '' : '/');
     }
 
+    /**
+     * @param string $baseUrl
+     * @return string
+     */
     protected function getPermalinkPrefix($baseUrl)
     {
         return rtrim(str_replace(['http://', 'https://', '{preview}/', '{language}/'], '', $baseUrl), "/") . '/';
     }
 
+    /**
+     * @param int $id
+     * @param string $action
+     * @return string
+     */
     protected function getModuleRoute($id, $action)
     {
         return moduleRoute(
@@ -1124,11 +1370,20 @@ abstract class ModuleController extends Controller
         );
     }
 
+    /**
+     * @param string $behavior
+     * @return bool
+     */
     protected function moduleHas($behavior)
     {
         return classHasTrait($this->repository, 'A17\Twill\Repositories\Behaviors\Handle' . ucfirst($behavior));
     }
 
+    /**
+     * @param string|null $back_link
+     * @param array $params
+     * @return void
+     */
     protected function setBackLink($back_link = null, $params = [])
     {
         if (!isset($back_link)) {
@@ -1149,17 +1404,30 @@ abstract class ModuleController extends Controller
         }
     }
 
+    /**
+     * @param string|null $fallback
+     * @param array $params
+     * @return string
+     */
     protected function getBackLink($fallback = null, $params = [])
     {
         $back_link = Session::get($this->getBackLinkSessionKey(), $fallback);
         return $back_link ?? moduleRoute($this->moduleName, $this->routePrefix, 'index', $params);
     }
 
+    /**
+     * @return string
+     */
     protected function getBackLinkSessionKey()
     {
         return $this->moduleName . ($this->submodule ? $this->submoduleParentId ?? '' : '') . '_back_link';
     }
 
+    /**
+     * @param int $id
+     * @param array $params
+     * @return \Illuminate\Http\RedirectResponse
+     */
     protected function redirectToForm($id, $params = [])
     {
         Session::put($this->moduleName . '_retain', true);
@@ -1172,11 +1440,19 @@ abstract class ModuleController extends Controller
         ));
     }
 
+    /**
+     * @param string $message
+     * @return \Illuminate\Http\JsonResponse
+     */
     protected function respondWithSuccess($message)
     {
         return $this->respondWithJson($message, FlashLevel::SUCCESS);
     }
 
+    /**
+     * @param string $redirectUrl
+     * @return \Illuminate\Http\JsonResponse
+     */
     protected function respondWithRedirect($redirectUrl)
     {
         return response()->json([
@@ -1184,11 +1460,20 @@ abstract class ModuleController extends Controller
         ]);
     }
 
+    /**
+     * @param string $message
+     * @return \Illuminate\Http\JsonResponse
+     */
     protected function respondWithError($message)
     {
         return $this->respondWithJson($message, FlashLevel::ERROR);
     }
 
+    /**
+     * @param string $message
+     * @param mixed $variant
+     * @return \Illuminate\Http\JsonResponse
+     */
     protected function respondWithJson($message, $variant)
     {
         return response()->json([
@@ -1197,6 +1482,10 @@ abstract class ModuleController extends Controller
         ]);
     }
 
+    /**
+     * @param array $input
+     * @return void
+     */
     protected function fireEvent($input = [])
     {
         fireCmsEvent('cms-module.saved', $input);

--- a/src/Http/Controllers/Admin/ResetPasswordController.php
+++ b/src/Http/Controllers/Admin/ResetPasswordController.php
@@ -25,16 +25,27 @@ class ResetPasswordController extends Controller
 
     use ResetsPasswords;
 
+    /**
+     * @return \Illuminate\Contracts\Auth\Guard
+     */
     protected function guard()
     {
         return Auth::guard('twill_users');
     }
 
+    /**
+     * @return \Illuminate\Contracts\Auth\PasswordBroker
+     */
     public function broker()
     {
         return Password::broker('twill_users');
     }
 
+    /**
+     * @param Request $request
+     * @param string|null $token
+     * @return \Illuminate\Http\RedirectResponse|\Illuminate\View\View
+     */
     public function showResetForm(Request $request, $token = null)
     {
         $user = $this->getUserFromToken($token);
@@ -53,6 +64,11 @@ class ResetPasswordController extends Controller
         ]);
     }
 
+    /**
+     * @param Request $request
+     * @param string|null $token
+     * @return \Illuminate\Http\RedirectResponse|\Illuminate\View\View
+     */
     public function showWelcomeForm(Request $request, $token = null)
     {
         $user = $this->getUserFromToken($token);
@@ -71,9 +87,14 @@ class ResetPasswordController extends Controller
         ]);
     }
 
-    /*
+    /**
+     * Attempts to find a user with the given token.
+     *
      * Since Laravel 5.4, reset tokens are encrypted, but we support both cases here
      * https://github.com/laravel/framework/pull/16850
+     *
+     * @param string $token
+     * @return \A17\Twill\Models\User|null
      */
     private function getUserFromToken($token)
     {

--- a/src/Http/Controllers/Admin/SettingController.php
+++ b/src/Http/Controllers/Admin/SettingController.php
@@ -7,12 +7,19 @@ use Event;
 
 class SettingController extends Controller
 {
+    /**
+     * @param SettingRepository $settings
+     */
     public function __construct(SettingRepository $settings)
     {
         parent::__construct();
         $this->settings = $settings;
     }
 
+    /**
+     * @param string $section
+     * @return \Illuminate\Http\RedirectResponse|\Illuminate\View\View
+     */
     public function index($section)
     {
         return view()->exists('admin.settings.' . $section) ? view('admin.settings.' . $section, [
@@ -26,6 +33,10 @@ class SettingController extends Controller
         ]) : redirect()->back();
     }
 
+    /**
+     * @param string $section
+     * @return \Illuminate\Http\RedirectResponse
+     */
     public function update($section)
     {
         if (array_key_exists('cancel', request()->all())) {

--- a/src/Http/Controllers/Admin/TemplatesController.php
+++ b/src/Http/Controllers/Admin/TemplatesController.php
@@ -4,16 +4,28 @@ namespace A17\Twill\Http\Controllers\Admin;
 
 class TemplatesController extends Controller
 {
+    /**
+     * @return \Illuminate\View\View
+     */
     public function index()
     {
         return view('templates.index');
     }
 
+    /**
+     * @param string $view
+     * @return \Illuminate\View\View
+     */
     public function view($view)
     {
         return view('templates.' . $view);
     }
 
+    /**
+     * @param string view
+     * @return \Illuminate\Http\JsonResponse
+     * @throws \Throwable
+     */
     public function xhr($view)
     {
         $response = [

--- a/src/Http/Controllers/Admin/UserController.php
+++ b/src/Http/Controllers/Admin/UserController.php
@@ -10,24 +10,48 @@ use PragmaRX\Google2FAQRCode\Google2FA;
 
 class UserController extends ModuleController
 {
+    /**
+     * @var string
+     */
     protected $namespace = 'A17\Twill';
 
+    /**
+     * @var string
+     */
     protected $moduleName = 'users';
 
+    /**
+     * @var string[]
+     */
     protected $indexWith = ['medias'];
 
+    /**
+     * @var array
+     */
     protected $defaultOrders = ['name' => 'asc'];
 
+    /**
+     * @var array
+     */
     protected $defaultFilters = [
         'search' => 'search',
     ];
 
+    /**
+     * @var array
+     */
     protected $filters = [
         'role' => 'role',
     ];
 
+    /**
+     * @var string
+     */
     protected $titleColumnKey = 'name';
 
+    /**
+     * @var array
+     */
     protected $indexColumns = [
         'name' => [
             'title' => 'Name',
@@ -46,14 +70,24 @@ class UserController extends ModuleController
         ],
     ];
 
+    /**
+     * @var array
+     */
     protected $indexOptions = [
         'permalink' => false,
     ];
 
+    /**
+     * @var array
+     */
     protected $fieldsPermissions = [
         'role' => 'edit-user-role',
     ];
 
+    /**
+     * @param Application $app
+     * @param Request $request
+     */
     public function __construct(Application $app, Request $request)
     {
         parent::__construct($app, $request);
@@ -78,6 +112,10 @@ class UserController extends ModuleController
         }
     }
 
+    /**
+     * @param Request $request
+     * @return array
+     */
     protected function indexData($request)
     {
         return [
@@ -95,6 +133,12 @@ class UserController extends ModuleController
         ];
     }
 
+    /**
+     * @param Request $request
+     * @return array
+     * @throws \PragmaRX\Google2FA\Exceptions\IncompatibleWithGoogleAuthenticatorException
+     * @throws \PragmaRX\Google2FA\Exceptions\InvalidCharactersException
+     */
     protected function formData($request)
     {
         $user = Auth::guard('twill_users')->user();
@@ -132,11 +176,19 @@ class UserController extends ModuleController
         ];
     }
 
+    /**
+     * @return array
+     */
     protected function getRequestFilters()
     {
         return json_decode($this->request->get('filter'), true) ?? ['status' => 'published'];
     }
 
+    /**
+     * @param \Illuminate\Database\Eloquent\Collection $items
+     * @param array $scopes
+     * @return array
+     */
     public function getIndexTableMainFilters($items, $scopes = [])
     {
         $statusFilters = [];
@@ -162,6 +214,10 @@ class UserController extends ModuleController
         return $statusFilters;
     }
 
+    /**
+     * @param string $option
+     * @return bool
+     */
     protected function getIndexOption($option)
     {
         if (in_array($option, ['publish', 'delete', 'restore'])) {
@@ -171,6 +227,10 @@ class UserController extends ModuleController
         return parent::getIndexOption($option);
     }
 
+    /**
+     * @param \A17\Twill\Models\Model $item
+     * @return array
+     */
     protected function indexItemData($item)
     {
         $canEdit = auth('twill_users')->user()->can('edit-user-role') || auth('twill_users')->user()->id === $item->id;

--- a/src/Http/Controllers/Front/Controller.php
+++ b/src/Http/Controllers/Front/Controller.php
@@ -10,6 +10,9 @@ use View;
 
 class Controller extends BaseController
 {
+    /**
+     * @var Seo
+     */
     public $seo;
 
     public function __construct()
@@ -27,5 +30,4 @@ class Controller extends BaseController
 
         View::share('seo', $this->seo);
     }
-
 }

--- a/src/Http/Controllers/Front/Helpers/Seo.php
+++ b/src/Http/Controllers/Front/Helpers/Seo.php
@@ -4,13 +4,40 @@ namespace A17\Twill\Http\Controllers\Front\Helpers;
 
 class Seo
 {
+    /**
+     * @var string|null
+     */
     public $title;
+
+    /**
+     * @var string|null
+     */
     public $description;
+
+    /**
+     * @var bool
+     */
     public $nofollow = false;
+
+    /**
+     * @var \A17\Twill\Models\Media|null
+     */
     public $image;
+
+    /**
+     * @var int
+     */
     public $width;
+
+    /**
+     * @var int
+     */
     public $height;
 
+    /**
+     * @param string $title
+     * @return void
+     */
     public function setTitle($title)
     {
         if (!empty($title)) {
@@ -18,6 +45,10 @@ class Seo
         }
     }
 
+    /**
+     * @param string $description
+     * @return void
+     */
     public function setDescription($description)
     {
         if (!empty($description)) {

--- a/src/Http/Controllers/Front/ShowWithPreview.php
+++ b/src/Http/Controllers/Front/ShowWithPreview.php
@@ -4,6 +4,11 @@ namespace A17\Twill\Http\Controllers\Front;
 
 trait ShowWithPreview
 {
+    /**
+     * @param string $slug
+     * @return \Illuminate\Http\RedirectResponse|\Illuminate\View\View
+     * @throws \Exception
+     */
     public function show($slug)
     {
         if (!isset($this->moduleName) || !isset($this->repository)) {
@@ -33,6 +38,10 @@ trait ShowWithPreview
         ] + $this->showData($slug, $item));
     }
 
+    /**
+     * @param string $slug
+     * @return \A17\Twill\Models\Model|null
+     */
     protected function getItem($slug)
     {
         return $this->repository->forSlug(
@@ -43,6 +52,10 @@ trait ShowWithPreview
         );
     }
 
+    /**
+     * @param $slug
+     * @return \A17\Twill\Models\Model|null
+     */
     protected function getItemPreview($slug)
     {
         return $this->repository->forSlugPreview(
@@ -52,6 +65,11 @@ trait ShowWithPreview
         );
     }
 
+    /**
+     * @param string $slug
+     * @param mixed $item
+     * @return array
+     */
     protected function showData($slug, $item)
     {
         return [];

--- a/src/Http/Middleware/Impersonate.php
+++ b/src/Http/Middleware/Impersonate.php
@@ -7,7 +7,13 @@ use Closure;
 
 class Impersonate
 {
-
+    /**
+     * Handles an incoming request.
+     *
+     * @param \Illuminate\Http\Request $request
+     * @param Closure $next
+     * @return mixed
+     */
     public function handle($request, Closure $next)
     {
         if ($request->session()->has('impersonate')) {

--- a/src/Http/Middleware/NoDebugBar.php
+++ b/src/Http/Middleware/NoDebugBar.php
@@ -7,14 +7,26 @@ use Illuminate\Foundation\Application;
 
 class NoDebugBar
 {
-
+    /**
+     * @var Application
+     */
     protected $app;
 
+    /**
+     * @param Application $app
+     */
     public function __construct(Application $app)
     {
         $this->app = $app;
     }
 
+    /**
+     * Handles an incoming request.
+     *
+     * @param \Illuminate\Http\Request $request
+     * @param Closure $next
+     * @return mixed
+     */
     public function handle($request, Closure $next)
     {
         if ($this->app->environment('development', 'local', 'staging')) {

--- a/src/Http/Middleware/RedirectIfAuthenticated.php
+++ b/src/Http/Middleware/RedirectIfAuthenticated.php
@@ -7,6 +7,13 @@ use Closure;
 
 class RedirectIfAuthenticated
 {
+    /**
+     * Handles an incoming request.
+     *
+     * @param \Illuminate\Http\Request $request
+     * @param Closure $next
+     * @return mixed
+     */
     public function handle($request, Closure $next, $guard = 'twill_users')
     {
         if (Auth::guard($guard)->check()) {

--- a/src/Http/Middleware/ValidateBackHistory.php
+++ b/src/Http/Middleware/ValidateBackHistory.php
@@ -6,7 +6,13 @@ use Closure;
 
 class ValidateBackHistory
 {
-
+    /**
+     * Handles an incoming request.
+     *
+     * @param \Illuminate\Http\Request $request
+     * @param Closure $next
+     * @return mixed
+     */
     public function handle($request, Closure $next)
     {
         $response = $next($request);

--- a/src/Http/Requests/Admin/FileRequest.php
+++ b/src/Http/Requests/Admin/FileRequest.php
@@ -4,6 +4,11 @@ namespace A17\Twill\Http\Requests\Admin;
 
 class FileRequest extends Request
 {
+    /**
+     * Gets the validation rules that apply to the request.
+     *
+     * @return array
+     */
     public function rules()
     {
         return config('twill.file_library.endpoint_type') === 'local'

--- a/src/Http/Requests/Admin/MediaRequest.php
+++ b/src/Http/Requests/Admin/MediaRequest.php
@@ -4,6 +4,11 @@ namespace A17\Twill\Http\Requests\Admin;
 
 class MediaRequest extends Request
 {
+    /**
+     * Gets the validation rules that apply to the request.
+     *
+     * @return array
+     */
     public function rules()
     {
         return config('twill.media_library.endpoint_type') === 'local'

--- a/src/Http/Requests/Admin/Request.php
+++ b/src/Http/Requests/Admin/Request.php
@@ -6,11 +6,21 @@ use Illuminate\Foundation\Http\FormRequest;
 
 abstract class Request extends FormRequest
 {
+    /**
+     * Determines if the user is authorized to make this request.
+     *
+     * @return bool
+     */
     public function authorize()
     {
         return true;
     }
 
+    /**
+     * Gets the validation rules that apply to the request.
+     *
+     * @return array
+     */
     public function rules()
     {
         switch ($this->method()) {
@@ -22,6 +32,11 @@ abstract class Request extends FormRequest
         return [];
     }
 
+    /**
+     * Gets the validation rules that apply to the translated fields.
+     *
+     * @return array
+     */
     protected function rulesForTranslatedFields($rules, $fields)
     {
         $locales = getLocales();
@@ -43,6 +58,12 @@ abstract class Request extends FormRequest
         return $rules;
     }
 
+    /**
+     * @param array $rules
+     * @param array $fields
+     * @param string $locale
+     * @return array
+     */
     private function updateRules($rules, $fields, $locale)
     {
         foreach ($fields as $field => $field_rules) {
@@ -61,6 +82,13 @@ abstract class Request extends FormRequest
         return $rules;
     }
 
+    /**
+     * Gets the error messages for the defined validation rules.
+     *
+     * @param array $messages
+     * @param array $fields
+     * @return array
+     */
     protected function messagesForTranslatedFields($messages, $fields)
     {
         foreach (getLocales() as $locale) {
@@ -70,6 +98,12 @@ abstract class Request extends FormRequest
         return $messages;
     }
 
+    /**
+     * @param array $messages
+     * @param array $fields
+     * @param string $locale
+     * @return array
+     */
     private function updateMessages($messages, $fields, $locale)
     {
         foreach ($fields as $field => $message) {
@@ -81,5 +115,4 @@ abstract class Request extends FormRequest
 
         return $messages;
     }
-
 }

--- a/src/Http/Requests/Admin/UserRequest.php
+++ b/src/Http/Requests/Admin/UserRequest.php
@@ -8,11 +8,21 @@ use PragmaRX\Google2FA\Google2FA;
 
 class UserRequest extends Request
 {
+    /**
+     * Determines if the user is authorized to make this request.
+     *
+     * @return bool
+     */
     public function authorize()
     {
         return true;
     }
 
+    /**
+     * Gets the validation rules that apply to the request.
+     *
+     * @return array
+     */
     public function rules()
     {
         switch ($this->method()) {

--- a/src/Http/ViewComposers/ActiveNavigation.php
+++ b/src/Http/ViewComposers/ActiveNavigation.php
@@ -7,14 +7,25 @@ use Illuminate\Http\Request;
 
 class ActiveNavigation
 {
-
+    /**
+     * @var Request
+     */
     protected $request;
 
+    /**
+     * @param Request $request
+     */
     public function __construct(Request $request)
     {
         $this->request = $request;
     }
 
+    /**
+     * Binds data to the view.
+     *
+     * @param View $view
+     * @return void
+     */
     public function compose(View $view)
     {
         if ($this->request->route()) {

--- a/src/Http/ViewComposers/CurrentUser.php
+++ b/src/Http/ViewComposers/CurrentUser.php
@@ -6,6 +6,12 @@ use Illuminate\Contracts\View\View;
 
 class CurrentUser
 {
+    /**
+     * Binds data to the view.
+     *
+     * @param View $view
+     * @return void
+     */
     public function compose(View $view)
     {
         $currentUser = auth('twill_users')->user();

--- a/src/Http/ViewComposers/FilesUploaderConfig.php
+++ b/src/Http/ViewComposers/FilesUploaderConfig.php
@@ -6,6 +6,12 @@ use Illuminate\Contracts\View\View;
 
 class FilesUploaderConfig
 {
+    /**
+     * Binds data to the view.
+     *
+     * @param View $view
+     * @return void
+     */
     public function compose(View $view)
     {
         $libraryDisk = config('twill.file_library.disk');

--- a/src/Http/ViewComposers/MediasUploaderConfig.php
+++ b/src/Http/ViewComposers/MediasUploaderConfig.php
@@ -6,6 +6,12 @@ use Illuminate\Contracts\View\View;
 
 class MediasUploaderConfig
 {
+    /**
+     * Binds data to the view.
+     *
+     * @param View $view
+     * @return void
+     */
     public function compose(View $view)
     {
         $libraryDisk = config('twill.media_library.disk');

--- a/src/Notifications/Reset.php
+++ b/src/Notifications/Reset.php
@@ -7,6 +7,12 @@ use Illuminate\Notifications\Messages\MailMessage;
 
 class Reset extends ResetPassword
 {
+    /**
+     * Build the mail representation of the notification.
+     *
+     * @param mixed $notifiable
+     * @return MailMessage
+     */
     public function toMail($notifiable)
     {
         return (new MailMessage)->markdown('twill::emails.html.email', [

--- a/src/Notifications/Welcome.php
+++ b/src/Notifications/Welcome.php
@@ -7,6 +7,12 @@ use Illuminate\Notifications\Messages\MailMessage;
 
 class Welcome extends ResetPassword
 {
+    /**
+     * Build the mail representation of the notification.
+     *
+     * @param mixed $notifiable
+     * @return MailMessage
+     */
     public function toMail($notifiable)
     {
         return (new MailMessage)->markdown('twill::emails.html.email', [

--- a/src/Repositories/Behaviors/HandleBlocks.php
+++ b/src/Repositories/Behaviors/HandleBlocks.php
@@ -7,6 +7,11 @@ use A17\Twill\Repositories\BlockRepository;
 
 trait HandleBlocks
 {
+    /**
+     * @param \A17\Twill\Models\Model $object
+     * @param array $fields
+     * @return \A17\Twill\Models\Model|void
+     */
     public function hydrateHandleBlocks($object, $fields)
     {
         if ($this->shouldIgnoreFieldBeforeSave('blocks')) {
@@ -37,9 +42,13 @@ trait HandleBlocks
         $object->setRelation('blocks', $blocksCollection);
 
         return $object;
-
     }
 
+    /**
+     * @param \A17\Twill\Models\Model $object
+     * @param array $fields
+     * @return void
+     */
     public function afterSaveHandleBlocks($object, $fields)
     {
         if ($this->shouldIgnoreFieldBeforeSave('blocks')) {
@@ -61,6 +70,11 @@ trait HandleBlocks
         });
     }
 
+    /**
+     * @param \A17\Twill\Models\Model $object
+     * @param array $fields
+     * @return \Illuminate\Support\Collection
+     */
     private function getBlocks($object, $fields)
     {
         $blocks = collect();
@@ -92,6 +106,12 @@ trait HandleBlocks
         return $blocks;
     }
 
+    /**
+     * @param array $block
+     * @param \A17\Twill\Models\Model $object
+     * @param bool $repeater
+     * @return array
+     */
     private function buildBlock($block, $object, $repeater = false)
     {
         $block['blockable_id'] = $object->id;
@@ -100,6 +120,12 @@ trait HandleBlocks
         return app(BlockRepository::class)->buildFromCmsArray($block, $repeater);
     }
 
+
+    /**
+     * @param \A17\Twill\Models\Model $object
+     * @param array $fields
+     * @return array
+     */
     public function getFormFieldsHandleBlocks($object, $fields)
     {
         $fields['blocks'] = null;
@@ -193,6 +219,10 @@ trait HandleBlocks
         return $fields;
     }
 
+    /**
+     * @param \A17\Twill\Models\Block $block
+     * @return array
+     */
     protected function getBlockBrowsers($block)
     {
         return collect($block['content']['browsers'])->mapWithKeys(function ($ids, $relation) use ($block) {

--- a/src/Repositories/Behaviors/HandleDates.php
+++ b/src/Repositories/Behaviors/HandleDates.php
@@ -6,11 +6,20 @@ use Carbon\Carbon;
 
 trait HandleDates
 {
+    /**
+     * @param array $fields
+     * @return array
+     */
     public function prepareFieldsBeforeCreateHandleDates($fields)
     {
         return $this->prepareFieldsBeforeSaveHandleDates(null, $fields);
     }
 
+    /**
+     * @param \A17\Twill\Models\Model|null $object
+     * @param array $fields
+     * @return array
+     */
     public function prepareFieldsBeforeSaveHandleDates($object, $fields)
     {
         foreach ($this->model->getDates() as $f) {
@@ -25,6 +34,11 @@ trait HandleDates
         return $fields;
     }
 
+    /**
+     * @param array $fields
+     * @param string $f
+     * @return array
+     */
     public function prepareDatesField($fields, $f)
     {
         if ($date = Carbon::parse($fields[$f])) {

--- a/src/Repositories/Behaviors/HandleFiles.php
+++ b/src/Repositories/Behaviors/HandleFiles.php
@@ -6,6 +6,11 @@ use A17\Twill\Models\File;
 
 trait HandleFiles
 {
+    /**
+     * @param \A17\Twill\Models\Model $object
+     * @param array $fields
+     * @return \A17\Twill\Models\Model
+     */
     public function hydrateHandleFiles($object, $fields)
     {
         if ($this->shouldIgnoreFieldBeforeSave('files')) {
@@ -27,6 +32,11 @@ trait HandleFiles
         return $object;
     }
 
+    /**
+     * @param \A17\Twill\Models\Behaviors\HasFiles $object
+     * @param array $fields
+     * @return void
+     */
     public function afterSaveHandleFiles($object, $fields)
     {
         if ($this->shouldIgnoreFieldBeforeSave('files')) {
@@ -40,6 +50,10 @@ trait HandleFiles
         });
     }
 
+    /**
+     * @param $fields
+     * @return \Illuminate\Support\Collection
+     */
     private function getFiles($fields)
     {
         $files = collect();
@@ -71,6 +85,11 @@ trait HandleFiles
         return $files;
     }
 
+    /**
+     * @param \A17\Twill\Models\Model $object
+     * @param array $fields
+     * @return array
+     */
     public function getFormFieldsHandleFiles($object, $fields)
     {
         $fields['files'] = null;

--- a/src/Repositories/Behaviors/HandleMedias.php
+++ b/src/Repositories/Behaviors/HandleMedias.php
@@ -6,6 +6,11 @@ use A17\Twill\Models\Media;
 
 trait HandleMedias
 {
+    /**
+     * @param \A17\Twill\Models\Model $object
+     * @param array $fields
+     * @return \A17\Twill\Models\Model
+     */
     public function hydrateHandleMedias($object, $fields)
     {
         if ($this->shouldIgnoreFieldBeforeSave('medias')) {
@@ -27,6 +32,11 @@ trait HandleMedias
         return $object;
     }
 
+    /**
+     * @param \A17\Twill\Models\Model $object
+     * @param array $fields
+     * @return void
+     */
     public function afterSaveHandleMedias($object, $fields)
     {
         if ($this->shouldIgnoreFieldBeforeSave('medias')) {
@@ -40,6 +50,10 @@ trait HandleMedias
         });
     }
 
+    /**
+     * @param array $fields
+     * @return \Illuminate\Support\Collection
+     */
     private function getMedias($fields)
     {
         $medias = collect();
@@ -91,6 +105,11 @@ trait HandleMedias
         return $medias;
     }
 
+    /**
+     * @param \A17\Twill\Models\Model $object
+     * @param array $fields
+     * @return array
+     */
     public function getFormFieldsHandleMedias($object, $fields)
     {
         $fields['medias'] = null;
@@ -132,6 +151,10 @@ trait HandleMedias
         return $fields;
     }
 
+    /**
+     * @param string $role
+     * @return array
+     */
     public function getCrops($role)
     {
         return $this->model->mediasParams[$role];

--- a/src/Repositories/BlockRepository.php
+++ b/src/Repositories/BlockRepository.php
@@ -2,6 +2,8 @@
 
 namespace A17\Twill\Repositories;
 
+use A17\Twill\Models\Behaviors\HasFiles;
+use A17\Twill\Models\Behaviors\HasMedias;
 use A17\Twill\Models\Block;
 use A17\Twill\Repositories\Behaviors\HandleFiles;
 use A17\Twill\Repositories\Behaviors\HandleMedias;
@@ -10,22 +12,38 @@ class BlockRepository extends ModuleRepository
 {
     use HandleMedias, HandleFiles;
 
+    /**
+     * @param Block $model
+     */
     public function __construct(Block $model)
     {
         $this->model = $model;
     }
 
+    /**
+     * @param string $role
+     * @return array
+     */
     public function getCrops($role)
     {
         return config('twill.block_editor.crops')[$role];
     }
 
+    /**
+     * @param HasMedias|HasFiles $object
+     * @return void
+     */
     public function afterDelete($object)
     {
         $object->medias()->sync([]);
         $object->files()->sync([]);
     }
 
+    /**
+     * @param array $block
+     * @param bool $repeater
+     * @return array
+     */
     public function buildFromCmsArray($block, $repeater = false)
     {
         $blocksFromConfig = config('twill.block_editor.' . ($repeater ? 'repeaters' : 'blocks'));

--- a/src/Repositories/FileRepository.php
+++ b/src/Repositories/FileRepository.php
@@ -10,17 +10,29 @@ class FileRepository extends ModuleRepository
 {
     use HandleTags;
 
+    /**
+     * @param File $model
+     */
     public function __construct(File $model)
     {
         $this->model = $model;
     }
 
+    /**
+     * @param \Illuminate\Database\Query\Builder $query
+     * @param array $scopes
+     * @return \Illuminate\Database\Query\Builder
+     */
     public function filter($query, array $scopes = [])
     {
         $this->searchIn($query, $scopes, 'search', ['filename']);
         return parent::filter($query, $scopes);
     }
 
+    /**
+     * @param int $id
+     * @return void
+     */
     public function delete($id)
     {
         if (($object = $this->model->find($id)) != null) {
@@ -33,6 +45,10 @@ class FileRepository extends ModuleRepository
         }
     }
 
+    /**
+     * @param array $fields
+     * @return array
+     */
     public function prepareFieldsBeforeCreate($fields)
     {
         if (!isset($fields['size'])) {

--- a/src/Repositories/MediaRepository.php
+++ b/src/Repositories/MediaRepository.php
@@ -1,5 +1,6 @@
 <?php
 
+
 namespace A17\Twill\Repositories;
 
 use A17\Twill\Models\Media;

--- a/src/Repositories/SettingRepository.php
+++ b/src/Repositories/SettingRepository.php
@@ -9,11 +9,19 @@ class SettingRepository extends ModuleRepository
 {
     use HandleMedias;
 
+    /**
+     * @param Setting $model
+     */
     public function __construct(Setting $model)
     {
         $this->model = $model;
     }
 
+    /**
+     * @param string $key
+     * @param string|null $section
+     * @return string|null
+     */
     public function byKey($key, $section = null)
     {
         return $this->model->when($section, function ($query) use ($section) {
@@ -21,6 +29,10 @@ class SettingRepository extends ModuleRepository
         })->where('key', $key)->exists() ? $this->model->where('key', $key)->with('translations')->first()->value : null;
     }
 
+    /**
+     * @param string|null $section
+     * @return array
+     */
     public function getFormFields($section = null)
     {
         $settings = $this->model->when($section, function ($query) use ($section) {
@@ -42,6 +54,11 @@ class SettingRepository extends ModuleRepository
         })->toArray() + ['medias' => $medias];
     }
 
+    /**
+     * @param array $settingsFields
+     * @param string|null $section
+     * @return void
+     */
     public function saveAll($settingsFields, $section = null)
     {
         $section = $section ? ['section' => $section] : [];
@@ -80,6 +97,10 @@ class SettingRepository extends ModuleRepository
         }
     }
 
+    /**
+     * @param string $role
+     * @return array
+     */
     public function getCrops($role)
     {
         return config('twill.settings.crops')[$role];

--- a/src/Repositories/UserRepository.php
+++ b/src/Repositories/UserRepository.php
@@ -11,11 +11,19 @@ class UserRepository extends ModuleRepository
 {
     use HandleMedias;
 
+    /**
+     * @param User $model
+     */
     public function __construct(User $model)
     {
         $this->model = $model;
     }
 
+    /**
+     * @param \Illuminate\Database\Query\Builder $query
+     * @param array $scopes
+     * @return \Illuminate\Database\Query\Builder
+     */
     public function filter($query, array $scopes = [])
     {
         $query->when(isset($scopes['role']), function ($query) use ($scopes) {
@@ -26,27 +34,45 @@ class UserRepository extends ModuleRepository
         return parent::filter($query, $scopes);
     }
 
+    /**
+     * @param \A17\Twill\Models\Model $user
+     * @param array $fields
+     */
     public function afterUpdateBasic($user, $fields)
     {
         $this->sendWelcomeEmail($user);
         parent::afterUpdateBasic($user, $fields);
     }
 
+    /**
+     * @return int
+     */
     public function getCountForPublished()
     {
         return $this->model->where('role', '<>', 'SUPERADMIN')->published()->count();
     }
 
+    /**
+     * @return int
+     */
     public function getCountForDraft()
     {
         return $this->model->where('role', '<>', 'SUPERADMIN')->draft()->count();
     }
 
+    /**
+     * @return int
+     */
     public function getCountForTrash()
     {
         return $this->model->where('role', '<>', 'SUPERADMIN')->onlyTrashed()->count();
     }
 
+    /**
+     * @param \A17\Twill\Models\Model $user
+     * @param array $fields
+     * @return string[]
+     */
     public function prepareFieldsBeforeSave($user, $fields)
     {
         $editor = auth('twill_users')->user();
@@ -62,12 +88,21 @@ class UserRepository extends ModuleRepository
         return parent::prepareFieldsBeforeSave($user, $fields);
     }
 
+    /**
+     * @param \A17\Twill\Models\Model|User $user
+     * @param array $fields
+     * @return void
+     */
     public function afterSave($user, $fields)
     {
         $this->sendWelcomeEmail($user);
         parent::afterSave($user, $fields);
     }
 
+    /**
+     * @param User $user
+     * @return void
+     */
     private function sendWelcomeEmail($user)
     {
         if (empty($user->password) && $user->published && !DB::table(config('twill.password_resets_table', 'twill_password_resets'))->where('email', $user->email)->exists()) {

--- a/src/RouteServiceProvider.php
+++ b/src/RouteServiceProvider.php
@@ -15,6 +15,11 @@ class RouteServiceProvider extends ServiceProvider
 {
     protected $namespace = 'A17\Twill\Http\Controllers';
 
+    /**
+     * Bootstraps the package services.
+     *
+     * @return void
+     */
     public function boot()
     {
         $this->registerRouteMiddlewares();
@@ -22,6 +27,10 @@ class RouteServiceProvider extends ServiceProvider
         parent::boot();
     }
 
+    /**
+     * @param Router $router
+     * @return void
+     */
     public function map(Router $router)
     {
         if (($patterns=config('twill.admin_route_patterns')) != null) {
@@ -83,6 +92,11 @@ class RouteServiceProvider extends ServiceProvider
         }
     }
 
+    /**
+     * Register Route middleware.
+     *
+     * @return void
+     */
     private function registerRouteMiddlewares()
     {
         /*
@@ -97,6 +111,11 @@ class RouteServiceProvider extends ServiceProvider
         Route::$middlewareRegisterMethod('validateBackHistory', ValidateBackHistory::class);
     }
 
+    /**
+     * Registers Route macros.
+     *
+     * @return void
+     */
     protected function registerMacros()
     {
         Route::macro('moduleShowWithPreview', function ($moduleName, $routePrefix = null, $controllerName = null) {

--- a/src/Services/Cache/CloudfrontCacheService.php
+++ b/src/Services/Cache/CloudfrontCacheService.php
@@ -13,16 +13,25 @@ class CloudfrontCacheService
     protected static $defaultRegion = 'us-east-1';
     protected static $defaultSdkVersion = '2016-01-13';
 
+    /**
+     * @return string
+     */
     public static function getSdkVersion()
     {
         return config('services.cloudfront.sdk_version') ?? self::$defaultSdkVersion;
     }
 
+    /**
+     * @return string
+     */
     public static function getRegion()
     {
         return config('services.cloudfront.region') ?? self::$defaultRegion;
     }
 
+    /**
+     * @return CloudFrontClient
+     */
     public static function getClient()
     {
         $cloudFront = new CloudFrontClient(array(
@@ -46,6 +55,10 @@ class CloudfrontCacheService
         }
     }
 
+    /**
+     * @param string[] $urls
+     * @return void
+     */
     public function invalidate($urls = ["/*"])
     {
         if (!$this->hasInProgressInvalidation()) {
@@ -59,6 +72,9 @@ class CloudfrontCacheService
         }
     }
 
+    /**
+     * @return bool
+     */
     private function hasInProgressInvalidation()
     {
         $list = $this->client->listInvalidations(array('DistributionId' => config('services.cloudfront.distribution')))->get('InvalidationList');
@@ -67,9 +83,12 @@ class CloudfrontCacheService
         }
 
         return false;
-
     }
 
+    /**
+     * @param array $paths
+     * @return \Aws\Result
+     */
     private function createInvalidationRequest($paths = array())
     {
         if (is_object($this->client) && count($paths) > 0) {

--- a/src/Services/FileLibrary/Disk.php
+++ b/src/Services/FileLibrary/Disk.php
@@ -6,6 +6,10 @@ use Storage;
 
 class Disk implements FileServiceInterface
 {
+    /**
+     * @param mixed $id
+     * @return mixed
+     */
     public function getUrl($id)
     {
         return Storage::disk(config('twill.file_library.disk'))->url($id);

--- a/src/Services/FileLibrary/FileService.php
+++ b/src/Services/FileLibrary/FileService.php
@@ -6,6 +6,9 @@ use Illuminate\Support\Facades\Facade;
 
 class FileService extends Facade
 {
+    /**
+     * @return string
+     */
     protected static function getFacadeAccessor()
     {
         return 'fileService';

--- a/src/Services/FileLibrary/FileServiceInterface.php
+++ b/src/Services/FileLibrary/FileServiceInterface.php
@@ -4,5 +4,9 @@ namespace A17\Twill\Services\FileLibrary;
 
 interface FileServiceInterface
 {
+    /**
+     * @param string $id
+     * @return string
+     */
     public function getUrl($id);
 }

--- a/src/Services/MediaLibrary/ImageService.php
+++ b/src/Services/MediaLibrary/ImageService.php
@@ -6,6 +6,9 @@ use Illuminate\Support\Facades\Facade;
 
 class ImageService extends Facade
 {
+    /**
+     * @return string
+     */
     protected static function getFacadeAccessor()
     {
         return 'imageService';

--- a/src/Services/MediaLibrary/ImageServiceDefaults.php
+++ b/src/Services/MediaLibrary/ImageServiceDefaults.php
@@ -4,6 +4,9 @@ namespace A17\Twill\Services\MediaLibrary;
 
 trait ImageServiceDefaults
 {
+    /**
+     * @return string
+     */
     public function getSocialFallbackUrl()
     {
         if ($id = config("twill.seo.image_default_id")) {
@@ -13,6 +16,9 @@ trait ImageServiceDefaults
         return config("twill.seo.image_local_fallback");
     }
 
+    /**
+     * @return string
+     */
     public function getTransparentFallbackUrl()
     {
         return "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7";

--- a/src/Services/MediaLibrary/ImageServiceInterface.php
+++ b/src/Services/MediaLibrary/ImageServiceInterface.php
@@ -4,15 +4,71 @@ namespace A17\Twill\Services\MediaLibrary;
 
 interface ImageServiceInterface
 {
+    /**
+     * @param string $id
+     * @param array $params
+     * @return string
+     */
     public function getUrl($id, array $params = []);
-    public function getUrlWithCrop($id, array $crop_params, array $params = []);
-    public function getUrlWithFocalCrop($id, array $cropParams, $width, $height, array $params = []);
-    public function getLQIPUrl($id, array $params = []);
-    public function getSocialUrl($id, array $params = []);
-    public function getCmsUrl($id, array $params = []);
-    public function getRawUrl($id);
-    public function getDimensions($id);
-    public function getSocialFallbackUrl();
-    public function getTransparentFallbackUrl();
 
+    /**
+     * @param string $id
+     * @param array $crop_params
+     * @param array $params
+     * @return string
+     */
+    public function getUrlWithCrop($id, array $crop_params, array $params = []);
+
+    /**
+     * @param string $id
+     * @param array $cropParams
+     * @param int $width
+     * @param int $height
+     * @param array $params
+     * @return string
+     */
+    public function getUrlWithFocalCrop($id, array $cropParams, $width, $height, array $params = []);
+
+    /**
+     * @param string $id
+     * @param array $params
+     * @return string
+     */
+    public function getLQIPUrl($id, array $params = []);
+
+    /**
+     * @param string $id
+     * @param array $params
+     * @return string
+     */
+    public function getSocialUrl($id, array $params = []);
+
+    /**
+     * @param string $id
+     * @param array $params
+     * @return string
+     */
+    public function getCmsUrl($id, array $params = []);
+
+    /**
+     * @param string $id
+     * @return string
+     */
+    public function getRawUrl($id);
+
+    /**
+     * @param string $id
+     * @return array|null
+     */
+    public function getDimensions($id);
+
+    /**
+     * @return string
+     */
+    public function getSocialFallbackUrl();
+
+    /**
+     * @return string
+     */
+    public function getTransparentFallbackUrl();
 }

--- a/src/Services/MediaLibrary/Imgix.php
+++ b/src/Services/MediaLibrary/Imgix.php
@@ -9,6 +9,9 @@ class Imgix implements ImageServiceInterface
 {
     use ImageServiceDefaults;
 
+    /**
+     * @var UrlBuilder
+     */
     private $urlBuilder;
 
     public function __construct()
@@ -22,45 +25,87 @@ class Imgix implements ImageServiceInterface
         $this->urlBuilder = $urlBuilder;
     }
 
+    /**
+     * @param string $id
+     * @param array $params
+     * @return string
+     */
     public function getUrl($id, array $params = [])
     {
         $defaultParams = config('twill.imgix.default_params');
         return $this->urlBuilder->createURL($id, ends_with($id, '.svg') ? [] : array_replace($defaultParams, $params));
     }
 
+    /**
+     * @param string $id
+     * @param array $cropParams
+     * @param array $params
+     * @return string
+     */
     public function getUrlWithCrop($id, array $cropParams, array $params = [])
     {
         return $this->getUrl($id, $this->getCrop($cropParams) + $params);
     }
 
+    /**
+     * @param string $id
+     * @param array $cropParams
+     * @param mixed $width
+     * @param mixed $height
+     * @param array $params
+     * @return string
+     */
     public function getUrlWithFocalCrop($id, array $cropParams, $width, $height, array $params = [])
     {
         return $this->getUrl($id, $this->getFocalPointCrop($cropParams, $width, $height) + $params);
     }
 
+    /**
+     * @param string $id
+     * @param array $params
+     * @return string
+     */
     public function getLQIPUrl($id, array $params = [])
     {
         $defaultParams = config('twill.imgix.lqip_default_params');
         return $this->getUrl($id, array_replace($defaultParams, $params));
     }
 
+    /**
+     * @param string $id
+     * @param array $params
+     * @return string
+     */
     public function getSocialUrl($id, array $params = [])
     {
         $defaultParams = config('twill.imgix.social_default_params');
         return $this->getUrl($id, array_replace($defaultParams, $params));
     }
 
+    /**
+     * @param string $id
+     * @param array $params
+     * @return string
+     */
     public function getCmsUrl($id, array $params = [])
     {
         $defaultParams = config('twill.imgix.cms_default_params');
         return $this->getUrl($id, array_replace($defaultParams, $params));
     }
 
+    /**
+     * @param string $id
+     * @return string
+     */
     public function getRawUrl($id)
     {
         return $this->urlBuilder->createURL($id);
     }
 
+    /**
+     * @param string $id
+     * @return array|null
+     */
     public function getDimensions($id)
     {
         $url = $this->urlBuilder->createURL($id, ['fm' => 'json']);
@@ -88,6 +133,10 @@ class Imgix implements ImageServiceInterface
         }
     }
 
+    /**
+     * @param array $crop_params
+     * @return array
+     */
     protected function getCrop($crop_params)
     {
         if (!empty($crop_params)) {
@@ -97,6 +146,12 @@ class Imgix implements ImageServiceInterface
         return [];
     }
 
+    /**
+     * @param array $crop_params
+     * @param int $width
+     * @param int $height
+     * @return array
+     */
     protected function getFocalPointCrop($crop_params, $width, $height)
     {
         if (!empty($crop_params)) {

--- a/src/Services/MediaLibrary/Local.php
+++ b/src/Services/MediaLibrary/Local.php
@@ -6,41 +6,83 @@ class Local implements ImageServiceInterface
 {
     use ImageServiceDefaults;
 
+    /**
+     * @param string $id
+     * @param array $params
+     * @return string
+     */
     public function getUrl($id, array $params = [])
     {
         return $this->getRawUrl($id);
     }
 
+    /**
+     * @param string $id
+     * @param array $crop_params
+     * @param array $params
+     * @return string
+     */
     public function getUrlWithCrop($id, array $crop_params, array $params = [])
     {
         return $this->getRawUrl($id);
     }
 
+    /**
+     * @param string $id
+     * @param array $cropParams
+     * @param int $width
+     * @param int $height
+     * @param array $params
+     * @return string
+     */
     public function getUrlWithFocalCrop($id, array $cropParams, $width, $height, array $params = [])
     {
         return $this->getRawUrl($id);
     }
 
+    /**
+     * @param string $id
+     * @param array $params
+     * @return string
+     */
     public function getLQIPUrl($id, array $params = [])
     {
         return $this->getRawUrl($id);
     }
 
+    /**
+     * @param string $id
+     * @param array $params
+     * @return string
+     */
     public function getSocialUrl($id, array $params = [])
     {
         return $this->getRawUrl($id);
     }
 
+    /**
+     * @param string $id
+     * @param array $params
+     * @return string
+     */
     public function getCmsUrl($id, array $params = [])
     {
         return $this->getRawUrl($id);
     }
 
+    /**
+     * @param string $id
+     * @return string
+     */
     public function getRawUrl($id)
     {
         return '/' . $id;
     }
 
+    /**
+     * @param string $id
+     * @return array|null
+     */
     public function getDimensions($id)
     {
         return null;

--- a/src/Services/Uploader/SignS3Upload.php
+++ b/src/Services/Uploader/SignS3Upload.php
@@ -11,7 +11,6 @@ class SignS3Upload
     private $secret;
 
     private $endpoint;
-
     public function fromPolicy($policy, SignS3UploadListener $listener, $disk = 'libraries')
     {
         $policyObject = json_decode($policy, true);

--- a/src/TwillServiceProvider.php
+++ b/src/TwillServiceProvider.php
@@ -32,6 +32,11 @@ use View;
 
 class TwillServiceProvider extends ServiceProvider
 {
+    /**
+     * Service providers to be registered.
+     *
+     * @var string[]
+     */
     protected $providers = [
         RouteServiceProvider::class,
         AuthServiceProvider::class,
@@ -41,6 +46,11 @@ class TwillServiceProvider extends ServiceProvider
         ActivitylogServiceProvider::class,
     ];
 
+    /**
+     * Bootstraps the package services.
+     *
+     * @return void
+     */
     public function boot()
     {
         $this->requireHelpers();
@@ -57,6 +67,11 @@ class TwillServiceProvider extends ServiceProvider
         $this->addViewComposers();
     }
 
+    /**
+     * Registers the package services.
+     *
+     * @return void
+     */
     public function register()
     {
         $this->mergeConfigs();
@@ -74,6 +89,11 @@ class TwillServiceProvider extends ServiceProvider
         config(['twill.version' => trim(file_get_contents(__DIR__ . '/../VERSION'))]);
     }
 
+    /**
+     * Registers the package service providers.
+     *
+     * @return void
+     */
     private function registerProviders()
     {
         foreach ($this->providers as $provider) {
@@ -101,6 +121,11 @@ class TwillServiceProvider extends ServiceProvider
         }
     }
 
+    /**
+     * Registers the package facade aliases.
+     *
+     * @return void
+     */
     private function registerAliases()
     {
         $loader = AliasLoader::getInstance();
@@ -121,6 +146,11 @@ class TwillServiceProvider extends ServiceProvider
 
     }
 
+    /**
+     * Defines the package configuration files for publishing.
+     *
+     * @return void
+     */
     private function publishConfigs()
     {
         if (config('twill.enabled.users-management')) {
@@ -156,6 +186,11 @@ class TwillServiceProvider extends ServiceProvider
         $this->publishes([__DIR__ . '/../config/translatable.php' => config_path('translatable.php')], 'config');
     }
 
+    /**
+     * Merges the package configuration files into the given configuration namespaces.
+     *
+     * @return void
+     */
     private function mergeConfigs()
     {
         $this->mergeConfigFrom(__DIR__ . '/../config/twill.php', 'twill');
@@ -172,6 +207,11 @@ class TwillServiceProvider extends ServiceProvider
         $this->mergeConfigFrom(__DIR__ . '/../config/dashboard.php', 'twill.dashboard');
     }
 
+    /**
+     * Defines the package migration files for publishing.
+     *
+     * @return void
+     */
     private function publishMigrations()
     {
         $migrations = ['CreateTagsTables', 'CreateBlocksTable', 'CreateRelatedTable'];
@@ -197,6 +237,10 @@ class TwillServiceProvider extends ServiceProvider
         }
     }
 
+    /**
+     * @param string $migration
+     * @return void
+     */
     private function publishMigration($migration)
     {
         if (!class_exists($migration)) {
@@ -207,6 +251,9 @@ class TwillServiceProvider extends ServiceProvider
         }
     }
 
+    /**
+     * @return void
+     */
     private function publishAssets()
     {
         $this->publishes([
@@ -214,6 +261,9 @@ class TwillServiceProvider extends ServiceProvider
         ], 'assets');
     }
 
+    /**
+     * @return void
+     */
     private function registerAndPublishViews()
     {
         $viewPath = __DIR__ . '/../views';
@@ -222,6 +272,9 @@ class TwillServiceProvider extends ServiceProvider
         $this->publishes([$viewPath => resource_path('views/vendor/twill')], 'views');
     }
 
+    /**
+     * @return void
+     */
     private function registerCommands()
     {
         $this->commands([
@@ -234,6 +287,9 @@ class TwillServiceProvider extends ServiceProvider
         ]);
     }
 
+    /**
+     * @return void
+     */
     private function requireHelpers()
     {
         require_once __DIR__ . '/Helpers/routes_helpers.php';
@@ -244,6 +300,11 @@ class TwillServiceProvider extends ServiceProvider
         require_once __DIR__ . '/Helpers/helpers.php';
     }
 
+    /**
+     * @param string $view
+     * @param string $expression
+     * @return string
+     */
     private function includeView($view, $expression)
     {
         list($name) = str_getcsv($expression, ',', '\'');
@@ -261,6 +322,11 @@ class TwillServiceProvider extends ServiceProvider
         return "<?php echo \$__env->make('{$view}', array_except(get_defined_vars(), ['__data', '__path']))->with{$expression}->render(); ?>";
     }
 
+    /**
+     * Defines the package additional Blade Directives.
+     *
+     * @return void
+     */
     private function extendBlade()
     {
         $blade = $this->app['view']->getEngineResolver()->resolve('blade')->getCompiler();
@@ -325,6 +391,11 @@ class TwillServiceProvider extends ServiceProvider
         });
     }
 
+    /**
+     * Registers the package additional View Composers.
+     *
+     * @return void
+     */
     private function addViewComposers()
     {
         if (config('twill.enabled.users-management')) {
@@ -352,6 +423,11 @@ class TwillServiceProvider extends ServiceProvider
 
     }
 
+    /**
+     * Registers and publishes the package additional translations.
+     *
+     * @return void
+     */
     private function registerAndPublishTranslations()
     {
         $translationPath = __DIR__ . '/../lang';

--- a/src/ValidationServiceProvider.php
+++ b/src/ValidationServiceProvider.php
@@ -8,7 +8,11 @@ use Validator;
 
 class ValidationServiceProvider extends ServiceProvider
 {
-
+    /**
+     * Registers the package additional validation rules.
+     *
+     * @return void
+     */
     public function boot()
     {
         Validator::extend('absolute_or_relative_url', function ($attribute, $value, $parameters, $validator) {
@@ -54,6 +58,9 @@ class ValidationServiceProvider extends ServiceProvider
         });
     }
 
+    /**
+     * @return void
+     */
     public function register()
     {
 


### PR DESCRIPTION
This is related to #295. I've added the docblocks to all methods and classes. What I am missing in most of the places are method descriptions. So what I did is that I only added annotations `@param` and `@return`. Adding those method descriptions is a huge procedure and I need a lot of time to do that since I would basically have to briefly explain the whole systems' functionality. I am not giving up on that, I am just postponing that.

But first I would really love that we merge this one. I would also like to hear from you guys about these changes.