### PR TITLE
Duplicate entities directly from listing

### DIFF
--- a/frontend/js/components/table/TableRow.vue
+++ b/frontend/js/components/table/TableRow.vue
@@ -11,7 +11,7 @@
     </td>
     <td class="tablecell tablecell--spacer">&nbsp;</td>
     <td class="tablecell tablecell--sticky">
-      <a17-table-cell-actions v-bind="currentComponentProps()" @editInPlace="editInPlace" @update="tableCellUpdate" @restoreRow=" restoreRow" @deleteRow="deleteRow"/>
+      <a17-table-cell-actions v-bind="currentComponentProps()" @editInPlace="editInPlace" @update="tableCellUpdate" @restoreRow=" restoreRow" @deleteRow="deleteRow" @duplicateRow="duplicateRow"/>
     </td>
   </tr>
 </template>

--- a/frontend/js/components/table/tableCell/TableCellActions.vue
+++ b/frontend/js/components/table/tableCell/TableCellActions.vue
@@ -28,6 +28,9 @@
       <a v-else-if="row.delete"
          href="#"
          @click.prevent="deleteRow">Delete</a>
+      <a v-if="row.hasOwnProperty('duplicate')"
+         href="#"
+         @click.prevent="duplicateRow">Duplicate</a>
     </div>
   </a17-dropdown>
 </template>

--- a/frontend/js/mixins/datatableRow.js
+++ b/frontend/js/mixins/datatableRow.js
@@ -158,6 +158,9 @@ export default {
       } else {
         this.$store.dispatch(ACTIONS.DELETE_ROW, row)
       }
+    },
+    duplicateRow: function (row) {
+      this.$store.dispatch(ACTIONS.DUPLICATE_ROW, row)
     }
   }
 }

--- a/frontend/js/mixins/tableCell.js
+++ b/frontend/js/mixins/tableCell.js
@@ -41,6 +41,9 @@ export default {
     },
     deleteRow: function () {
       this.$emit('deleteRow', this.row)
+    },
+    duplicateRow: function () {
+      this.$emit('duplicateRow', this.row)
     }
   }
 }

--- a/frontend/js/store/actions/index.js
+++ b/frontend/js/store/actions/index.js
@@ -10,6 +10,7 @@ export const SET_DATATABLE_NESTED = 'setDatatableNestedDatas'
 export const SET_DATATABLE = 'setDatatableDatas'
 export const TOGGLE_PUBLISH = 'togglePublishedData'
 export const DELETE_ROW = 'deleteData'
+export const DUPLICATE_ROW = 'duplicateData'
 export const RESTORE_ROW = 'restoreData'
 export const TOGGLE_FEATURE = 'toggleFeaturedData'
 export const BULK_PUBLISH = 'bulkPublishData'
@@ -40,6 +41,7 @@ export default {
   SET_DATATABLE,
   TOGGLE_PUBLISH,
   DELETE_ROW,
+  DUPLICATE_ROW,
   RESTORE_ROW,
   TOGGLE_FEATURE,
   BULK_PUBLISH,

--- a/frontend/js/store/api/datatable.js
+++ b/frontend/js/store/api/datatable.js
@@ -76,6 +76,15 @@ export default {
     })
   },
 
