### PR TITLE
Fix maps implementation when printing values from an array.

### DIFF
--- a/views/partials/form/_map.blade.php
+++ b/views/partials/form/_map.blade.php
@@ -17,10 +17,7 @@
 @push('vuexStore')
     window.STORE.form.fields.push({
         name: '{{ $name }}',
-        value: {
-            'latlng': {!! json_encode($item->$name) !!},
-            'address': ''
-        }
+        value: {!! json_encode($item->$name) !!}
     })
 @endpush
 @endunless


### PR DESCRIPTION
Fields are already named in the saved json object so it should not
be placed inside latlng.