### PR TITLE
Fix « Handle Repeater » feature compatibility with Laravel 5.6

### DIFF
--- a/src/Repositories/ModuleRepository.php
+++ b/src/Repositories/ModuleRepository.php
@@ -880,7 +880,7 @@ abstract class ModuleRepository
             $model = ucfirst(Str::singular($relation));
         }
 
-        return App::get(Config::get('twill.namespace') . "\\Repositories\\" . ucfirst($model) . "Repository");
+        return App::make(Config::get('twill.namespace') . "\\Repositories\\" . ucfirst($model) . "Repository");
     }
 
     /**


### PR DESCRIPTION
Fix HandleRepeater feature for Laravel 5.6