### PR TITLE
Move logic to model

### DIFF
--- a/src/Http/Controllers/Admin/LoginController.php
+++ b/src/Http/Controllers/Admin/LoginController.php
@@ -136,7 +136,7 @@ class LoginController extends Controller
         $user = User::findOrFail($userId);
 
         $valid = (new Google2FA)->verifyKey(
-            $this->encrypter->decrypt($user->google_2fa_secret),
+            $user->google_2fa_secret,
             $request->input('verify-code')
         );
 

--- a/src/Http/Controllers/Admin/UserController.php
+++ b/src/Http/Controllers/Admin/UserController.php
@@ -157,20 +157,9 @@ class UserController extends ModuleController
         $with2faSettings = $this->config->get('twill.enabled.users-2fa') && $user->id == $request->route('user');;
 
         if ($with2faSettings) {
-            $google2fa = new Google2FA();
+            $user->generate2faSecretKey();
 
-            if (is_null($user->google_2fa_secret)) {
-                $secret = $google2fa->generateSecretKey();
-                $user->google_2fa_secret = \Crypt::encrypt($secret);
-                $user->save();
-            }
-
-            $qrCode = $google2fa->getQRCodeInline(
-                $this->config->get('app.name'),
-                $user->email,
-                \Crypt::decrypt($user->google_2fa_secret),
-                200
-            );
+            $qrCode = $user->get2faQrCode();
         }
 
         return [

--- a/src/Http/Requests/Admin/UserRequest.php
+++ b/src/Http/Requests/Admin/UserRequest.php
@@ -51,7 +51,7 @@ class UserRequest extends Request
                                 $shouldValidateOTP = $userIsEnabling || $userIsDisabling;
 
                                 if ($shouldValidateOTP) {
-                                    $valid = (new Google2FA)->verifyKey(Crypt::decrypt($user->google_2fa_secret), $value ?? '');
+                                    $valid = (new Google2FA)->verifyKey($user->google_2fa_secret, $value ?? '');
 
                                     if (!$valid) {
                                         $fail('Your one time password is invalid.');


### PR DESCRIPTION
This PR is doing 2 things:

1. Moving the secret key generation logic from the controller to the user model, so it can be reused in tests.
2. Creating a mutator/accessor so we never forget to encrypt google_2fa_secret