### PR TITLE
Allow firstOrCreate to have only attributes

### DIFF
--- a/src/Repositories/ModuleRepository.php
+++ b/src/Repositories/ModuleRepository.php
@@ -20,7 +20,7 @@ use PDO;
 abstract class ModuleRepository
 {
     use HandleDates, HandleBrowsers, HandleRepeaters, HandleFieldsGroups;
-  
+
     /**
      * @var \A17\Twill\Models\Model
      */
@@ -200,9 +200,9 @@ abstract class ModuleRepository
      * @param $fields
      * @return \A17\Twill\Models\Model
      */
-    public function firstOrCreate($attributes, $fields)
+    public function firstOrCreate($attributes, $fields = [])
     {
-        return $this->model->where($attributes)->first() ?? $this->create($fields);
+        return $this->model->where($attributes)->first() ?? $this->create($attributes + $fields);
     }
 
     /**


### PR DESCRIPTION
This will allow us to first or create models that only have, for example, a name. It's also more compatible with Eloquent's `firstCreate()`: https://github.com/laravel/framework/blob/9f0af8433eaae7a59e297229ca84d998e0e56edf/src/Illuminate/Database/Eloquent/Builder.php#L431