### PR TITLE
Bug fix with undefined route name when blocks-editor is disabled

### DIFF
--- a/src/Http/Controllers/Admin/ModuleController.php
+++ b/src/Http/Controllers/Admin/ModuleController.php
@@ -1200,7 +1200,7 @@ abstract class ModuleController extends Controller
             'permalinkPrefix' => $this->getPermalinkPrefix($baseUrl),
             'saveUrl' => $this->getModuleRoute($item->id, 'update'),
             'editor' => $this->moduleHas('revisions') && $this->moduleHas('blocks') && !$this->disableEditor,
-            'blockPreviewUrl' => URL::route('admin.blocks.preview'),
+            'blockPreviewUrl' => Route::has('admin.blocks.preview')? URL::route('admin.blocks.preview') : '#',
             'revisions' => $this->moduleHas('revisions') ? $item->revisionsArray() : null,
         ] + (Route::has($previewRouteName) ? [
             'previewUrl' => moduleRoute($this->moduleName, $this->routePrefix, 'preview', $item->id),


### PR DESCRIPTION
If block-editor feature is disabled, i.e. in `config/twill.php`
```
    'enabled' => [
        'block-editor' => false
    ],
```
When accessing a module edit page (e.g. `/posts/1/edit`) an `InvalidArgumentException` is thrown with error message: "Route [admin.blocks.preview] not defined." even if the module doesn't support blocks. 

This PR fixes this error by firstly checking if this route exists before generating its URL