### PR TITLE
Define a default locale on table mediables

### DIFF
--- a/migrations/add_locale_column_to_twill_mediables.php
+++ b/migrations/add_locale_column_to_twill_mediables.php
@@ -9,7 +9,7 @@ class AddLocaleColumnToTwillMediables extends Migration
     {
         if (Schema::hasTable('mediables') && !Schema::hasColumn('mediables', 'locale')) {
             Schema::table('mediables', function (Blueprint $table) {
-                $table->string('locale', 7)->index();
+                $table->string('locale', 7)->default($this->getCurrentLocale())->index();
             });
         }
     }
@@ -22,5 +22,10 @@ class AddLocaleColumnToTwillMediables extends Migration
                 $table->dropColumn('locale');
             });
         }
+    }
+
+    function getCurrentLocale()
+    {
+        return getLocales()[0] ?? config('app.locale');
     }
 }


### PR DESCRIPTION
In SQLite you have to set a default value for "NOT NULL" columns, otherwise you will, while migrating, receive a 

```
Migrating: 2019_10_10_30011_add_locale_column_to_twill_mediables

   Illuminate\Database\QueryException  : SQLSTATE[HY000]: General error: 1 Cannot add a NOT NULL column with default value NULL (SQL: alter table "mediables" add column "locale" varchar not null)
```