### PR TITLE
Fixed the issue that "'delete' => true" not working in indexOptions

### DIFF
--- a/src/Http/Controllers/Admin/ModuleController.php
+++ b/src/Http/Controllers/Admin/ModuleController.php
@@ -763,7 +763,7 @@ abstract class ModuleController extends Controller
                 'publish_start_date' => $item->publish_start_date,
                 'publish_end_date' => $item->publish_end_date,
                 'edit' => $canEdit ? $this->getModuleRoute($item->id, 'edit') : null,
-                'delete' => ($canEdit && $itemCanDelete) ? $this->getModuleRoute($item->id, 'destroy') : null,
+                'delete' => $itemCanDelete ? $this->getModuleRoute($item->id, 'destroy') : null,
             ] + ($this->getIndexOption('editInModal') ? [
                 'editInModal' => $this->getModuleRoute($item->id, 'edit'),
                 'updateUrl' => $this->getModuleRoute($item->id, 'update'),


### PR DESCRIPTION
Please see the detail in https://github.com/area17/twill/issues/289
Ability to delete an item doesn't necessary to have canEdit option set as true.