### PR TITLE
Fix issue with wrong logo url

### DIFF
--- a/views/partials/navigation/_title.blade.php
+++ b/views/partials/navigation/_title.blade.php
@@ -1,3 +1,8 @@
 <h1 class="header__title">
-    <a href="/">{{ config('app.name') }} <span class="envlabel">{{ app()->environment() === 'production' ? 'prod' : app()->environment() }}</span></a>
+    <a href={{ config('twill.enabled.dashboard') ? route('admin.dashboard') : '#' }}>
+        {{ config('app.name') }}
+        <span class="envlabel">
+            {{ app()->environment() === 'production' ? 'prod' : app()->environment() }}
+        </span>
+    </a>
 </h1>


### PR DESCRIPTION
Click the logo on the top left should always redirect user to dashboard page.

When use the admin path `example.com/admin` rather than `admin.example.com`, click the logo will redirect user to `example.com` if we use static `/` as the href, this PR is intended to fix this issue.