### PR TITLE
Form – Forms with no Content fieldset

### DIFF
--- a/views/layouts/form.blade.php
+++ b/views/layouts/form.blade.php
@@ -16,10 +16,12 @@
         <div class="navbar navbar--sticky" data-sticky-top="navbar">
             @php
                 $additionalFieldsets = $additionalFieldsets ?? [];
-                array_unshift($additionalFieldsets, [
-                    'fieldset' => 'content',
-                    'label' => $contentFieldsetLabel ?? 'Content'
-                ]);
+                if(!$disableContentFieldset ?? true) {
+                    array_unshift($additionalFieldsets, [
+                        'fieldset' => 'content',
+                        'label' => $contentFieldsetLabel ?? 'Content'
+                    ]);
+                }
             @endphp
             <a17-sticky-nav data-sticky-target="navbar" :items="{{ json_encode($additionalFieldsets) }}">
                 <a17-title-editor
@@ -56,9 +58,9 @@
                             ></a17-page-nav>
                         </div>
                     </aside>
-                    <section class="col col--primary">
+                    <section class="col col--primary" data-sticky-top="publisher">
                         @unless($disableContentFieldset ?? false)
-                            <a17-fieldset title="{{ $contentFieldsetLabel ?? 'Content' }}" id="content" data-sticky-top="publisher">
+                            <a17-fieldset title="{{ $contentFieldsetLabel ?? 'Content' }}" id="content">
                                 @yield('contentFields')
                             </a17-fieldset>
                         @endunless


### PR DESCRIPTION
On forms there were 2 issues when the Content fieldset is deactivated :
- Sticky Publisher module : the sticky publisher module behave weirdly because there is no top anchor defined : it stop being sticky at some point and jump at the bottom of the page
- Sticky navigation : the sticky nav sections incorrectly start with 'Content'