### PR TITLE
Added stale bot github action 🤖

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,34 @@
+on:
+  schedule:
+    - cron: "0 12 * * *"
+name: Stale Bot workflow
+jobs:
+  build:
+    name: stale
+    runs-on: ubuntu-latest
+    steps:
+      - name: stale
+        id: stale
+        uses: yanhao-li/stale@v2.0.0
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DAYS_BEFORE_STALE: 90
+          DAYS_BEFORE_CLOSE: 120
+          DRY_RUN: false
+          OPERATIONS_PER_RUN: 5000
+          STALE_ISSUE_MESSAGE: |
+            Hi!
+            Since there is no activities for at least 3 months, this issue is going to be marked as `stale?` automatically.
+            The resources of the Twill team is limited, and so we are asking for your help.
+            If we missed this issue or if you want to keep it open, please reply here. 
+            You can also add the label "not stale" to keep this issue open!
+            Thank you for your contribution.
+          CLOSE_MESSAGE: |
+            Hello again!
+            It has been another month since this issue was tagged `stale?`, and it will be closed automatically.
+            Please feel free to reopen this issue or create a new one if you need anything else.
+            Thank you!
+          EXEMPT_ISSUE_LABELS: |
+            not stale
+            imact: high
+            good first issue


### PR DESCRIPTION
This PR proposed adding a Github action to mark inactivity issues with `stale?` tag and then it will be closed after some time if no further actions initiated.

---

### Background
Twill's GitHub community is receiving new issues every day, and there are many old issues that haven't been properly taken care of for many reasons. 

There definitely has a large room for Twill to improve, and every feature request or suggestion is appreciated, however, because the resource is limited, I think the Twill community may like to focus on one thing at one time. 

As from my understanding, Twill's goal is rather to be a CMS toolkit that could handle 10,000 jobs in a mediocre degree, it more likely wishes to be a tool focus on 10 jobs but doing them perfectly.

There always has a reason that an issue getting no replies, maybe itself is invalid, maybe it's a very edge case, maybe there are some blockers. The community didn't reply to them because Twill has a large space to grow, people have other higher priority things to focus on. We don't want to say the word "No" because we think we will find time later to come back handle them. but time gets wasted when more and more such issues deluged, and some truly valuable suggestions getting submerged inside them.
 
A stale 🤖 is more objective and say no to people with no bias 😉, so as to ~~mandatorily~~ help everyone here to focus on the paramount thing to make Twill move faster. The best way to save a stale issue is to create a PR now! We do need everyone's help from the community.

### What the stale bot will do?
- The action uses a fork from https://github.com/gatsbyjs/stale
- It can be configured in `.github/workflows/stale.yml`
- The action will run every day at 12:00.
- It will find all issues that have been inactivity for longer than 3 months and mark `stale?` tag on them, as well as leaving a comment.
- If a stale issue has been inactivity for another month, it will be closed.
- Users could reply with anything under the issues to prevent it to be closed. 
- Specific exempt tags could be set that the bot will not deal with those issues.

---
I have set up the demo bot in my forked Twill repo, you could take a look and try it there, it's running every 5 mins for all issues for testing purpose: https://github.com/yanhao-li/twill/issues/9

I do understand this is a controversial proposal, so please leave feel free to leave any commented below and let's discuss.  