### PR TITLE
Add style for subscript into wysiwyg

### DIFF
--- a/frontend/js/components/Wysiwyg.vue
+++ b/frontend/js/components/Wysiwyg.vue
@@ -375,6 +375,11 @@
         vertical-align: super;
         font-size: smaller;
       }
+
+      sub {
+        vertical-align: sub;
+        font-size: smaller;
+      }
     }
 
     .ql-toolbar.ql-snow {


### PR DESCRIPTION
Style for subscript usage into wysiwg was missing. 
I just added default style for that.