### PR TITLE
Fix custom blocks when inline rendering is enabled

### DIFF
--- a/views/partials/form/utils/_blocks_templates.blade.php
+++ b/views/partials/form/utils/_blocks_templates.blade.php
@@ -8,7 +8,7 @@
     $blocksForInlineTemplates = collect($allBlocks)->reject(function ($block) {
         return $block['compiled'] ?? false;
     })->filter(function ($block, $blockName) {
-        return View::exists($blockName);
+        return View::exists('admin.blocks.'.$blockName);
     });
 @endphp
 


### PR DESCRIPTION
The admin wasn't picking up the blocks passed in the config file because the view filter was missing the path in which the blocks are stored.