### PR TITLE
Improve the module maker by letting user choose traits to include through questions

### DIFF
--- a/src/Commands/ModuleMake.php
+++ b/src/Commands/ModuleMake.php
@@ -43,13 +43,13 @@ class ModuleMake extends Command
     {
         $moduleName = $this->argument('moduleName');
 
-        $blockable = $this->option('hasBlocks') ?? false;
-        $translatable = $this->option('hasTranslation') ?? false;
-        $sluggable = $this->option('hasSlug') ?? false;
-        $mediable = $this->option('hasMedias') ?? false;
-        $fileable = $this->option('hasFiles') ?? false;
-        $sortable = $this->option('hasPosition') ?? false;
-        $revisionable = $this->option('hasRevisions') ?? false;
+        $blockable = $this->checkOption('hasBlocks');
+        $translatable = $this->checkOption('hasTranslation');
+        $sluggable = $this->checkOption('hasSlug');
+        $mediable = $this->checkOption('hasMedias');
+        $fileable = $this->checkOption('hasFiles');
+        $sortable = $this->checkOption('hasPosition');
+        $revisionable = $this->checkOption('hasRevisions');
 
         $activeTraits = [$blockable, $translatable, $sluggable, $mediable, $fileable, $revisionable, $sortable];
 
@@ -250,5 +250,21 @@ class ModuleMake extends Command
         $this->files->put($viewsPath . '/form.blade.php', $this->files->get(__DIR__ . '/stubs/' . $formView . '.blade.stub'));
 
         $this->info("Form view created successfully! Include your form fields using @formField directives!");
+    }
+
+    private function checkOption($option)
+    {
+        $questions = [
+            'hasBlocks' => 'Does this module require blocks?',
+            'hasTranslation' => 'Does this module require translation?',
+            'hasSlug' => 'Does this module require slug?',
+            'hasMedias' => 'Does this module has medias?',
+            'hasFiles' => 'Does this module has files?',
+            'hasPosition' => 'Does this module require position?',
+            'hasRevisions' => 'Does this module require revisions?'
+        ];
+
+        // If option is not provided, ask choice question.
+        return $this->option($option) ? true : 'yes' === $this->choice($questions[$option], ['yes', 'no'], 1);
     }
 }


### PR DESCRIPTION
This PR proposed to add a `checkOption` method in `ModuleMake.php`, which will prompt choice questions while creating a new module, for user to decide which trait has to be brought in, instead of provide `-BTSMFPR` options manually.

The command now will work as the image shows below, if no options are provided:

![image](https://user-images.githubusercontent.com/12378652/62546128-f03d4900-b830-11e9-9646-2295321e7f2b.png)

It will only prompt for options that hasn't been explicitly defined in command, and the default answer is `false`:

![image](https://user-images.githubusercontent.com/12378652/62546135-f3383980-b830-11e9-8150-b4b748d6138e.png)


 