### PR TITLE
Permanently delete trashed records

### DIFF
--- a/frontend/js/components/table/BulkEdit.vue
+++ b/frontend/js/components/table/BulkEdit.vue
@@ -16,6 +16,7 @@
                   <button v-if="bulkFeaturable(true)" @click="bulkUnFeature">Unfeature</button>
                   <button v-if="bulkDeletable()" @click="bulkDelete">Delete</button>
                   <button v-if="bulkRestorable()" @click="bulkRestore">Restore</button>
+                  <button v-if="bulkDestroyable()" @click="bulkDestroy">Destroy</button>
                 </li>
               </ul>
             </div>
@@ -71,6 +72,9 @@
       bulkRestorable: function () {
         return window.CMS_URLS.bulkRestore !== '' && this.bulkStatus.deleted
       },
+      bulkDestroyable: function () {
+        return window.CMS_URLS.bulkDestroy !== '' && this.bulkStatus.deleted
+      },
       clearBulkSelect: function () {
         this.$store.commit(DATATABLE.REPLACE_DATATABLE_BULK, [])
       },
@@ -95,6 +99,9 @@
       },
       bulkRestore: function () {
         this.$store.dispatch(ACTIONS.BULK_RESTORE)
+      },
+      bulkDestroy: function () {
+        this.$store.dispatch(ACTIONS.BULK_DESTROY)
       }
     }
   }

--- a/frontend/js/components/table/TableRow.vue
+++ b/frontend/js/components/table/TableRow.vue
@@ -11,7 +11,7 @@
     </td>
     <td class="tablecell tablecell--spacer">&nbsp;</td>
     <td class="tablecell tablecell--sticky">
-      <a17-table-cell-actions v-bind="currentComponentProps()" @editInPlace="editInPlace" @update="tableCellUpdate" @restoreRow=" restoreRow" @deleteRow="deleteRow"/>
+      <a17-table-cell-actions v-bind="currentComponentProps()" @editInPlace="editInPlace" @update="tableCellUpdate" @restoreRow=" restoreRow" @destroyRow="destroyRow" @deleteRow="deleteRow"/>
     </td>
   </tr>
 </template>

--- a/frontend/js/components/table/tableCell/TableCellActions.vue
+++ b/frontend/js/components/table/tableCell/TableCellActions.vue
@@ -25,6 +25,9 @@
       <a v-if="row.hasOwnProperty('deleted')"
          href="#"
          @click.prevent="restoreRow">Restore</a>
+      <a v-if="row.hasOwnProperty('deleted')"
+         href="#"
+         @click.prevent="destroyRow">Destroy</a>
       <a v-else-if="row.delete"
          href="#"
          @click.prevent="deleteRow">Delete</a>

