### PR TITLE
Fix inconsistent use of integer and bigInteger on MariaDB 10.3

### DIFF
--- a/migrations/create_blocks_table.php
+++ b/migrations/create_blocks_table.php
@@ -14,7 +14,7 @@ class CreateBlocksTable extends Migration
     public function up()
     {
         Schema::create('blocks', function (Blueprint $table) {
-            $table->increments('id');
+            $table->{twillIncrementsMethod()}('id');
             $table->integer('blockable_id')->nullable()->unsigned();
             $table->string('blockable_type')->nullable();
             $table->integer('position')->unsigned();

--- a/migrations/create_features_table.php
+++ b/migrations/create_features_table.php
@@ -14,7 +14,7 @@ class CreateFeaturesTable extends Migration
     public function up()
     {
         Schema::create('features', function (Blueprint $table) {
-            $table->increments('id');
+            $table->{twillIncrementsMethod()}('id');
             $table->string('featured_id', 36);
             $table->string('featured_type', 255);
             $table->string('bucket_key')->index();

--- a/migrations/create_files_tables.php
+++ b/migrations/create_files_tables.php
@@ -14,7 +14,7 @@ class CreateFilesTables extends Migration
     public function up()
     {
         Schema::create('files', function (Blueprint $table) {
-            $table->increments('id')->unsigned();
+            $table->{twillIncrementsMethod()}('id');
             $table->timestamps();
             $table->softDeletes();
             $table->string('uuid');
@@ -23,12 +23,12 @@ class CreateFilesTables extends Migration
         });
 
         Schema::create('fileables', function (Blueprint $table) {
-            $table->increments('id');
+            $table->{twillIncrementsMethod()}('id');
             $table->timestamps();
             $table->softDeletes();
-            $table->integer('file_id')->unsigned();
+            $table->{twillIntegerMethod()}('file_id')->unsigned();
             $table->foreign('file_id', 'fk_files_file_id')->references('id')->on('files')->onDelete('cascade')->onUpdate('cascade');
-            $table->integer('fileable_id')->nullable()->unsigned();
+            $table->{twillIntegerMethod()}('fileable_id')->nullable()->unsigned();
             $table->string('fileable_type')->nullable();
             $table->string('role')->nullable();
             $table->string('locale', 6)->index();

--- a/migrations/create_medias_tables.php
+++ b/migrations/create_medias_tables.php
@@ -14,7 +14,7 @@ class CreateMediasTables extends Migration
     public function up()
     {
         Schema::create('medias', function (Blueprint $table) {
-            $table->increments('id')->unsigned();
+            $table->{twillIncrementsMethod()}('id');
             $table->timestamps();
             $table->softDeletes();
             $table->string('uuid');
@@ -26,12 +26,12 @@ class CreateMediasTables extends Migration
         });
 
         Schema::create('mediables', function (Blueprint $table) {
-            $table->increments('id');
+            $table->{twillIncrementsMethod()}('id');
             $table->timestamps();
             $table->softDeletes();
-            $table->integer('mediable_id')->nullable()->unsigned();
+            $table->{twillIntegerMethod()}('mediable_id')->nullable()->unsigned();
             $table->string('mediable_type')->nullable();
-            $table->integer('media_id')->unsigned();
+            $table->{twillIntegerMethod()}('media_id')->unsigned();
             $table->integer('crop_x')->nullable();
             $table->integer('crop_y')->nullable();
             $table->integer('crop_w')->nullable();

--- a/migrations/create_settings_table.php
+++ b/migrations/create_settings_table.php
@@ -14,7 +14,7 @@ class CreateSettingsTable extends Migration
     public function up()
     {
         Schema::create('settings', function (Blueprint $table) {
-            $table->increments('id');
+            $table->{twillIncrementsMethod()}('id');
             $table->timestamps();
             $table->softDeletes();
             $table->string('key')->nullable()->index();

--- a/migrations/create_tags_tables.php
+++ b/migrations/create_tags_tables.php
@@ -14,7 +14,7 @@ class CreateTagsTables extends Migration
     public function up()
     {
         Schema::create('tagged', function (Blueprint $table) {
-            $table->increments('id');
+            $table->{twillIncrementsMethod()}('id');
             $table->string('taggable_type');
             $table->integer('taggable_id')->unsigned();
             $table->integer('tag_id')->unsigned();
@@ -22,7 +22,7 @@ class CreateTagsTables extends Migration
         });
 
         Schema::create('tags', function (Blueprint $table) {
-            $table->increments('id');
+            $table->{twillIncrementsMethod()}('id');
             $table->string('namespace');
             $table->string('slug');
             $table->string('name');

--- a/migrations/create_twill_activity_log_table.php
+++ b/migrations/create_twill_activity_log_table.php
@@ -13,7 +13,7 @@ class CreateTwillActivityLogTable extends Migration
     {
         if (!Schema::hasTable(config('activitylog.table_name'))) {
             Schema::create(config('activitylog.table_name'), function (Blueprint $table) {
-                $table->increments('id');
+                $table->{twillIncrementsMethod()}('id');
                 $table->string('log_name')->nullable();
                 $table->text('description');
                 $table->integer('subject_id')->nullable();

--- a/src/Helpers/migrations_helpers.php
+++ b/src/Helpers/migrations_helpers.php
@@ -2,6 +2,30 @@
 
 use Illuminate\Support\Str;
 
+if (!function_exists('twillIncrementsMethod')) {
+    /**
+     * @return string
+     */
+    function twillIncrementsMethod()
+    {
+        return config('twill.migrations_use_big_integers')
+            ? 'bigIncrements'
+            : 'increments';
+    }
+}
+
+if (!function_exists('twillIntegerMethod')) {
+    /**
+     * @return string
+     */
+    function twillIntegerMethod()
+    {
+        return config('twill.migrations_use_big_integers')
+            ? 'bigInteger'
+            : 'integer';
+    }
+}
+
 if (!function_exists('createDefaultFields')) {
     /**
      * @param \Illuminate\Database\Schema\Blueprint $table
@@ -13,11 +37,7 @@ if (!function_exists('createDefaultFields')) {
      */
     function createDefaultTableFields($table, $softDeletes = true, $published = true, $publishDates = false, $visibility = false)
     {
-        if (config('twill.migrations_use_big_integers')) {
-            $table->bigIncrements('id');
-        } else {
-            $table->increments('id');
-        }
+        $table->{twillIncrementsMethod()}('id');
 
         if ($softDeletes) {
             $table->softDeletes();
@@ -53,13 +73,8 @@ if (!function_exists('createDefaultTranslationsTableFields')) {
             $tableNamePlural = Str::plural($tableNameSingular);
         }
 
-        if (config('twill.migrations_use_big_integers')) {
-            $table->bigIncrements('id');
-            $table->bigInteger("{$tableNameSingular}_id")->unsigned();
-        } else {
-            $table->increments('id');
-            $table->integer("{$tableNameSingular}_id")->unsigned();
-        }
+        $table->{twillIncrementsMethod()}('id');
+        $table->{twillIntegerMethod()}("{$tableNameSingular}_id")->unsigned();
 
         $table->softDeletes();
         $table->timestamps();
@@ -84,13 +99,8 @@ if (!function_exists('createDefaultSlugsTableFields')) {
             $tableNamePlural = Str::plural($tableNameSingular);
         }
 
-        if (config('twill.migrations_use_big_integers')) {
-            $table->bigIncrements('id');
-            $table->bigInteger("{$tableNameSingular}_id")->unsigned();
-        } else {
-            $table->increments('id');
-            $table->integer("{$tableNameSingular}_id")->unsigned();
-        }
+        $table->{twillIncrementsMethod()}('id');
+        $table->{twillIntegerMethod()}("{$tableNameSingular}_id")->unsigned();
 
         $table->softDeletes();
         $table->timestamps();
@@ -119,13 +129,8 @@ if (!function_exists('createDefaultRelationshipTableFields')) {
             $table2NamePlural = Str::plural($table2NameSingular);
         }
 
-        if (config('twill.migrations_use_big_integers')) {
-            $table->bigInteger("{$table1NameSingular}_id")->unsigned();
-            $table->bigInteger("{$table2NameSingular}_id")->unsigned();
-        } else {
-            $table->integer("{$table1NameSingular}_id")->unsigned();
-            $table->integer("{$table2NameSingular}_id")->unsigned();
-        }
+        $table->{twillIntegerMethod()}("{$table1NameSingular}_id")->unsigned();
+        $table->{twillIntegerMethod()}("{$table2NameSingular}_id")->unsigned();
 
         $table->foreign("{$table1NameSingular}_id")->references('id')->on($table1NamePlural)->onDelete('cascade');
         $table->foreign("{$table2NameSingular}_id")->references('id')->on($table2NamePlural)->onDelete('cascade');
@@ -146,15 +151,9 @@ if (!function_exists('createDefaultRevisionsTableFields')) {
             $tableNamePlural = Str::plural($tableNameSingular);
         }
 
-        if (config('twill.migrations_use_big_integers')) {
-            $table->bigIncrements('id');
-            $table->bigInteger("{$tableNameSingular}_id")->unsigned()->index();
-            $table->bigInteger('user_id')->unsigned()->nullable();
-        } else {
-            $table->increments('id');
-            $table->integer("{$tableNameSingular}_id")->unsigned()->index();
-            $table->integer('user_id')->unsigned()->nullable();
-        }
+        $table->{twillIncrementsMethod()}('id');
+        $table->{twillIntegerMethod()}("{$tableNameSingular}_id")->unsigned();
+        $table->{twillIntegerMethod()}('user_id')->unsigned()->nullable();
 
         $table->timestamps();
         $table->json('payload');


### PR DESCRIPTION
Changes to support bigInteger wasn't done in full. It may be working for some database servers, but MariaDB 10.3 is not accepting to have a bigInteger increments column being referenced as integer on foreign keys.

To make it a little less verbose and easier to add on new migrations, I also created two new helper functions: `twillIncrementsMethod()` and `twillIntegerMethod()`.

This is a broader fix than https://github.com/area17/twill/pull/502.
