### PR TITLE
Wysiwyg - Make sure quill is ready when checking content length

### DIFF
--- a/frontend/js/components/Wysiwyg.vue
+++ b/frontend/js/components/Wysiwyg.vue
@@ -198,6 +198,11 @@
           }
         }
 
+        // check text length
+        if (this.hasMaxlength && this.showCounter) {
+          this.updateCounter(this.getTextLength())
+        }
+
         // emit ready
         this.$emit('ready', this.quill)
       },
@@ -260,8 +265,6 @@
       } else {
         this.initQuill()
       }
-
-      this.updateCounter(this.getTextLength())
     },
     beforeDestroy () {
       this.quill = null


### PR DESCRIPTION
This will remove the initial error message displaying on page load.