### PR TITLE
Fix typo in docs for nested module

### DIFF
--- a/docs/.sections/crud-modules.md
+++ b/docs/.sections/crud-modules.md
@@ -1137,7 +1137,7 @@ use Kalnoy\Nestedset\NodeTrait;
 ...
 
 class Page extends Model {
-    use HasPostion, NodeTrait;
+    use HasPosition, NodeTrait;
     ...
     public static function saveTreeFromIds($nodesArray)
     {


### PR DESCRIPTION
That's probably a part of the docs people just straight up copy. 
Just found the typo while copying the code myself 🙈