### PR TITLE
Exception handler should return json response on ajax call

### DIFF
--- a/src/Exceptions/Handler.php
+++ b/src/Exceptions/Handler.php
@@ -125,6 +125,10 @@ class Handler extends ExceptionHandler
             return $this->convertValidationExceptionToResponse($e, $request);
         }
 
+        if ($this->isJsonOutputFormat) {
+            return $this->prepareJsonResponse($request, $e);
+        }
+
         return $this->renderHttpExceptionWithView($request, $e);
     }
 


### PR DESCRIPTION
Using `Illuminate\Foundation\Exceptions\Handler` to handle the json response.

Sample responses:

`app.debug === true`:
```
message: "Target class [App\Repositories\ArticleRepository] does not exist."
exception: "Illuminate\Contracts\Container\BindingResolutionException"
file: ".../vendor/laravel/framework/src/Illuminate/Container/Container.php"
line: 805
trace: [,…]
```

`app.debug === false`:
```
message: "Server Error"
```