### PR TITLE
Fix config key

### DIFF
--- a/src/TwillServiceProvider.php
+++ b/src/TwillServiceProvider.php
@@ -213,7 +213,7 @@ class TwillServiceProvider extends ServiceProvider
 
     private function publishMigrations()
     {
-        if (config('twill.load_default_migrations_from_twill', true)) {
+        if (config('twill.load_default_migrations', true)) {
             $this->loadMigrationsFrom(__DIR__ . '/../migrations/default');
         }
 


### PR DESCRIPTION
Key name was different from twill.php's.

Maybe we should default that to `false`, but maybe only for people upgrading from 1.2 (somehow)?