### PR TITLE
Fix Laravel 6.3 installation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
     "php": "^7.0",
     "ext-json": "*",
     "ext-pdo": "*",
-    "laravel/framework": "~5.6.0|~5.7.0|~5.8.0|~6.0.0",
+    "laravel/framework": "~5.6.0|~5.7.0|~5.8.0|^6.3",
     "astrotomic/laravel-translatable": "^11.3",
     "cartalyst/tags": "^6.0.0|^7.0.0|^8.0.0|^9.0.0",
     "doctrine/dbal": "^2.9",


### PR DESCRIPTION
This is what I was getting when trying to install on a fresh Laravel 6.3 app:

![image](https://user-images.githubusercontent.com/3182864/67031519-1b250280-f0e8-11e9-82b2-2a8f9b762595.png)
