### PR TITLE
Added support for nested repeaters in block

### DIFF
--- a/src/Repositories/Behaviors/HandleBlocks.php
+++ b/src/Repositories/Behaviors/HandleBlocks.php
@@ -70,16 +70,30 @@ trait HandleBlocks
         $blockRepository = app(BlockRepository::class);
 
         $blockRepository->bulkDelete($object->blocks()->pluck('id')->toArray());
-
         $this->getBlocks($object, $fields)->each(function ($block) use ($object, $blockRepository) {
-
-            $blockCreated = $blockRepository->create($block);
-
-            $block['blocks']->each(function ($childBlock) use ($blockCreated, $blockRepository) {
-                $childBlock['parent_id'] = $blockCreated->id;
-                $blockRepository->create($childBlock);
-            });
+            $this->createBlock($blockRepository, $block);
         });
+    }
+
+    /**
+     * Create a block from formFields, and recursively create it's child blocks
+     *
+     * @param  \A17\Twill\Repositories\BlockRepository $blockRepository
+     * @param  array $blockFields
+     *
+     * @return \A17\Twill\Models\Block $blockCreated
+     */
+    private function createBlock(BlockRepository $blockRepository, $blockFields)
+    {
+        $blockCreated = $blockRepository->create($blockFields);
+
+        // Handle child blocks
+        $blockFields['blocks']->each(function ($childBlock) use ($blockCreated, $blockRepository) {
+            $childBlock['parent_id'] = $blockCreated->id;
+            $this->createBlock($blockRepository, $childBlock);
+        });
+
+        return $blockCreated;
     }
 
     /**
@@ -95,27 +109,39 @@ trait HandleBlocks
             foreach ($fields['blocks'] as $index => $block) {
                 $block = $this->buildBlock($block, $object);
                 $block['position'] = $index + 1;
-
-                $childBlocksList = Collection::make();
-
-                foreach ($block['blocks'] as $childKey => $childBlocks) {
-                    foreach ($childBlocks as $index => $childBlock) {
-                        $childBlock = $this->buildBlock($childBlock, $object, true);
-
-                        $childBlock['child_key'] = $childKey;
-                        $childBlock['position'] = $index + 1;
-
-                        $childBlocksList->push($childBlock);
-                    }
-                }
-
-                $block['blocks'] = $childBlocksList;
+                $block['blocks'] = $this->getChildBlocks($object, $block);
 
                 $blocks->push($block);
             }
         }
 
         return $blocks;
+    }
+
+    /**
+     * Recursively generate child blocks from the fields of a block
+     *
+     * @param  \A17\Twill\Models\Model $object
+     * @param  array $parentBlockFields
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    private function getChildBlocks($object, $parentBlockFields)
+    {
+        $childBlocksList = Collection::make();
+
+        foreach ($parentBlockFields['blocks'] as $childKey => $childBlocks) {
+            foreach ($childBlocks as $index => $childBlock) {
+                $childBlock = $this->buildBlock($childBlock, $object, true);
+                $childBlock['child_key'] = $childKey;
+                $childBlock['position'] = $index + 1;
+                $childBlock['blocks'] = $this->getChildBlocks($object, $childBlock);
+
+                $childBlocksList->push($childBlock);
+            }
+        }
+
+        return $childBlocksList;
     }
 
     /**


### PR DESCRIPTION
This PR is to add the nested repeaters as discussed in https://github.com/area17/twill/issues/74

I found out the fields passed to `afterSaveHandleBlocks` have included all information we needed to support nested repeaters, it's merely not be handled properly. 

This PR refactored the `HandleBlocks` trait a little bit by adding the following two methods:

- `createBlock` to create a block and recursively traverse it's child blocks and create them.
- `getChildBlocks` to recursively convert a child block's fields to the structure needed for creating a child block.