### PR TITLE
Use real bold font in wysiwyg editor

### DIFF
--- a/frontend/js/components/Wysiwyg.vue
+++ b/frontend/js/components/Wysiwyg.vue
@@ -336,6 +336,10 @@
         font-weight:700;
       }
 
+      b, p b, p strong, strong {
+        font-weight:700;
+      }
+
       p, ul, ol, h1, h2, h3, h4, h5 {
         margin-bottom:1em;
       }

--- a/frontend/scss/setup/_typography.scss
+++ b/frontend/scss/setup/_typography.scss
@@ -33,7 +33,7 @@
   font-display: swap;
 }
 
-/*@font-face {
+@font-face {
   font-family: 'Inter';
   font-style:  normal;
   font-weight: 700;
@@ -48,7 +48,7 @@
   src: url("/assets/admin/fonts/Inter-BoldItalic.woff2") format("woff2"),
        url("/assets/admin/fonts/Inter-BoldItalic.woff") format("woff");
   font-display: swap;
-}*/
+}
 
 $sans-serif: Inter, -apple-system, -system-ui, system-ui, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
 /*$sans-serif: "Helvetica Neue", Helvetica, Arial, sans-serif;*/

--- a/views/partials/head.blade.php
+++ b/views/partials/head.blade.php
@@ -11,6 +11,7 @@
 <!-- Fonts -->
 <link href="/assets/admin/fonts/Inter-Regular.woff2" rel="preload" as="font" type="font/woff2" crossorigin>
 <link href="/assets/admin/fonts/Inter-Medium.woff2" rel="preload" as="font" type="font/woff2" crossorigin>
+<!-- <link href="/assets/admin/fonts/Inter-Bold.woff2" rel="preload" as="font" type="font/woff2" crossorigin> -->
 
 <!-- head.js -->
 <script>


### PR DESCRIPTION
This change improves editor productivity by rendering bold passages in Inter's bold style instead of medium. Currently, bold sections in wysiwyg editors are barely detectable, making text hard to scan. See screenshots below for a before/after comparison.

**Before**:

<img width="785" alt="Screenshot 2020-02-07 at 15 50 23" src="https://user-images.githubusercontent.com/22225348/74039759-b35e3480-49c2-11ea-8f20-5b4cdd03be88.png">

**After**:

<img width="785" alt="Screenshot 2020-02-07 at 15 49 53" src="https://user-images.githubusercontent.com/22225348/74039813-c96bf500-49c2-11ea-8e84-7719aa0b485a.png">


I've made the preload hint in `head.blade.php` optional, since it makes sense to only load the bold style if there's an actual wysiwyg field in the current edit form.

