### PR TITLE
fix composer classname collisions with already published migrations

### DIFF
--- a/migrations/default/2020_02_09_000011_add_twill_default_locale_column_to_twill_mediables.php
+++ b/migrations/default/2020_02_09_000011_add_twill_default_locale_column_to_twill_mediables.php
@@ -3,7 +3,7 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 
-class AddLocaleColumnToTwillMediables extends Migration
+class AddTwillDefaultLocaleColumnToTwillMediables extends Migration
 {
     public function up()
     {

--- a/migrations/default/2020_02_09_000012_change_twill_default_locale_column_in_twill_fileables.php
+++ b/migrations/default/2020_02_09_000012_change_twill_default_locale_column_in_twill_fileables.php
@@ -3,7 +3,7 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 
-class ChangeLocaleColumnInTwillFileables extends Migration
+class ChangeTwillDefaultLocaleColumnInTwillFileables extends Migration
 {
     public function up()
     {


### PR DESCRIPTION
if you already published the twill migrations in an existing twill project, you will get composer classname collisions.
`PHP Fatal error:  Cannot declare class AddLocaleColumnToTwillMediables, because the name is already in use`

this PR applies TwillDefault to the class and filename.