### PR TITLE
Add noindex and nofollow header to CMS pages

### DIFF
--- a/views/partials/head.blade.php
+++ b/views/partials/head.blade.php
@@ -1,6 +1,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no" />
 <meta http-equiv="X-UA-Compatible" content="IE=Edge">
+<meta name="robots" content="noindex,nofollow" />
 
 <title>{{ config('app.name') }}</title>
 


### PR DESCRIPTION
In instances where the same codebase serves the frontend as well
as the CMS, it's challenging to use a robots.txt file to block
search engine spiders from indexing admin pages. Adding this
header help to ensure that CMS pages done find their way into
search engines.