### PR TITLE
Fix google2fa settings not being enabled

### DIFF
--- a/src/Http/Controllers/Admin/UserController.php
+++ b/src/Http/Controllers/Admin/UserController.php
@@ -154,7 +154,7 @@ class UserController extends ModuleController
     protected function formData($request)
     {
         $user = $this->authFactory->guard('twill_users')->user();
-        $with2faSettings = $this->config->get('twill.enabled.users-2fa') && $user->id == $this->request->get('user');
+        $with2faSettings = $this->config->get('twill.enabled.users-2fa') && $user->id == $request->route('user');;
 
         if ($with2faSettings) {
             $google2fa = new Google2FA();


### PR DESCRIPTION
This fix was missing from this commit: https://github.com/area17/twill/commit/9a6a1c105ed7f1b826a29792b2c4c1537ca038da