### PR TITLE
Fix HandleFieldsGroups trait

### DIFF
--- a/src/Repositories/ModuleRepository.php
+++ b/src/Repositories/ModuleRepository.php
@@ -35,6 +35,11 @@ abstract class ModuleRepository
     protected $countScope = [];
 
     /**
+     * @var array
+     */
+    protected $fieldsGroups = [];
+
+    /**
      * @param array $with
      * @param array $scopes
      * @param array $orders


### PR DESCRIPTION
With #410, there are some regressions into Twill repositories which extend `ModuleRepository`. 
If `$fieldsGroups` isn't define some repositories will break. 
I added a default value for `$fieldsGroups` into `ModuleRepository`. 