--- a/frontend/js/mixins/datatableRow.js
+++ b/frontend/js/mixins/datatableRow.js
@@ -149,6 +149,9 @@ export default {
     restoreRow: function (row) {
       this.$store.dispatch(ACTIONS.RESTORE_ROW, row)
     },
+    destroyRow: function (row) {
+      this.$store.dispatch(ACTIONS.DESTROY_ROW, row)
+    },
     deleteRow: function (row) {
       // open confirm dialog if any
       if (this.$root.$refs.warningDeleteRow) {

--- a/frontend/js/mixins/tableCell.js
+++ b/frontend/js/mixins/tableCell.js
@@ -2,11 +2,11 @@ export default {
   props: {
     col: {
       type: Object,
-      default: () => {}
+      default: () => { }
     },
     row: {
       type: Object,
-      default: () => {}
+      default: () => { }
     },
     editUrl: {
       type: String,
@@ -34,10 +34,13 @@ export default {
       this.editInPlace()
     },
     editInPlace: function (event, lang) {
-      this.$emit('editInPlace', {event: event, lang: lang})
+      this.$emit('editInPlace', { event: event, lang: lang })
     },
     restoreRow: function () {
       this.$emit('restoreRow', this.row)
+    },
+    destroyRow: function () {
+      this.$emit('destroyRow', this.row)
     },
     deleteRow: function () {
       this.$emit('deleteRow', this.row)

--- a/frontend/js/store/actions/index.js
+++ b/frontend/js/store/actions/index.js
@@ -11,12 +11,14 @@ export const SET_DATATABLE = 'setDatatableDatas'
 export const TOGGLE_PUBLISH = 'togglePublishedData'
 export const DELETE_ROW = 'deleteData'
 export const RESTORE_ROW = 'restoreData'
+export const DESTROY_ROW = 'destroyData'
 export const TOGGLE_FEATURE = 'toggleFeaturedData'
 export const BULK_PUBLISH = 'bulkPublishData'
 export const BULK_FEATURE = 'bulkFeatureData'
 export const BULK_EXPORT = 'bulkExportData'
 export const BULK_DELETE = 'bulkDeleteData'
 export const BULK_RESTORE = 'bulkRestoreData'
+export const BULK_DESTROY = 'bulkDestroyData'
 
 /* Form */
 export const REPLACE_FORM = 'replaceFormData'
@@ -41,12 +43,14 @@ export default {
   TOGGLE_PUBLISH,
   DELETE_ROW,
   RESTORE_ROW,
+  DESTROY_ROW,
   TOGGLE_FEATURE,
   BULK_PUBLISH,
   BULK_FEATURE,
   BULK_EXPORT,
   BULK_DELETE,
   BULK_RESTORE,
+  BULK_DESTROY,
   REPLACE_FORM,
   SAVE_FORM,
   UPDATE_FORM_IN_LISTING,

--- a/frontend/js/store/api/datatable.js
+++ b/frontend/js/store/api/datatable.js
@@ -76,6 +76,15 @@ export default {
     })
   },
 
+  destroy (row, callback) {
+    axios.put(window.CMS_URLS.forceDelete, { id: row.id }).then(function (resp) {
+      if (callback && typeof callback === 'function') callback(resp)
+    }, function (resp) {
+      globalError(component, resp)
+      console.log('destroy request error.')
+    })
+  },
+
   reorder (ids, callback) {
     axios.post(window.CMS_URLS.reorder, { ids: ids }).then(function (resp) {
       if (callback && typeof callback === 'function') callback(resp)
@@ -118,6 +127,15 @@ export default {
     }, function (resp) {
       globalError(component, resp)
       console.log('bulk restore request error.')
+    })
+  },
+
+  bulkDestroy (ids, callback) {
+    axios.post(window.CMS_URLS.bulkForceDelete, { ids: ids }).then(function (resp) {
+      if (callback && typeof callback === 'function') callback(resp)
+    }, function (resp) {
+      globalError(component, resp)
+      console.log('bulk destroy request error.')
     })
   }
 }

--- a/frontend/js/store/modules/datatable.js
+++ b/frontend/js/store/modules/datatable.js
@@ -242,14 +242,14 @@ const actions = {
       })
     }
   },
-  [ACTIONS.SET_DATATABLE_NESTED] ({commit, state, dispatch}) {
+  [ACTIONS.SET_DATATABLE_NESTED] ({ commit, state, dispatch }) {
     // Get all ids and children ids if any
     const ids = deepRemoveFromObj(state.data)
     api.reorder(ids, function (resp) {
-      commit(NOTIFICATION.SET_NOTIF, {message: resp.data.message, variant: resp.data.variant})
+      commit(NOTIFICATION.SET_NOTIF, { message: resp.data.message, variant: resp.data.variant })
     })
   },
-  [ACTIONS.SET_DATATABLE] ({commit, state, dispatch}) {
+  [ACTIONS.SET_DATATABLE] ({ commit, state, dispatch }) {
     const ids = state.data.map((row) => row.id)
 
     api.reorder(ids, function (resp) {
@@ -272,6 +272,12 @@ const actions = {
   },
   [ACTIONS.RESTORE_ROW] ({ commit, state, dispatch }, row) {
     api.restore(row, function (resp) {
+      commit(NOTIFICATION.SET_NOTIF, { message: resp.data.message, variant: resp.data.variant })
+      dispatch(ACTIONS.GET_DATATABLE)
+    })
+  },
+  [ACTIONS.DESTROY_ROW] ({ commit, state, dispatch }, row) {
+    api.destroy(row, function (resp) {
       commit(NOTIFICATION.SET_NOTIF, { message: resp.data.message, variant: resp.data.variant })
       dispatch(ACTIONS.GET_DATATABLE)
     })
@@ -320,6 +326,12 @@ const actions = {
   },
   [ACTIONS.BULK_RESTORE] ({ commit, state, dispatch }) {
     api.bulkRestore(state.bulk.join(), function (resp) {
+      commit(NOTIFICATION.SET_NOTIF, { message: resp.data.message, variant: resp.data.variant })
+      dispatch(ACTIONS.GET_DATATABLE)
+    })
+  },
+  [ACTIONS.BULK_DESTROY] ({ commit, state, dispatch }) {
+    api.bulkDestroy(state.bulk.join(), function (resp) {
       commit(NOTIFICATION.SET_NOTIF, { message: resp.data.message, variant: resp.data.variant })
       dispatch(ACTIONS.GET_DATATABLE)
     })

--- a/src/Http/Controllers/Admin/ModuleController.php
+++ b/src/Http/Controllers/Admin/ModuleController.php
@@ -65,6 +65,8 @@ abstract class ModuleController extends Controller
         'bulkFeature' => false,
         'restore' => true,
         'bulkRestore' => true,
+        'forceDelete' => true,
+        'bulkForceDelete' => true,
         'delete' => true,
         'bulkDelete' => true,
         'reorder' => false,
@@ -231,7 +233,7 @@ abstract class ModuleController extends Controller
         $this->middleware('can:edit', ['only' => ['store', 'edit', 'update']]);
         $this->middleware('can:publish', ['only' => ['publish', 'feature', 'bulkPublish', 'bulkFeature']]);
         $this->middleware('can:reorder', ['only' => ['reorder']]);
-        $this->middleware('can:delete', ['only' => ['destroy', 'bulkDelete', 'restore', 'bulkRestore', 'restoreRevision']]);
+        $this->middleware('can:delete', ['only' => ['destroy', 'bulkDelete', 'restore', 'bulkRestore', 'forceDelete', 'bulkForceDelete', 'restoreRevision']]);
     }
 
     /**
@@ -549,6 +551,32 @@ abstract class ModuleController extends Controller
         }
 
         return $this->respondWithError($this->modelTitle . ' items were not moved to trash. Something wrong happened!');
+    }
+
+    /**
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function forceDelete()
+    {
+        if ($this->repository->forceDelete($this->request->get('id'))) {
+            $this->fireEvent();
+            return $this->respondWithSuccess($this->modelTitle . ' destroyed!');
+        }
+
+        return $this->respondWithError($this->modelTitle . ' was not destroyed. Something wrong happened!');
+    }
+
+    /**
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function bulkForceDelete()
+    {
+        if ($this->repository->bulkForceDelete(explode(',', $this->request->get('ids')))) {
+            $this->fireEvent();
+            return $this->respondWithSuccess($this->modelTitle . ' items destroyed!');
+        }
+
+        return $this->respondWithError($this->modelTitle . ' items were not destroyed. Something wrong happened!');
     }
 
     /**
@@ -982,6 +1010,8 @@ abstract class ModuleController extends Controller
             'bulkPublish',
             'restore',
             'bulkRestore',
+            'forceDelete',
+            'bulkForceDelete',
             'reorder',
             'feature',
             'bulkFeature',
@@ -1017,6 +1047,8 @@ abstract class ModuleController extends Controller
                 'reorder' => 'reorder',
                 'delete' => 'delete',
                 'restore' => 'delete',
+                'forceDelete' => 'delete',
+                'bulkForceDelete' => 'delete',
                 'bulkPublish' => 'publish',
                 'bulkRestore' => 'delete',
                 'bulkFeature' => 'feature',

--- a/src/Repositories/ModuleRepository.php
+++ b/src/Repositories/ModuleRepository.php
@@ -384,6 +384,48 @@ abstract class ModuleRepository
      * @param mixed $id
      * @return mixed
      */
+    public function forceDelete($id)
+    {
+        return DB::transaction(function () use ($id) {
+            if (($object = $this->model->onlyTrashed()->find($id)) === null) {
+                return false;
+            } else {
+                $object->forceDelete();
+                $this->afterDelete($object);
+                return true;
+            }
+        }, 3);
+    }
+
+    /**
+     * @param mixed $id
+     * @return mixed
+     */
+    public function bulkForceDelete($ids)
+    {
+        return DB::transaction(function () use ($ids) {
+            try {
+                $query = $this->model->onlyTrashed()->whereIn('id', $ids);
+                $objects = $query->get();
+
+                $query->forceDelete();
+
+                $objects->each(function ($object) {
+                    $this->afterDelete($object);
+                });
+            } catch (\Exception $e) {
+                Log::error($e);
+                return false;
+            }
+
+            return true;
+        }, 3);
+    }
+
+    /**
+     * @param mixed $id
+     * @return mixed
+     */
     public function restore($id)
     {
         return DB::transaction(function () use ($id) {

--- a/src/RouteServiceProvider.php
+++ b/src/RouteServiceProvider.php
@@ -150,7 +150,7 @@ class RouteServiceProvider extends ServiceProvider
                 return ucfirst(Str::singular($s));
             }, $slugs));
 
-            $customRoutes = $defaults = ['reorder', 'publish', 'bulkPublish', 'browser', 'feature', 'bulkFeature', 'tags', 'preview', 'restore', 'bulkRestore', 'bulkDelete', 'restoreRevision'];
+            $customRoutes = $defaults = ['reorder', 'publish', 'bulkPublish', 'browser', 'feature', 'bulkFeature', 'tags', 'preview', 'restore', 'bulkRestore', 'forceDelete', 'bulkForceDelete', 'bulkDelete', 'restoreRevision'];
 
             if (isset($options['only'])) {
                 $customRoutes = array_intersect($defaults, (array) $options['only']);
@@ -178,7 +178,7 @@ class RouteServiceProvider extends ServiceProvider
                     Route::get($routeSlug . "/{id}", $mapping);
                 }
 
-                if (in_array($route, ['publish', 'feature', 'restore'])) {
+                if (in_array($route, ['publish', 'feature', 'restore', 'forceDelete'])) {
                     Route::put($routeSlug, $mapping);
                 }
 
@@ -186,7 +186,7 @@ class RouteServiceProvider extends ServiceProvider
                     Route::put($routeSlug . "/{id}", $mapping);
                 }
 
-                if (in_array($route, ['reorder', 'bulkPublish', 'bulkFeature', 'bulkDelete', 'bulkRestore'])) {
+                if (in_array($route, ['reorder', 'bulkPublish', 'bulkFeature', 'bulkDelete', 'bulkRestore', 'bulkForceDelete'])) {
                     Route::post($routeSlug, $mapping);
                 }
             }

--- a/views/layouts/listing.blade.php
+++ b/views/layouts/listing.blade.php
@@ -102,6 +102,8 @@
         bulkPublish: '{{ $bulkPublishUrl }}',
         restore: '{{ $restoreUrl }}',
         bulkRestore: '{{ $bulkRestoreUrl }}',
+        forceDelete: '{{ $forceDeleteUrl }}',
+        bulkForceDelete: '{{ $bulkForceDeleteUrl }}',
         reorder: '{{ $reorderUrl }}',
         feature: '{{ $featureUrl }}',
         bulkFeature: '{{ $bulkFeatureUrl }}',


### PR DESCRIPTION
Ref. Issue: #329.
- Added ability to destroy a.k.a. hard delete each trashed record.
- Added ability to bulk destroy the selected trashed records.
- Added ability to enable/disable the destroy function. Enabled by default.