### PR TITLE
Fix published being sent as string on json

### DIFF
--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -49,6 +49,8 @@ class User extends AuthenticatableContract
         ],
     ];
 
+    protected $casts = ['published' => 'boolean'];
+
     public function __construct(array $attributes = [])
     {
         $this->table = config('twill.users_table', 'twill_users');

--- a/views/layouts/form.blade.php
+++ b/views/layouts/form.blade.php
@@ -102,7 +102,7 @@
 
     window.STORE.publication = {
         withPublicationToggle: {{ json_encode(($publish ?? true) && isset($item) && $item->isFillable('published')) }},
-        published: {{ json_encode(isset($item) ? $item->published : false) }},
+        published: {{ isset($item) && $item->published ? 'true' : 'false' }},
         withPublicationTimeframe: {{ json_encode(($schedule ?? true) && isset($item) && $item->isFillable('publish_start_date')) }},
         publishedLabel: '{{ $customPublishedLabel ?? 'Live' }}',
         draftLabel: '{{ $customDraftLabel ?? 'Draft' }}',


### PR DESCRIPTION
In some installations we might get this kind of JSON error sometimes:

![image](https://user-images.githubusercontent.com/3182864/66876588-bdc66f80-ef88-11e9-8bcb-38a2de49e9b5.png)

It's caused by a string being converted to JSON, which is escaped by PHP to become a "proper" JSON:

``` php
json_encode("0")
```

The piece of code doing this is trying to convert a boolean to a JSON string, but depending on the database server, that boolean might not be a boolean, but a string, it's the case of SQLite, which doesn't have a boolean type:

``` javascript
window.STORE.publication = {
    published: {{ json_encode(isset($item) ? $item->published : false) }},
}
```

But in this case we don't even need to convert it to JSON, we can just render a string (true/false):

``` javascript
window.STORE.publication = {
    published: {{ isset($item) && $item->published ? 'true' : 'false' }},
}
```

And we should get the perfect JSON boolean:

![image](https://user-images.githubusercontent.com/3182864/66876809-7be9f900-ef89-11e9-8c32-c2bc3240d19f.png)
