### PR TITLE
Refactored HandleRepeaters trait

### DIFF
--- a/src/Repositories/ModuleRepository.php
+++ b/src/Repositories/ModuleRepository.php
@@ -6,6 +6,7 @@ use A17\Twill\Models\Behaviors\HasMedias;
 use A17\Twill\Models\Behaviors\Sortable;
 use A17\Twill\Repositories\Behaviors\HandleDates;
 use A17\Twill\Repositories\Behaviors\HandleBrowsers;
+use A17\Twill\Repositories\Behaviors\HandleRepeaters;
 use A17\Twill\Repositories\Behaviors\HandleFieldsGroups;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
@@ -18,7 +19,7 @@ use PDO;
 
 abstract class ModuleRepository
 {
-    use HandleDates, HandleBrowsers, HandleFieldsGroups;
+    use HandleDates, HandleBrowsers, HandleRepeaters, HandleFieldsGroups;
   
     /**
      * @var \A17\Twill\Models\Model


### PR DESCRIPTION
This PR intends to improve the behavior of automated repeaters as described in https://github.com/area17/twill/pull/400 and https://github.com/area17/twill/pull/467

##### Changelog:
- Completely refactored the `HandleRepeater` trait to improve the code quality and readability
- Autoloaded the `HandleRepeater` trait from ModuleRepository.

##### Next step:
I feel the new `$repeaters` attribute is now working very well and could handle most of the situations. I think we should add support for `updateRepeaterMany` and `updateRepeaterMorphMany`, and then we should encourage users to use this attribute instead of manually construct in `afterSave` method.