### PR TITLE
Fixed hydrate methods for automated repeaters and browsers

### DIFF
--- a/src/Repositories/Behaviors/HandleBrowsers.php
+++ b/src/Repositories/Behaviors/HandleBrowsers.php
@@ -151,11 +151,14 @@ trait HandleBrowsers
     {
         return collect($this->browsers)->map(function ($browser, $key) {
             $browserName = is_string($browser) ? $browser : $key;
+            $moduleName = !empty($browser['moduleName']) ? $browser['moduleName'] : $this->inferModuleNameFromBrowserName($browserName);
+            
             return [
                 'relation' => !empty($browser['relation']) ? $browser['relation'] : $this->inferRelationFromBrowserName($browserName),
                 'routePrefix' => isset($browser['routePrefix']) ? $browser['routePrefix'] : null,
                 'titleKey' => !empty($browser['titleKey']) ? $browser['titleKey'] : 'title',
-                'moduleName' => isset($browser['moduleName']) ? $browser['moduleName'] : null,
+                'moduleName' => $moduleName,
+                'model' => !empty($browser['model']) ? $browser['model'] : $this->inferModelFromModuleName($moduleName),
                 'positionAttribute' => !empty($browser['positionAttribute']) ? $browser['positionAttribute'] : 'position',
                 'browserName' => $browserName,
             ];
@@ -172,5 +175,30 @@ trait HandleBrowsers
     protected function inferRelationFromBrowserName(string $browserName): string
     {
         return Str::camel($browserName);
+    }
+
+    /**
+     * The model name should be singular upper camel case, ex. User, ArticleType
+     *
+     * @param  string $moduleName
+     *
+     * @return string
+     */
+    protected function inferModelFromModuleName(string $moduleName): string
+    {
+        return Str::studly(Str::singular($moduleName));
+    }
+
+    /**
+     * The module name should be plural lower camel case 
+     *
+     * @param  mixed $string
+     * @param  mixed $browserName
+     *
+     * @return string
+     */
+    protected function inferModuleNameFromBrowserName(string $browserName): string
+    {
+        return Str::camel(Str::plural($browserName));
     }
 }

--- a/src/Repositories/Behaviors/HandleRevisions.php
+++ b/src/Repositories/Behaviors/HandleRevisions.php
@@ -10,30 +10,14 @@ trait HandleRevisions
 {
     public function hydrateHandleRevisions($object, $fields)
     {
-        if (property_exists($this, 'browsers')) {
-            foreach ($this->browsers as $moduleKey => $module) {
-                if (is_string($module)) {
-                    $this->hydrateBrowser($object, $fields, $module);
-                } elseif (is_array($module)) {
-                    $relation = !empty($module['relation']) ? $module['relation'] : $moduleKey;
-                    $positionAttribute = !empty($module['positionAttribute']) ? $module['positionAttribute'] : 'position';
-                    $model = isset($module['model']) ? $module['model'] : null;
-                    $this->hydrateBrowser($object, $fields, $relation, $positionAttribute, $model);
-                }
-            }
+        // HandleRepeaters trait => getRepeaters
+        foreach($this->getRepeaters() as $repeater) {
+            $this->hydrateRepeater($object, $fields, $repeater['relation'], $repeater['model']);
         }
 
-        if (property_exists($this, 'repeaters')) {
-            foreach ($this->repeaters as $moduleKey => $module) {
-                if (is_string($module)) {
-                    $model = Str::studly(Str::singular($module));
-                    $this->hydrateRepeater($object, $fields, $module, $model);
-                } elseif (is_array($module)) {
-                    $relation = !empty($module['relation']) ? $module['relation'] : $moduleKey;
-                    $model = isset($module['model']) ? $module['model'] : Str::studly(Str::singular($moduleKey));
-                    $this->hydrateRepeater($object, $fields, $relation, $model);
-                }
-            }
+        // HandleBrowers trait => getBrowsers
+        foreach($this->getBrowsers() as $browser) {
+            $this->hydrateBrowser($object, $fields, $browser['relation'], $browser['positionAttribute'], $browser['model']);
         }
 
         return $object;


### PR DESCRIPTION
Following #537 and #538 . Updated the hydrate methods for the automated repeaters/browsers.