### PR TITLE
The fields group value should not be saved as encoded JSON string

### DIFF
--- a/src/Repositories/Behaviors/HandleFieldsGroups.php
+++ b/src/Repositories/Behaviors/HandleFieldsGroups.php
@@ -50,9 +50,9 @@ trait HandleFieldsGroups
 
     protected function handleFieldsGroups($fields) {
         foreach ($this->fieldsGroups as $group => $groupFields) {
-            $fields[$group] = json_encode(Arr::where(Arr::only($fields, $groupFields), function ($value, $key) {
+            $fields[$group] = Arr::where(Arr::only($fields, $groupFields), function ($value, $key) {
                 return !empty($value);
-            }));
+            });
             Arr::forget($fields, $groupFields);
         }
 


### PR DESCRIPTION
This PR is to fix a small bug in https://github.com/area17/twill/pull/410
When saving `fields_groups` to the database, the value in the `$fields` should be array format instead of an encoded json string, which may cause it to be double encoded.

When using this `fields_groups` feature, I will recommend using a `json` column in database, or the user should cast it by themselves.