+  duplicate (row, callback) {
+    axios.put(row.duplicate).then(function (resp) {
+      if (callback && typeof callback === 'function') callback(resp)
+    }, function (resp) {
+      globalError(component, resp)
+      console.log('duplicate request error.')
+    })
+  },
+
   reorder (ids, callback) {
     axios.post(window.CMS_URLS.reorder, { ids: ids }).then(function (resp) {
       if (callback && typeof callback === 'function') callback(resp)

--- a/frontend/js/store/modules/datatable.js
+++ b/frontend/js/store/modules/datatable.js
@@ -270,6 +270,12 @@ const actions = {
       dispatch(ACTIONS.GET_DATATABLE)
     })
   },
+  [ACTIONS.DUPLICATE_ROW] ({ commit, state, dispatch }, row) {
+    api.duplicate(row, function (resp) {
+      commit(NOTIFICATION.SET_NOTIF, { message: resp.data.message, variant: resp.data.variant })
+      dispatch(ACTIONS.GET_DATATABLE)
+    })
+  },
   [ACTIONS.RESTORE_ROW] ({ commit, state, dispatch }, row) {
     api.restore(row, function (resp) {
       commit(NOTIFICATION.SET_NOTIF, { message: resp.data.message, variant: resp.data.variant })

--- a/frontend/js/store/modules/datatable.js
+++ b/frontend/js/store/modules/datatable.js
@@ -273,7 +273,9 @@ const actions = {
   [ACTIONS.DUPLICATE_ROW] ({ commit, state, dispatch }, row) {
     api.duplicate(row, function (resp) {
       commit(NOTIFICATION.SET_NOTIF, { message: resp.data.message, variant: resp.data.variant })
-      dispatch(ACTIONS.GET_DATATABLE)
+      if (resp.data.hasOwnProperty('redirect')) {
+        window.location.replace(resp.data.redirect)
+      }
     })
   },
   [ACTIONS.RESTORE_ROW] ({ commit, state, dispatch }, row) {

--- a/src/AuthServiceProvider.php
+++ b/src/AuthServiceProvider.php
@@ -67,6 +67,12 @@ class AuthServiceProvider extends ServiceProvider
             });
         });
 
+        Gate::define('duplicate', function ($user) {
+            return $this->authorize($user, function ($user) {
+                return $this->userHasRole($user, [UserRole::PUBLISHER, UserRole::ADMIN]);
+            });
+        });
+
         Gate::define('upload', function ($user) {
             return $this->authorize($user, function ($user) {
                 return $this->userHasRole($user, [UserRole::PUBLISHER, UserRole::ADMIN]);

--- a/src/Http/Controllers/Admin/ModuleController.php
+++ b/src/Http/Controllers/Admin/ModuleController.php
@@ -543,12 +543,16 @@ abstract class ModuleController extends Controller
             $this->fireEvent();
             activity()->performedOn($item)->log('duplicated');
 
-            return $this->respondWithRedirect(moduleRoute(
-                $this->moduleName,
-                $this->routePrefix,
-                'edit',
-                array_filter(['id' => $newItem->id])
-            ));
+            return Response::json([
+                'message' => $this->modelTitle . ' duplicated with Success!',
+                'variant' => FlashLevel::SUCCESS,
+                'redirect' => moduleRoute(
+                    $this->moduleName,
+                    $this->routePrefix,
+                    'edit',
+                    array_filter(['id' => $newItem->id])
+                )
+            ]);
         }
 
         return $this->respondWithError($this->modelTitle . ' was not duplicated. Something wrong happened!');

--- a/src/Http/Controllers/Admin/ModuleController.php
+++ b/src/Http/Controllers/Admin/ModuleController.php
@@ -539,10 +539,16 @@ abstract class ModuleController extends Controller
     {
 
         $item = $this->repository->getById($submoduleId ?? $id);
-        if ($this->repository->duplicate($submoduleId ?? $id)) {
+        if ($newItem = $this->repository->duplicate($submoduleId ?? $id)) {
             $this->fireEvent();
             activity()->performedOn($item)->log('duplicated');
-            return $this->respondWithSuccess($this->modelTitle . ' duplicated!');
+
+            return $this->respondWithRedirect(moduleRoute(
+                $this->moduleName,
+                $this->routePrefix,
+                'edit',
+                array_filter(['id' => $newItem->id])
+            ));
         }
 
         return $this->respondWithError($this->modelTitle . ' was not duplicated. Something wrong happened!');

--- a/src/Repositories/ModuleRepository.php
+++ b/src/Repositories/ModuleRepository.php
@@ -350,13 +350,15 @@ abstract class ModuleRepository
             return false;
         }
 
-        $revision = $object->revisions()->orderBy('created_at', 'desc')->first();
+        if (($revision = $object->revisions()->orderBy('created_at', 'desc')->first()) === null) {
+            return false;
+        }
 
-        $input = collect(json_decode($revision->payload, true))->only(['name', 'slug', 'languages'])->toArray();
+        $revisionInput = json_decode($revision->payload, true);
+        $baseInput = collect($revisionInput)->only(['slug', 'languages'])->filter()->toArray();
+        $newObject = $this->create($baseInput);
 
-        $newObject = $this->create($input);
-
-        $this->update($newObject->id, json_decode($revision->payload, true));
+        $this->update($newObject->id, $revisionInput);
 
         return $newObject;
     }

--- a/src/Repositories/ModuleRepository.php
+++ b/src/Repositories/ModuleRepository.php
@@ -19,7 +19,7 @@ use PDO;
 abstract class ModuleRepository
 {
     use HandleDates, HandleBrowsers, HandleFieldsGroups;
-  
+
     /**
      * @var \A17\Twill\Models\Model
      */
@@ -337,6 +337,27 @@ abstract class ModuleRepository
         DB::transaction(function () use ($ids) {
             $this->model->setNewOrder($ids);
         }, 3);
+    }
+
+    /**
+     * @param mixed $id
+     * @return mixed
+     */
+    public function duplicate($id)
+    {
+        return true;
+
+        // TODO: Implement duplication logic
+
+        // return DB::transaction(function () use ($id) {
+        //     if (($object = $this->model->find($id)) === null) {
+        //         return false;
+        //     }
+
+        //     $object->duplicate();
+        //     $this->afterDuplicate($object);
+        //     return true;
+        // }, 3);
     }
 
     /**

--- a/src/Repositories/ModuleRepository.php
+++ b/src/Repositories/ModuleRepository.php
@@ -345,19 +345,20 @@ abstract class ModuleRepository
      */
     public function duplicate($id)
     {
-        return true;
 
-        // TODO: Implement duplication logic
+        if (($object = $this->model->find($id)) === null) {
+            return false;
+        }
 
-        // return DB::transaction(function () use ($id) {
-        //     if (($object = $this->model->find($id)) === null) {
-        //         return false;
-        //     }
+        $revision = $object->revisions()->orderBy('created_at', 'desc')->first();
 
-        //     $object->duplicate();
-        //     $this->afterDuplicate($object);
-        //     return true;
-        // }, 3);
+        $input = collect(json_decode($revision->payload, true))->only(['name', 'slug', 'languages'])->toArray();
+
+        $newObject = $this->create($input);
+
+        $this->update($newObject->id, json_decode($revision->payload, true));
+
+        return $newObject;
     }
 
     /**

--- a/src/RouteServiceProvider.php
+++ b/src/RouteServiceProvider.php
@@ -150,7 +150,7 @@ class RouteServiceProvider extends ServiceProvider
                 return ucfirst(Str::singular($s));
             }, $slugs));
 
-            $customRoutes = $defaults = ['reorder', 'publish', 'bulkPublish', 'browser', 'feature', 'bulkFeature', 'tags', 'preview', 'restore', 'bulkRestore', 'bulkDelete', 'restoreRevision'];
+            $customRoutes = $defaults = ['reorder', 'publish', 'bulkPublish', 'browser', 'feature', 'bulkFeature', 'tags', 'preview', 'restore', 'duplicate', 'bulkRestore', 'bulkDelete', 'restoreRevision'];
 
             if (isset($options['only'])) {
                 $customRoutes = array_intersect($defaults, (array) $options['only']);
@@ -176,6 +176,10 @@ class RouteServiceProvider extends ServiceProvider
 
                 if (in_array($route, ['restoreRevision'])) {
                     Route::get($routeSlug . "/{id}", $mapping);
+                }
+
+                if (in_array($route, ['duplicate'])) {
+                    Route::put($routeSlug . "/{id}", $mapping);
                 }
 
                 if (in_array($route, ['publish', 'feature', 'restore'])) {


### PR DESCRIPTION
RFC for entities duplication:

This is the first working version with an experimental approach on how to achieve content duplication.

1. Create a new item using the bare minimum attributes
2. Update this item using the latest revision from the original item
3. Trigger a notification and a redirect to the form page for the new element

Please feel free to shoot ideas and comments as this PR is still subject to change.

Requirements:

- Model should implement revisions
- Activate duplication on your Twill Controller for your model

`protected $indexOptions = [
        'duplicate' => true
    ];`