### PR TITLE
Feature/additionnal links in buckets & listings

### DIFF
--- a/frontend/js/components/Button.vue
+++ b/frontend/js/components/Button.vue
@@ -44,12 +44,19 @@
     },
     computed: {
       buttonClasses: function () {
-        return [
-          `button`,
-          this.size ? `button--${this.size}` : '',
-          this.variant ? `button--${this.variant}` : '',
-          this.icon ? `button--icon button--${this.icon}` : ''
-        ]
+        const classes = [ `button`, this.size ? `button--${this.size}` : '' ]
+
+        if (this.variant) {
+          this.variant.split(' ').forEach((val) => {
+            classes.push(`button--${val}`)
+          })
+        }
+
+        if (this.icon) {
+          classes.push(`button--icon button--${this.icon}`)
+        }
+
+        return classes
       }
     },
     methods: {

--- a/frontend/js/components/Filter.vue
+++ b/frontend/js/components/Filter.vue
@@ -174,7 +174,11 @@
     div {
       display:inline-block;
 
-      input, button {
+      button, a {
+        vertical-align: middle;
+      }
+
+      input, button, a {
         margin-left:15px;
       }
     }

--- a/frontend/js/components/buckets/Bucket.vue
+++ b/frontend/js/components/buckets/Bucket.vue
@@ -3,7 +3,10 @@
     <div class="buckets__page-title">
       <div class="container buckets__page-title-content">
         <h2><slot/></h2>
-        <a17-button variant="validate" @click="save">Publish</a17-button>
+        <div class="buckets__page-title-actions">
+          <a17-button variant="validate" @click="save">Publish</a17-button>
+          <a17-button v-for="link in extraActions" :key="link.url" el="a" :href="link.url" :download="link.download || ''" :target="link.target || ''" :rel="link.rel || ''" variant="secondary">{{ link.label }}</a17-button>
+        </div>
       </div>
     </div>
     <div class="container">
@@ -98,6 +101,11 @@
       restricted: {
         type: Boolean,
         default: true
+      },
+      // Optionnal additionnal actions showing up after the Publish button
+      extraActions: {
+        type: Array,
+        default: function () { return [] }
       }
     },
     components: {
@@ -273,13 +281,24 @@
     background-color: $color__border--light;
     border-bottom: 1px solid $color__border;
     overflow: hidden;
+  }
 
-    .buckets__page-title-content {
-      padding-top: 30px;
-      padding-bottom: 30px;
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
+  .buckets__page-title-content {
+    padding-top: 30px;
+    padding-bottom: 30px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  .buckets__page-title-actions {
+    display: flex;
+    flex-wrap: nowrap;
+
+    a,
+    button {
+      margin-left: 20px;
+      vertical-align: middle;
     }
   }
 

--- a/src/Http/Controllers/Admin/FeaturedController.php
+++ b/src/Http/Controllers/Admin/FeaturedController.php
@@ -84,6 +84,7 @@ class FeaturedController extends Controller
             ],
             'maxPage' => $firstSource['maxPage'],
             'offset' => $firstSource['offset'],
+            'bucketSectionLinks' => $featuredSection['sectionIntroLinks'] ?? null,
             'bucketSourceTitle' => $featuredSection['sourceHeaderTitle'] ?? null,
             'bucketsSectionIntro' => $featuredSection['sectionIntroText'] ?? null,
             'restricted' => $featuredSection['restricted'] ?? true,

--- a/src/Http/Controllers/Admin/ModuleController.php
+++ b/src/Http/Controllers/Admin/ModuleController.php
@@ -111,6 +111,13 @@ abstract class ModuleController extends Controller
     protected $filters = [];
 
     /**
+     * Additional links to display in the listing filter
+     *
+     * @var array
+     */
+    protected $filterLinks = [];
+
+    /**
      * Default orders for the index view.
      *
      * @var array
@@ -668,6 +675,7 @@ abstract class ModuleController extends Controller
             'tableMainFilters' => $this->getIndexTableMainFilters($items),
             'filters' => json_decode($this->request->get('filter'), true) ?? [],
             'hiddenFilters' => array_keys(Arr::except($this->filters, array_keys($this->defaultFilters))),
+            'filterLinks' => $this->filterLinks ?? [],
             'maxPage' => method_exists($items, 'lastPage') ? $items->lastPage() : 1,
             'defaultMaxPage' => method_exists($items, 'total') ? ceil($items->total() / $this->perPage) : 1,
             'offset' => method_exists($items, 'perPage') ? $items->perPage() : count($items),

--- a/views/layouts/buckets.blade.php
+++ b/views/layouts/buckets.blade.php
@@ -2,8 +2,18 @@
 
 @section('appTypeClass', 'body--buckets')
 
+@php
+    $bucketSectionLinks = $bucketSectionLinks ?? [];
+@endphp
+
 @section('content')
-    <a17-buckets title="{{ $bucketSourceTitle ?? 'Available items' }}" empty-buckets="No items featured." empty-source="No items available." :restricted="{!! json_encode($restricted ?? true) !!}">
+    <a17-buckets
+        title="{{ $bucketSourceTitle ?? 'Available items' }}"
+        empty-buckets="No items featured."
+        empty-source="No items available."
+        :restricted="{!! json_encode($restricted ?? true) !!}"
+        :extra-actions="{{ json_encode($bucketSectionLinks) }}"
+    >
         {{ $bucketsSectionIntro ?? 'What would you like to feature today?' }}
     </a17-buckets>
 @stop

--- a/views/layouts/listing.blade.php
+++ b/views/layouts/listing.blade.php
@@ -51,6 +51,15 @@
                     @if($create)
                         <div slot="additional-actions">
                             <a17-button variant="validate" size="small" v-on:click="create">Add new</a17-button>
+                            @foreach($filterLinks as $link)
+                                <a17-button el="a" href="{{ $link['url'] ?? '#' }}" download="{{ $link['download'] ?? '' }}" rel="{{ $link['rel'] ?? '' }}" target="{{ $link['target'] ?? '' }}" variant="small secondary">{{ $link['label'] }}</a17-button>
+                            @endforeach
+                        </div>
+                    @elseif(isset($filterLinks) && count($filterLinks))
+                        <div slot="additional-actions">
+                            @foreach($filterLinks as $link)
+                                <a17-button el="a" href="{{ $link['url'] ?? '#' }}" download="{{ $link['download'] ?? '' }}" rel="{{ $link['rel'] ?? '' }}" target="{{ $link['target'] ?? '' }}" variant="small secondary">{{ $link['label'] }}</a17-button>
+                            @endforeach
                         </div>
                     @endif
                 </a17-filter>


### PR DESCRIPTION
This add the possibility to add links in Buckets and Listings.

![Capture d’écran 2019-12-18 à 15 26 02](https://user-images.githubusercontent.com/546129/71096420-8d7c9680-21ae-11ea-9aa0-6514885ee182.png)

**Buckets**

Links can be created in the twill config for each buckets, this is called 'sectionIntroLinks' :

```
'home_featured' => [
    'name' => 'Featured work',
    'sectionIntroText' => "What would you like to feature on the homepage today?",
    'sectionIntroLinks' => [
        [
            'label' => 'Another link',
            'url' => '/page'
        ],
        [
            'label' => 'A link to a new tab',
            'url' => 'http://google.com',
            'target' => '_blank'
        ],
        [
            'label' => 'Download link',
            'url' => '/pathtofile/toto.pdf',
            'download' => 'toto.pdf'
        ]
    ]
]
```

**Listings**

Links can be added for each listings in their respective Controller :

```
$filterLinks = [
        [
            'label' => 'Another link',
            'url' => '/page'
        ],
        [
            'label' => 'A link to a new tab',
            'url' => 'http://google.com',
            'target' => '_blank'
        ],
        [
            'label' => 'Download link',
            'url' => '/pathtofile/toto.pdf',
            'download' => 'toto.pdf'
        ]
]
```


