### PR TITLE
Fix/destroy sub module

### DIFF
--- a/src/Http/Controllers/Admin/ModuleController.php
+++ b/src/Http/Controllers/Admin/ModuleController.php
@@ -528,7 +528,7 @@ abstract class ModuleController extends Controller
      */
     public function destroy($id, $submoduleId = null)
     {
-        $item = $this->repository->getById($id);
+        $item = $this->repository->getById($submoduleId ?? $id);
         if ($this->repository->delete($submoduleId ?? $id)) {
             $this->fireEvent();
             activity()->performedOn($item)->log('deleted');

--- a/src/Repositories/Behaviors/HandleBrowsers.php
+++ b/src/Repositories/Behaviors/HandleBrowsers.php
@@ -46,9 +46,9 @@ trait HandleBrowsers
                 }
             }
         }
-        
+
         return $fields;
-    } 
+    }
 
     /**
      * @param \A17\Twill\Models\Model $object
@@ -70,7 +70,7 @@ trait HandleBrowsers
 
         $object->$relationship()->sync($relatedElementsWithPosition);
     }
-    
+
     /**
      * @param \A17\Twill\Models\Model $object
      * @param array $fields
@@ -81,7 +81,7 @@ trait HandleBrowsers
     public function updateOrderedBelongsTomany($object, $fields, $relationship, $positionAttribute = 'position') {
         $this->updateBrowser($object, $fields, $relationship, $positionAttribute);
     }
-    
+
     /**
      * @param mixed $object
      * @param array $fields
@@ -127,7 +127,7 @@ trait HandleBrowsers
                 'id' => $relatedElement->id,
                 'name' => $relatedElement->titleInBrowser ?? $relatedElement->title,
                 'endpointType' => $relatedElement->getMorphClass(),
-            ] + (($relatedElement->adminEditUrl ?? null) ? [] : [
+            ] + (empty($relatedElement->adminEditUrl) ? [] : [
                 'edit' => $relatedElement->adminEditUrl,
             ]) + (classHasTrait($relatedElement, HasMedias::class) ? [
                 'thumbnail' => $relatedElement->defaultCmsImage(['w' => 100, 'h' => 100]),


### PR DESCRIPTION
When we try to delete a sub-module, the function uses the parent rather than the child to record the activity that triggers an error.