### PR TITLE
Make the module generator smarter: Transform the module name passed in to correct format.

### DIFF
--- a/src/Commands/ModuleMake.php
+++ b/src/Commands/ModuleMake.php
@@ -41,7 +41,7 @@ class ModuleMake extends Command
 
     public function handle()
     {
-        $moduleName = $this->argument('moduleName');
+        $moduleName = Str::plural(lcfirst($this->argument('moduleName')));
 
         $blockable = $this->option('hasBlocks') ?? false;
         $translatable = $this->option('hasTranslation') ?? false;


### PR DESCRIPTION
This PR make the following module generator commands result same effect.
```
php artisan twill:module Post
```
```
php artisan twill:module post
```
```
php artisan twill:module Posts
```