### PR TITLE
Fix join() in Glide service

### DIFF
--- a/src/Services/MediaLibrary/Glide.php
+++ b/src/Services/MediaLibrary/Glide.php
@@ -52,10 +52,10 @@ class Glide implements ImageServiceInterface
         $this->app = $app;
         $this->request = $request;
 
-        $baseUrl = join([
+        $baseUrl = join('/', [
             rtrim($this->config->get('twill.glide.base_url'), '/'),
             ltrim($this->config->get('twill.glide.base_path'), '/'),
-        ], '/');
+        ]);
 
         $this->server = ServerFactory::create([
             'response' => new LaravelResponseFactory($this->request),


### PR DESCRIPTION
There is still a deprecated `join()` in the codebase that makes **Glide** choke in PHP 7.4. This PR hopeful fixes it 🎉 