### PR TITLE
Fix HandleBrowsers array key handling

### DIFF
--- a/src/Repositories/Behaviors/HandleBrowsers.php
+++ b/src/Repositories/Behaviors/HandleBrowsers.php
@@ -12,12 +12,12 @@ trait HandleBrowsers
     public function afterSaveHandleBrowsers($object, $fields)
     {
         if (property_exists($this, 'browsers')) {
-            foreach ($this->browsers as $module) {
+            foreach ($this->browsers as $moduleKey => $module) {
                 if (is_string($module)) {
                     $this->updateBrowser($object, $fields, $module, 'position', $module);
                 } elseif (is_array($module)) {
-                    $browserName = !empty($module['browserName']) ? $module['browserName'] : key($module);
-                    $relation = !empty($module['relation']) ? $module['relation'] : key($module);
+                    $browserName = !empty($module['browserName']) ? $module['browserName'] : $moduleKey;
+                    $relation = !empty($module['relation']) ? $module['relation'] : $moduleKey;
                     $positionAttribute = !empty($module['positionAttribute']) ? $module['positionAttribute'] : 'position';
                     $this->updateBrowser($object, $fields, $relation, $positionAttribute, $browserName);
                 }
@@ -33,22 +33,22 @@ trait HandleBrowsers
     public function getFormFieldsHandleBrowsers($object, $fields)
     {
         if (property_exists($this, 'browsers')) {
-            foreach ($this->browsers as $module) {
+            foreach ($this->browsers as $moduleKey => $module) {
                 if (is_string($module)) {
                     $fields['browsers'][$module] = $this->getFormFieldsForBrowser($object, $module, null, 'title', null);
                 } elseif (is_array($module)) {
-                    $relation = !empty($module['relation']) ? $module['relation'] : key($module);
+                    $relation = !empty($module['relation']) ? $module['relation'] : $moduleKey;
                     $routePrefix = isset($module['routePrefix']) ? $module['routePrefix'] : null;
                     $titleKey = !empty($module['titleKey']) ? $module['titleKey'] : 'title';
                     $moduleName = isset($module['moduleName']) ? $module['moduleName'] : null;
-                    $browserName = !empty($module['browserName']) ? $module['browserName'] : key($module);
+                    $browserName = !empty($module['browserName']) ? $module['browserName'] : $moduleKey;
                     $fields['browsers'][$browserName] = $this->getFormFieldsForBrowser($object, $relation, $routePrefix, $titleKey, $moduleName);
                 }
             }
         }
-        
+
         return $fields;
-    } 
+    }
 
     /**
      * @param \A17\Twill\Models\Model $object
@@ -70,7 +70,7 @@ trait HandleBrowsers
 
         $object->$relationship()->sync($relatedElementsWithPosition);
     }
-    
+
     /**
      * @param \A17\Twill\Models\Model $object
      * @param array $fields
@@ -81,7 +81,7 @@ trait HandleBrowsers
     public function updateOrderedBelongsTomany($object, $fields, $relationship, $positionAttribute = 'position') {
         $this->updateBrowser($object, $fields, $relationship, $positionAttribute);
     }
-    
+
     /**
      * @param mixed $object
      * @param array $fields


### PR DESCRIPTION
Made this PR originally from the master branch. Closed that PR and made new one from the 1.2 branch, as GitHub was getting confused when i changed the base on that original PR. Sorry about that.

**Original Comment:**
Fix for the pull request #400 that got merged. I love this new feature, but it wasn't working when you specified a setting like 'routePrefix' like in the Screenshot of that pull request because of the way it retrieved the arraykey.