### PR TITLE
Add quotes when populating store from form field

### DIFF
--- a/views/partials/form/utils/_selector_input_store.blade.php
+++ b/views/partials/form/utils/_selector_input_store.blade.php
@@ -9,6 +9,7 @@ window.STORE.form.fields.push({
                     @endphp
                 @endif
                 @if (is_numeric($formFieldsValue)) {{ $formFieldsValue }}
+                @elseif (is_string($formFieldsValue)) '{{ $formFieldsValue }}'
                 @else {!! $formFieldsValue !!}
                 @endif
            @else


### PR DESCRIPTION
I ran into an error when using select field in settings field.

Blade was passing string value without quotes to window.STORE.form.fields which failed because JS considers value as variable and was unable to load it (as it does not exists), resulting in select field not being populated with value saved in DB.

I came across this when using select in settings page only.