### PR TITLE
Forms - [Feature] : Disable submit options

### DIFF
--- a/frontend/js/components/Dropdown.vue
+++ b/frontend/js/components/Dropdown.vue
@@ -381,6 +381,12 @@
         width: 100%;
         background: transparent;
         text-align: left;
+
+        &:disabled {
+          cursor: default;
+          pointer-events: none;
+          opacity: .5;
+        }
       }
 
        a,

--- a/frontend/js/components/MultiButton.vue
+++ b/frontend/js/components/MultiButton.vue
@@ -1,17 +1,22 @@
 <template>
   <div class="multibutton">
-    <a17-dropdown ref="submitDown" position="bottom-right" width="full" :offset="0">
-      <a17-button :type="type" @click="buttonClicked(options[0].name)" :name="options[0].name" variant="validate">{{ options[0].text }}</a17-button>
-      <button class="multibutton__trigger" type="button" @click="$refs.submitDown.toggle()" v-if="otherOptions.length"><span v-svg symbol="dropdown_module"></span></button>
+    <div class="multibutton__btns">
+      <a17-dropdown ref="submitDown" position="bottom-right" width="full" :offset="0">
+        <a17-button v-if="isDisabled(options[0])" type="button" variant="validate" :disabled="true">{{ options[0].text }}</a17-button>
+        <a17-button v-else :type="type" @click="buttonClicked(options[0].name)" :name="options[0].name" variant="validate">{{ options[0].text }}</a17-button>
+        <button class="multibutton__trigger" type="button" @click="$refs.submitDown.toggle()" v-if="hasValidOptions"><span v-svg symbol="dropdown_module"></span></button>
 
-      <div slot="dropdown__content" v-if="otherOptions.length">
-        <ul>
-          <li v-for="option in otherOptions" :key="option.name">
-            <button @click="buttonClicked(option.name)" :type="type" :name="option.name">{{ option.text }}</button>
-          </li>
-        </ul>
-      </div>
-    </a17-dropdown>
+        <div slot="dropdown__content" v-if="otherOptions.length">
+          <ul>
+            <li v-for="option in otherOptions" :key="option.name">
+              <button v-if="isDisabled(option)" type="button" disabled>{{ option.text }}</button>
+              <button v-else @click="buttonClicked(option.name)" :type="type" :name="option.name">{{ option.text }}</button>
+            </li>
+          </ul>
+        </div>
+      </a17-dropdown>
+    </div>
+    <p v-if="isDisabled(options[0]) && !hasValidOptions && message" class="multibutton__message">{{ message }}</p>
   </div>
 </template>
 
