### PR TITLE
Parse twill version from composer's installed.json

### DIFF
--- a/src/TwillServiceProvider.php
+++ b/src/TwillServiceProvider.php
@@ -90,7 +90,7 @@ class TwillServiceProvider extends ServiceProvider
             'blocks' => Block::class,
         ]);
 
-        config(['twill.version' => trim(file_get_contents(__DIR__ . '/../VERSION'))]);
+        config(['twill.version' => $this->twillVersion()]);
     }
 
     /**
@@ -456,6 +456,18 @@ class TwillServiceProvider extends ServiceProvider
             return $view->with($with);
         });
 
+    }
+
+    /**
+     * @return string
+     */
+    protected function twillVersion(): string
+    {
+        $packages = json_decode(file_get_contents(base_path('vendor/composer/installed.json'))) ?: [];
+
+        $version = optional(collect($packages)->firstWhere('name', 'area17/twill'))->version;
+
+        return $version ?? trim(file_get_contents(__DIR__ . '/../VERSION'));
     }
 
     /**


### PR DESCRIPTION
With the latest update to `v1.2.2`, I believe you might have forgotten to bump up the version value in VERSION file causing the attribution in the footer to show an old version: `v1.2.1`

With this PR, I am proposing a different way to get the installed twill version: via composer `installed.json` file which should always yield the correct version, and if something goes wrong, it defaults to the value from `VERSION` file