### PR TITLE
More Accurate Migration Timestamps on Install

### DIFF
--- a/src/TwillServiceProvider.php
+++ b/src/TwillServiceProvider.php
@@ -268,7 +268,7 @@ class TwillServiceProvider extends ServiceProvider
             // Verify that migration doesn't exist
             $migration_file = database_path('migrations/*_' . snake_case($migration) . '.php');
             if (empty($files->glob($migration_file))) {
-                $timestamp = date('Y_m_d_', time()) . (30000 + $this->migrationsCounter);
+                $timestamp = date('Y_m_d_Hi') . str_pad($this->migrationsCounter, 2, 0, STR_PAD_LEFT);
                 $migrationSourcePath = __DIR__ . '/../migrations/' . snake_case($migration) . '.php';
                 $migrationOutputPath = database_path('migrations/' . $timestamp . '_' . snake_case($migration) . '.php');
 


### PR DESCRIPTION
This change improves on the approach taken here 97cb4785980d5826ac3dce1f1b986228bb3d8c9b by maintaining both the publishing order and relative timing of the migration files created by `twill:install`.

I noticed that when I created an articles table migration after installing Twill that chronologically it appeared that I had created the articles table before installing Twill, which was not the case. And the timestamp length of the Twill migrations appeared off, so I checked out the code.
```
2014_10_12_000000_create_users_table.php
2014_10_12_100000_create_password_resets_table.php
2019_09_22_221744_create_articles_tables.php
2019_09_22_30001_create_tags_tables.php
2019_09_22_30002_create_blocks_table.php
2019_09_22_30003_create_related_table.php
2019_09_22_30004_create_twill_users_tables.php
2019_09_22_30005_create_twill_activity_log_table.php
2019_09_22_30006_create_files_tables.php
2019_09_22_30007_create_medias_tables.php
2019_09_22_30008_create_features_table.php
2019_09_22_30009_create_settings_table.php
2019_09_22_30010_change_locale_column_in_twill_fileables.php
2019_09_22_30011_add_locale_column_to_twill_mediables.php
```

This proposed change would make the Twill migration files accurate down to the minute and use what should be the seconds in a timestamp as the publishing order of the migration.

I think this may be an improvement over `30000 + $this->migrationsCounter`.

This assumes: 1) that there are not more than 99 migrations and 2) that more precise timestamps are preferable to an impossible timestamp, which may indicate to a user, "this migration was automated".