@@ -21,6 +26,10 @@
     props: {
       type: {
         default: 'button'
+      },
+      message: {
+        type: String,
+        default: ''
       },
       options: {
         default: function () { return [] }
@@ -33,9 +42,22 @@
       otherOptions: function () {
         if (this.options.length) return this.options.slice(1)
         else return []
+      },
+      hasValidOptions: function () {
+        const allValidOptions = this.options.filter(function (opt) {
+          return !opt.hasOwnProperty('disabled') || opt.disabled === false
+        })
+        return Boolean(allValidOptions.length > 0)
       }
     },
     methods: {
+      isDisabled: function (btn) {
+        if (btn.hasOwnProperty('disabled')) {
+          return btn.disabled === true
+        } else {
+          return false
+        }
+      },
       buttonClicked: function (val) {
         this.$emit('button-clicked', val)
       }
@@ -48,7 +70,12 @@
 
   $height_btn: 40px;
 
-  .multibutton {
+  .multibutton__message {
+    margin-top: 10px;
+    color: $color__text--light;
+  }
+
+  .multibutton__btns {
     height:$height_btn;
     position:relative;
     display:block;

--- a/frontend/js/components/MultiButton.vue
+++ b/frontend/js/components/MultiButton.vue
@@ -1,26 +1,25 @@
 <template>
   <div class="multibutton">
-    <div class="multibutton__btns">
-      <a17-dropdown ref="submitDown" position="bottom-right" width="full" :offset="0">
-        <a17-button v-if="isDisabled(options[0])" type="button" variant="validate" :disabled="true">{{ options[0].text }}</a17-button>
-        <a17-button v-else :type="type" @click="buttonClicked(options[0].name)" :name="options[0].name" variant="validate">{{ options[0].text }}</a17-button>
-        <button class="multibutton__trigger" type="button" @click="$refs.submitDown.toggle()" v-if="hasValidOptions"><span v-svg symbol="dropdown_module"></span></button>
+    <a17-dropdown ref="submitDown" position="bottom-right" width="full" :offset="0">
+      <a17-button v-if="isDisabled(options[0])" type="button" variant="validate" :disabled="true">{{ options[0].text }}</a17-button>
+      <a17-button v-else :type="type" @click="buttonClicked(options[0].name)" :name="options[0].name" variant="validate">{{ options[0].text }}</a17-button>
+      <button class="multibutton__trigger" type="button" @click="$refs.submitDown.toggle()" v-if="hasValidOptions"><span v-svg symbol="dropdown_module"></span></button>
 
-        <div slot="dropdown__content" v-if="otherOptions.length">
-          <ul>
-            <li v-for="option in otherOptions" :key="option.name">
-              <button v-if="isDisabled(option)" type="button" disabled>{{ option.text }}</button>
-              <button v-else @click="buttonClicked(option.name)" :type="type" :name="option.name">{{ option.text }}</button>
-            </li>
-          </ul>
-        </div>
-      </a17-dropdown>
-    </div>
-    <p v-if="isDisabled(options[0]) && !hasValidOptions && message" class="multibutton__message">{{ message }}</p>
+      <div slot="dropdown__content" v-if="otherOptions.length">
+        <ul>
+          <li v-for="option in otherOptions" :key="option.name">
+            <button v-if="isDisabled(option)" type="button" disabled>{{ option.text }}</button>
+            <button v-else @click="buttonClicked(option.name)" :type="type" :name="option.name">{{ option.text }}</button>
+          </li>
+        </ul>
+      </div>
+    </a17-dropdown>
   </div>
 </template>
 
 <script>
+  import { NOTIFICATION } from '@/store/mutations'
+
   export default {
     name: 'A17Multibutton',
     props: {
@@ -47,7 +46,19 @@
         const allValidOptions = this.options.filter(function (opt) {
           return !opt.hasOwnProperty('disabled') || opt.disabled === false
         })
-        return Boolean(allValidOptions.length > 0)
+
+        const bool = Boolean(allValidOptions.length > 0)
+
+        if (!bool && this.message) {
+          this.$store.commit(NOTIFICATION.SET_NOTIF, {
+            message: this.message,
+            variant: 'success'
+          })
+        } else {
+          this.$store.commit(NOTIFICATION.CLEAR_NOTIF, 'success')
+        }
+
+        return bool
       }
     },
     methods: {
@@ -70,12 +81,7 @@
 
   $height_btn: 40px;
 
-  .multibutton__message {
-    margin-top: 10px;
-    color: $color__text--light;
-  }
-
-  .multibutton__btns {
+  .multibutton {
     height:$height_btn;
     position:relative;
     display:block;

--- a/frontend/js/components/Publisher.vue
+++ b/frontend/js/components/Publisher.vue
@@ -11,7 +11,7 @@
         <a href="#" class="publisher__link" @click.prevent="openPreview"><span v-svg symbol="preview"></span><span class="f--link-underlined--o">Preview changes</span></a>
       </div>
       <div class="publisher__item publisher__item--btns">
-        <a17-multibutton @button-clicked="buttonClicked" :options="submitOptions" type="submit"></a17-multibutton>
+        <a17-multibutton @button-clicked="buttonClicked" :options="submitOptions" type="submit" :message="submitDisableMessage"></a17-multibutton>
       </div>
   </div>
   <!-- <div class="publisher__trash">
@@ -106,7 +106,8 @@
         withPublicationTimeframe: state => state.publication.withPublicationTimeframe,
         visibility: state => state.publication.visibility,
         visibilityOptions: state => state.publication.visibilityOptions,
-        reviewProcess: state => state.publication.reviewProcess
+        reviewProcess: state => state.publication.reviewProcess,
+        submitDisableMessage: state => state.publication.submitDisableMessage
       }),
       ...mapGetters([
         'publishedLanguages',

--- a/frontend/js/components/editor/EditorSidebar.vue
+++ b/frontend/js/components/editor/EditorSidebar.vue
@@ -29,7 +29,8 @@
         </draggable>
       </div>
       <div class="editorSidebar__actions">
-        <a17-button @click="saveForm(submitOptions[0].name)" :name="submitOptions[0].name" variant="validate">{{ submitOptions[0].text }}</a17-button>
+        <a17-button v-if="isSubmitDisabled(submitOptions[0])" variant="validate" :disabled="true">{{ submitOptions[0].text }}</a17-button>
+        <a17-button v-else @click="saveForm(submitOptions[0].name)" :name="submitOptions[0].name" variant="validate">{{ submitOptions[0].text }}</a17-button>
       </div>
     </template>
     <template v-else>
@@ -72,6 +73,13 @@
       })
     },
     methods: {
+      isSubmitDisabled: function (btn) {
+        if (btn.hasOwnProperty('disabled')) {
+          return btn.disabled === true
+        } else {
+          return false
+        }
+      },
       toggleDropdown: function (index) {
         if (this.blocks.length > 1) {
           const ddName = this.moveDropdown(index)

--- a/frontend/js/main-form.js
+++ b/frontend/js/main-form.js
@@ -132,7 +132,8 @@ window.vm = new Vue({
       isCustom: state => state.form.isCustom
     }),
     ...mapGetters([
-      'getSaveType'
+      'getSaveType',
+      'isEnabledSubmitOption'
     ])
   },
   methods: {
@@ -141,11 +142,20 @@ window.vm = new Vue({
         this.isFormUpdated = false
         this.$store.commit(FORM.UPDATE_FORM_LOADING, true)
         this.unSubscribe()
-        this.$nextTick(() => { // let's wait for the loading state to be properly deployed (used to save wysiwyg fields)
+
+        // let's wait for the loading state to be properly deployed (used to save content of wysiwyg fields)
+        this.$nextTick(() => {
           const saveType = this.getSaveType || document.activeElement.name
-          this.$store.dispatch(ACTIONS.SAVE_FORM, saveType).then(() => {
+
+          // isEnabledSubmitOption is an extra check to test is the form can be submit by making sure the saveType is not disabled
+          if (this.isEnabledSubmitOption(saveType)) {
+            this.$store.dispatch(ACTIONS.SAVE_FORM, saveType).then(() => {
+              this.mutationsSubscribe()
+            })
+          } else {
+            this.$store.commit(FORM.UPDATE_FORM_LOADING, false)
             this.mutationsSubscribe()
-          })
+          }
         })
       }
     },

--- a/frontend/js/store/modules/publication.js
+++ b/frontend/js/store/modules/publication.js
@@ -101,6 +101,20 @@ const getters = {
   getSubmitOptions: state => {
     return (state.published || !state.withPublicationToggle) ? state.submitOptions[state.publishSubmit] : state.submitOptions['draft']
   },
+  isEnabledSubmitOption: (state, getters) => name => {
+    // default is true (for example on custom form or if we dont have submitOptions setup)
+    let enabled = true
+    let activeOption = {}
+
+    const matches = getters.getSubmitOptions.filter((el) => el.name === name)
+    if (matches.length) activeOption = matches[0]
+
+    if (activeOption.hasOwnProperty('disabled')) {
+      enabled = !activeOption.disabled
+    }
+
+    return enabled
+  },
   getSaveType: (state, getters) => {
     return state.saveType || getters.getSubmitOptions[0].name
   }

--- a/frontend/js/store/modules/publication.js
+++ b/frontend/js/store/modules/publication.js
@@ -22,59 +22,72 @@ const state = {
       label: 'Private'
     }
   ],
+  submitDisableMessage: window.STORE.publication.submitDisableMessage || '',
   submitOptions: window.STORE.publication.submitOptions || {
     draft: [
       {
         name: 'save',
-        text: 'Save as draft'
+        text: 'Save as draft',
+        disabled: false
       },
       {
         name: 'save-close',
-        text: 'Save as draft and close'
+        text: 'Save as draft and close',
+        disabled: false
       },
       {
         name: 'save-new',
-        text: 'Save as draft and create new'
+        text: 'Save as draft and create new',
+        disabled: false
       },
       {
         name: 'cancel',
-        text: 'Cancel'
+        text: 'Cancel',
+        disabled: false
       }
     ],
     live: [
       {
         name: 'publish',
-        text: 'Publish'
+        text: 'Publish',
+        disabled: false
       },
       {
         name: 'publish-close',
-        text: 'Publish and close'
+        text: 'Publish and close',
+        disabled: false
       },
       {
         name: 'publish-new',
-        text: 'Publish and create new'
+        text: 'Publish and create new',
+        disabled: false
       },
       {
         name: 'cancel',
-        text: 'Cancel'
+        text: 'Cancel',
+        disabled: false
       }
     ],
     update: [
       {
         name: 'update',
-        text: 'Update'
+        text: 'Update',
+        disabled: false
       },
       {
         name: 'update-close',
-        text: 'Update and close'
+        text: 'Update and close',
+        disabled: false
       },
       {
         name: 'update-new',
-        text: 'Update and create new'
+        text: 'Update and create new',
+        disabled: false
       },
       {
         name: 'cancel',
-        text: 'Cancel'
+        text: 'Cancel',
+        disabled: false
       }
     ]
   }

--- a/views/layouts/form.blade.php
+++ b/views/layouts/form.blade.php
@@ -169,7 +169,62 @@
                     text: 'Cancel'
                 }
             ]
-        } @else null @endif
+        } @else {
+            draft: [
+              {
+                name: 'save',
+                text: 'Save as draft'
+              },
+              {
+                name: 'save-close',
+                text: 'Save as draft and close'
+              },
+              {
+                name: 'save-new',
+                text: 'Save as draft and create new'
+              },
+              {
+                name: 'cancel',
+                text: 'Cancel'
+              }
+            ],
+            live: [
+              {
+                name: 'publish',
+                text: 'Publish'
+              },
+              {
+                name: 'publish-close',
+                text: 'Publish and close'
+              },
+              {
+                name: 'publish-new',
+                text: 'Publish and create new'
+              },
+              {
+                name: 'cancel',
+                text: 'Cancel'
+              }
+            ],
+            update: [
+              {
+                name: 'update',
+                text: 'Update'
+              },
+              {
+                name: 'update-close',
+                text: 'Update and close'
+              },
+              {
+                name: 'update-new',
+                text: 'Update and create new'
+              },
+              {
+                name: 'cancel',
+                text: 'Cancel'
+              }
+            ]
+        } @endif
     }
 
     window.STORE.revisions = {!! json_encode($revisions ?? []) !!}

--- a/views/layouts/form.blade.php
+++ b/views/layouts/form.blade.php
@@ -109,6 +109,7 @@
         withPublicationTimeframe: {{ json_encode(($schedule ?? true) && isset($item) && $item->isFillable('publish_start_date')) }},
         publishedLabel: '{{ $customPublishedLabel ?? 'Live' }}',
         draftLabel: '{{ $customDraftLabel ?? 'Draft' }}',
+        submitDisableMessage: '{{ $submitDisableMessage ?? '' }}',
         startDate: '{{ $item->publish_start_date ?? '' }}',
         endDate: '{{ $item->publish_end_date ?? '' }}',
         visibility: '{{ isset($item) && $item->isFillable('public') ? ($item->public ? 'public' : 'private') : false }}',


### PR DESCRIPTION
This is an enhancement to disable some or all submitOptions on forms. 

If no submit options is available a notification will show to display a message :
The message can be set in the form layout blade file under this variable : `$submitDisableMessage`

The submitOtptions can be setup this way :

For example to setup the permissions to Save as draft only (but not publish Live) you could set the submit Options this way :

```
{
    draft: [
      {
        name: 'save',
        text: 'Save as draft',
        disabled: false
      },
      {
        name: 'save-close',
        text: 'Save as draft and close',
        disabled: false
      },
      {
        name: 'save-new',
        text: 'Save as draft and create new',
        disabled: false
      },
      {
        name: 'cancel',
        text: 'Cancel',
        disabled: false
      }
    ],
    live: [
      {
        name: 'publish',
        text: 'Publish',
        disabled: true
      },
      {
        name: 'publish-close',
        text: 'Publish and close',
        disabled: true
      },
      {
        name: 'publish-new',
        text: 'Publish and create new',
        disabled: true
      },
      {
        name: 'cancel',
        text: 'Cancel',
        disabled: true
      }
    ],
    update: [
      {
        name: 'update',
        text: 'Update',
        disabled: true
      },
      {
        name: 'update-close',
        text: 'Update and close',
        disabled: true
      },
      {
        name: 'update-new',
        text: 'Update and create new',
        disabled: true
      },
      {
        name: 'cancel',
        text: 'Cancel',
        disabled: true
      }
    ]
  }
```

![Capture d’écran 2019-11-22 à 17 30 52](https://user-images.githubusercontent.com/546129/69443240-500f1f80-0d4e-11ea-849f-ce9ef4365056.png)
