### PR TITLE
Persist the active_subdomain in config

### DIFF
--- a/config/twill.php
+++ b/config/twill.php
@@ -63,6 +63,7 @@ return [
      */
     'support_subdomain_admin_routing' => false,
     'admin_app_subdomain' => 'admin',
+    'active_subdomain' => null,
 
     /*
     |--------------------------------------------------------------------------

--- a/src/Http/Middleware/SupportSubdomainRouting.php
+++ b/src/Http/Middleware/SupportSubdomainRouting.php
@@ -14,6 +14,10 @@ class SupportSubdomainRouting
         $parameter = 'subdomain';
         $subdomain = $request->route()->parameter($parameter) ?? key(config('twill.app_names'));
 
+        if (config('twill.active_subdomain') !== $subdomain) {
+            config(['twill.active_subdomain' => $subdomain]);
+        }
+        
         // Set subdomain as default URL parameter to not have
         // to add it manually when using route helpers
         URL::defaults([$parameter => $subdomain]);


### PR DESCRIPTION
Added the `active_subdomain` to the config file to indicate the current active subdomain.