### PR TITLE
Group Fields in JSON column

### DIFF
--- a/src/Repositories/Behaviors/HandleFieldsGroups.php
+++ b/src/Repositories/Behaviors/HandleFieldsGroups.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace A17\Twill\Repositories\Behaviors;
+
+use Illuminate\Support\Arr;
+
+trait HandleFieldsGroups
+{
+
+    /**
+     * @param \A17\Twill\Models\Model|null $object
+     * @param array $fields
+     * @return array
+     */
+    public function prepareFieldsBeforeSaveHandleFieldsGroups($object, $fields)
+    {
+        foreach ($this->fieldsGroups as $group => $groupFields) {
+            $fields[$group] = json_encode(Arr::only($fields, $groupFields));
+            Arr::forget($fields, $groupFields);
+        }
+
+        return $fields;
+    }
+
+    /**
+     * @param \A17\Twill\Models\Model|null $object
+     * @param array $fields
+     * @return array
+     */
+    public function prepareFieldsBeforeCreateHandleFieldsGroups($object, $fields)
+    {
+        foreach ($this->fieldsGroups as $group => $groupFields) {
+            $fields[$group] = json_encode(Arr::only($fields, $groupFields));
+            Arr::forget($fields, $groupFields);
+        }
+
+        return $fields;
+    }
+
+    /**
+     * @param \A17\Twill\Models\Model $object
+     * @param array $fields
+     * @return array
+     */
+    public function getFormFieldsHandleFieldsGroups($object, $fields)
+    {
+        foreach ($this->fieldsGroups as $group => $groupFields) {
+            if ($object->$group) {
+                $fields = array_merge($fields, json_decode($object->$group, true));
+            }
+        }
+
+        return $fields;
+    }
+}

--- a/src/Repositories/Behaviors/HandleFieldsGroups.php
+++ b/src/Repositories/Behaviors/HandleFieldsGroups.php
@@ -48,7 +48,7 @@ trait HandleFieldsGroups
         return $fields;
     }
 
-    protected function HandleFieldsGroups($fields) {
+    protected function handleFieldsGroups($fields) {
         foreach ($this->fieldsGroups as $group => $groupFields) {
             $fields[$group] = json_encode(Arr::where(Arr::only($fields, $groupFields), function ($value, $key) {
                 return !empty($value);

--- a/src/Repositories/ModuleRepository.php
+++ b/src/Repositories/ModuleRepository.php
@@ -5,6 +5,7 @@ namespace A17\Twill\Repositories;
 use A17\Twill\Models\Behaviors\HasMedias;
 use A17\Twill\Models\Behaviors\Sortable;
 use A17\Twill\Repositories\Behaviors\HandleDates;
+use A17\Twill\Repositories\Behaviors\HandleFieldsGroups;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\App;
@@ -16,7 +17,7 @@ use PDO;
 
 abstract class ModuleRepository
 {
-    use HandleDates;
+    use HandleDates, HandleFieldsGroups;
 
     /**
      * @var \A17\Twill\Models\Model


### PR DESCRIPTION
This PR is intended to provide a solution per discussion in https://github.com/area17/twill/issues/162.

A new trait `HandleFieldsGroup` was added, users have to create new json columns manually on the table, and for each column, the fields that needed to saved as group should be declared as `$fieldsGroups` in the repository, as the below example demonstrated.

```php
class ProjectRepository extends ModuleRepository
{
    protected $fieldsGroups = [
        'fields_group' => [
            'field1',
            'field2',
            'field3'
        ]
    ];
}
```

### Supported Fields:
- `input`
- `wysiwyg`
- `date_picker`
- `select`
- `multi_select`
- `map` (haven't tested, but should work)
- `color`
- `checkbox`
- `checkboxes`

### Further improvements
- Support Browsers and Repeaters
- Added the `fieldsGroups` attribute to `repository.stub`
- Added it as a new option on ModuleMake CLI to add the json column automatically

Any comments/thoughts are welcomed!