### PR TITLE
Add Once Option to Create Super Admin Command on Twill Install

### DIFF
--- a/src/Commands/CreateSuperAdmin.php
+++ b/src/Commands/CreateSuperAdmin.php
@@ -14,7 +14,7 @@ class CreateSuperAdmin extends Command
      *
      * @var string
      */
-    protected $signature = 'twill:superadmin';
+    protected $signature = 'twill:superadmin {--once}';
 
     /**
      * The console command description.
@@ -52,21 +52,25 @@ class CreateSuperAdmin extends Command
      */
     public function handle()
     {
-        $this->info("Let's create a superadmin account!");
-        $email = $this->setEmail();
-        $password = $this->setPassword();
+        if ($this->guardAgainstMultiple()) {
+            $this->info("A super admin account exists.");
+        } else {
+            $this->info("Let's create a superadmin account!");
+            $email = $this->setEmail();
+            $password = $this->setPassword();
 
-        $user = User::create([
-            'name' => "Admin",
-            'email' => $email,
-            'role' => 'SUPERADMIN',
-            'published' => true,
-        ]);
+            $user = User::create([
+                'name' => "Admin",
+                'email' => $email,
+                'role' => 'SUPERADMIN',
+                'published' => true,
+            ]);
 
-        $user->password = bcrypt($password);
-        $user->save();
+            $user->password = bcrypt($password);
+            $user->save();
 
-        $this->info("Your account has been created");
+            $this->info("Your account has been created");
+        }
     }
 
     /**
@@ -131,5 +135,18 @@ class CreateSuperAdmin extends Command
         return $this->validatorFactory->make(['password' => $password], [
             'password' => 'required|min:6',
         ])->passes();
+    }
+
+    /**
+     * Check for existence of a super admin. (option)
+     *
+     * @return boolean
+     */
+    private function guardAgainstMultiple()
+    {
+        if ($this->option('once')) {
+            return User::whereRole('SUPERADMIN')->exists();
+        }
+        return false;
     }
 }

--- a/src/Commands/Install.php
+++ b/src/Commands/Install.php
@@ -109,7 +109,7 @@ class Install extends Command
      */
     private function createSuperAdmin()
     {
-        $this->call('twill:superadmin');
+        $this->call('twill:superadmin --once');
     }
 
     /**


### PR DESCRIPTION
This is a very low priority idea for the `twill:install` command. A few of the operations that run check for file existence and only run if a file does not exist, but no existence check is performed for super admin accounts. This change makes this command's results slightly more consistent, in the instance where the command has been run already and someone has run it again.

So, if you were to run `twill:install` twice, for whatever reason, you would currently get...

```
Publishing complete.
Nothing to migrate.
Publishing complete.
Copied Directory [/vendor/area17/twill/dist] To [/public]
Publishing complete.
Let's create a superadmin account!

 Enter an email:
 >

```

Which feels inconsistent to me. This change would make it report...

```
Publishing complete.
Nothing to migrate.
Publishing complete.
Copied Directory [/vendor/area17/twill/dist] To [/public]
Publishing complete.
A super admin account exists.
```

More of a draft of an idea than anything else, thanks!