### PR TITLE
upgrade translatable from dimsav to astrotomic

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,21 +52,21 @@
     "php": "^7.0",
     "ext-json": "*",
     "ext-pdo": "*",
-    "laravel/framework": "~5.3.0|~5.4.0|~5.5.0|~5.6.0|~5.7.0|~5.8.0",
-    "dimsav/laravel-translatable": "^6.0.1|^7.0.0|^8.0.0|^9.0.0|^10.0.0",
+    "astrotomic/laravel-translatable": "^11.3",
+    "barryvdh/laravel-debugbar": "^2.4|^3.1",
     "cartalyst/tags": "^3.0.0|^4.0.0|^5.0.0|^6.0.0|^7.0.0|^8.0.0",
     "doctrine/dbal": "^2.9",
-    "league/flysystem-aws-s3-v3": "^1.0.13",
-    "myclabs/php-enum": "^1.5.0",
-    "imgix/imgix-php": "^3.0.0",
-    "lsrur/inspector": "^1.0",
-    "barryvdh/laravel-debugbar": "^2.4|^3.1",
     "guzzlehttp/guzzle": "^6.2",
-    "spatie/once": "^2.0.0",
-    "spatie/laravel-analytics": "^3.6.0|^3.7.0",
-    "spatie/laravel-activitylog": "^2.5|^3.2",
+    "imgix/imgix-php": "^3.0.0",
+    "laravel/framework": "~5.3.0|~5.4.0|~5.5.0|~5.6.0|~5.7.0|~5.8.0",
+    "league/flysystem-aws-s3-v3": "^1.0.13",
+    "league/glide-laravel": "^1.0",
+    "lsrur/inspector": "^1.0",
+    "myclabs/php-enum": "^1.5.0",
     "pragmarx/google2fa-qrcode": "^1.0.3",
-    "league/glide-laravel": "^1.0"
+    "spatie/laravel-activitylog": "^2.5|^3.2",
+    "spatie/laravel-analytics": "^3.6.0|^3.7.0",
+    "spatie/once": "^2.0.0"
   },
   "require-dev": {
     "phpunit/phpunit": "~5.0|~6.0|~7.0"
@@ -83,5 +83,8 @@
         ]
     }
   },
-  "minimum-stability": "stable"
+  "minimum-stability": "stable",
+  "config": {
+    "sort-packages": true
+  }
 }

--- a/src/Models/Behaviors/HasTranslation.php
+++ b/src/Models/Behaviors/HasTranslation.php
@@ -2,7 +2,7 @@
 
 namespace A17\Twill\Models\Behaviors;
 
-use Dimsav\Translatable\Translatable;
+use Astrotomic\Translatable\Translatable;
 
 trait HasTranslation
 {

--- a/src/TwillServiceProvider.php
+++ b/src/TwillServiceProvider.php
@@ -22,7 +22,7 @@ use A17\Twill\Services\MediaLibrary\ImageService;
 use Barryvdh\Debugbar\Facade as Debugbar;
 use Barryvdh\Debugbar\ServiceProvider as DebugbarServiceProvider;
 use Cartalyst\Tags\TagsServiceProvider;
-use Dimsav\Translatable\TranslatableServiceProvider;
+use Astrotomic\Translatable\TranslatableServiceProvider;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Foundation\AliasLoader;


### PR DESCRIPTION
This PR upgrades from `dimsav/laravel-translatable` to `astrotomic/laravel-translatable`. This could be breaking because several older versions are dropped and the namespace changed.
So for everyone who used the package in his own code action is required.

https://github.com/Astrotomic/laravel-translatable/issues/10