### PR TITLE
Fix S3 Uploader when custom path is used

### DIFF
--- a/frontend/js/components/media-library/Uploader.vue
+++ b/frontend/js/components/media-library/Uploader.vue
@@ -184,26 +184,36 @@
       _onAllCompleteCallback (succeeded, failed) {
         // reset folder name for next upload session
         this.unique_folder_name = null
+        this.dirUUID = null
         this.uploadProgress(0)
       },
       _onSubmitCallback (id, name) {
         this.$emit('clear')
         // each upload session will add upload files with original filenames in a folder named using a uuid
-        this.unique_folder_name = this.unique_folder_name || (this.uploaderConfig.endpointRoot + qq.getUniqueId())
-        this._uploader.methods.setParams({ unique_folder_name: this.unique_folder_name }, id)
+        this.dirUUID = this.dirUUID || qq.getUniqueId()
+        this.unique_folder_name = this.unique_folder_name || (this.uploaderConfig.endpointRoot + this.dirUUID)
 
-        // determine the image dimensions and add it to params sent on upload success
-        const imageUrl = URL.createObjectURL(this._uploader.methods.getFile(id))
-        const img = new Image()
+        if (this.type.value === 'image') {
+          // determine the image dimensions and add it to params sent on upload success
+          const imageUrl = URL.createObjectURL(this._uploader.methods.getFile(id))
+          const img = new Image()
 
-        img.onload = () => {
+          img.onload = () => {
+            this._uploader.methods.setParams({
+              width: img.width,
+              height: img.height,
+              unique_folder_name: this.unique_folder_name,
+              dir_uuid: this.dirUUID
+            }, id)
+          }
+
+          img.src = imageUrl
+        } else {
           this._uploader.methods.setParams({
-            width: img.width,
-            height: img.height
+            unique_folder_name: this.unique_folder_name,
+            dir_uuid: this.dirUUID
           }, id)
         }
-
-        img.src = imageUrl
 
         const media = {
           id: this._uploader.methods.getUuid(id),

--- a/src/Http/Controllers/Admin/FileLibraryController.php
+++ b/src/Http/Controllers/Admin/FileLibraryController.php
@@ -191,8 +191,15 @@ class FileLibraryController extends ModuleController implements SignUploadListen
      */
     public function storeReference($request)
     {
+        $dir_uuid = $request->input('dir_uuid');
+        $unique_folder_name = $request->input('unique_folder_name');
+        $uuid = $request->input('key') ?? $request->input('blob');
+
+        $prefix_path = str_replace($dir_uuid, '', $unique_folder_name);
+        $path = str_replace($prefix_path, '', $uuid);
+
         $fields = [
-            'uuid' => $request->input('key') ?? $request->input('blob'),
+            'uuid' => $path,
             'filename' => $request->input('name'),
         ];
 

--- a/src/Http/Controllers/Admin/MediaLibraryController.php
+++ b/src/Http/Controllers/Admin/MediaLibraryController.php
@@ -184,8 +184,15 @@ class MediaLibraryController extends ModuleController implements SignUploadListe
      */
     public function storeReference($request)
     {
+        $dir_uuid = $request->input('dir_uuid');
+        $unique_folder_name = $request->input('unique_folder_name');
+        $uuid = $request->input('key') ?? $request->input('blob');
+
+        $prefix_path = str_replace($dir_uuid, '', $unique_folder_name);
+        $path = str_replace($prefix_path, '', $uuid);
+
         $fields = [
-            'uuid' => $request->input('key') ?? $request->input('blob'),
+            'uuid' => $path,
             'filename' => $request->input('name'),
             'width' => $request->input('width'),
             'height' => $request->input('height'),


### PR DESCRIPTION
Proposed solution for #553 

Added parameters `unique_folder_name` [which was occassionally being overwritten before] and `dir_uuid` to upload endpoint callback in Uploader.vue to identify the directory and unique identifier used for file location

Added logic in `storeReference` method of `FileLibraryController` and `MediaLibraryController` to handle new parameters and store only the unique portion of the `uuid` without custom root