### PR TITLE
Replace dimsav/laravel-translatable with astrotomic/laravel-translatable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
     "ext-json": "*",
     "ext-pdo": "*",
     "laravel/framework": "~5.3.0|~5.4.0|~5.5.0|~5.6.0|~5.7.0|~5.8.0",
-    "dimsav/laravel-translatable": "^6.0.1|^7.0.0|^8.0.0|^9.0.0|^10.0.0",
+    "astrotomic/laravel-translatable": "^6.0.1|^7.0.0|^8.0.0|^9.0.0|^10.0.0",
     "cartalyst/tags": "^3.0.0|^4.0.0|^5.0.0|^6.0.0|^7.0.0|^8.0.0",
     "doctrine/dbal": "^2.9",
     "league/flysystem-aws-s3-v3": "^1.0.13",


### PR DESCRIPTION
`dimsav/laravel-translatable` has been deprecated. https://github.com/Astrotomic/laravel-translatable is the actively maintained replacement