### PR TITLE
Use Composer to load helpers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -74,7 +74,15 @@
   "autoload": {
     "psr-4": {
       "A17\\Twill\\": "src/"
-    }
+    },
+    "files": [
+      "src/Helpers/routes_helpers.php",
+      "src/Helpers/i18n_helpers.php",
+      "src/Helpers/media_library_helpers.php",
+      "src/Helpers/frontend_helpers.php",
+      "src/Helpers/migrations_helpers.php",
+      "src/Helpers/helpers.php"
+    ]
   },
   "extra": {
     "laravel": {

--- a/src/TwillServiceProvider.php
+++ b/src/TwillServiceProvider.php
@@ -65,8 +65,6 @@ class TwillServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        $this->requireHelpers();
-
         $this->publishConfigs();
         $this->publishMigrations();
         $this->publishAssets();
@@ -328,19 +326,6 @@ class TwillServiceProvider extends ServiceProvider
             Build::class,
             Update::class,
         ]);
-    }
-
-    /**
-     * @return void
-     */
-    private function requireHelpers()
-    {
-        require_once __DIR__ . '/Helpers/routes_helpers.php';
-        require_once __DIR__ . '/Helpers/i18n_helpers.php';
-        require_once __DIR__ . '/Helpers/media_library_helpers.php';
-        require_once __DIR__ . '/Helpers/frontend_helpers.php';
-        require_once __DIR__ . '/Helpers/migrations_helpers.php';
-        require_once __DIR__ . '/Helpers/helpers.php';
     }
 
     /**


### PR DESCRIPTION
To correctly boot tests in PHP 7.4, I had to load helpers earlier in the package lifecycle.