### PR TITLE
Update migrations_helpers to support Laravel 6.

### DIFF
--- a/src/Helpers/migrations_helpers.php
+++ b/src/Helpers/migrations_helpers.php
@@ -106,7 +106,7 @@ if (!function_exists('createDefaultRelationshipTableFields')) {
         $table->foreign("{$table1NameSingular}_id")->references('id')->on($table1NamePlural)->onDelete('cascade');
         $table->integer("{$table2NameSingular}_id")->unsigned();
         $table->foreign("{$table2NameSingular}_id")->references('id')->on($table2NamePlural)->onDelete('cascade');
-        $table->index(["{$table2NameSingular}_id", "{$table1NameSingular}_id"], "idx_{$table1NameSingular}_{$table2NameSingular}_" . str_random(5));
+        $table->index(["{$table2NameSingular}_id", "{$table1NameSingular}_id"], "idx_{$table1NameSingular}_{$table2NameSingular}_" . Str::random(5));
     }
 }
 


### PR DESCRIPTION
Use Str::random Facade instead of helper. Required for Laravel 6 support.
this was missed in the L6 pull request that got merged.