### PR TITLE
Add new fieldNote option to browser, medias and files fields

### DIFF
--- a/frontend/js/components/files/FileField.vue
+++ b/frontend/js/components/files/FileField.vue
@@ -1,5 +1,5 @@
 <template>
-  <a17-inputframe :error="error" :label="label" :locale="locale" @localize="updateLocale" :size="size" :name="name">
+  <a17-inputframe :error="error" :label="label" :locale="locale" @localize="updateLocale" :size="size" :name="name" :note="fieldNote">
     <div class="fileField">
       <table class="fileField__list" v-if="items.length">
         <draggable :tag="'tbody'" v-model="items">
@@ -57,6 +57,10 @@
         default: 1
       },
       note: {
+        type: String,
+        default: ''
+      },
+      fieldNote: {
         type: String,
         default: ''
       }

--- a/views/partials/form/_browser.blade.php
+++ b/views/partials/form/_browser.blade.php
@@ -16,11 +16,12 @@
     $max = $max ?? 1;
     $itemLabel = $itemLabel ?? strtolower($label);
     $note = $note ?? 'Add' . ($max > 1 ? " up to $max ". $itemLabel : ' one ' . Str::singular($itemLabel));
+    $fieldNote = $fieldNote ?? '';
     $sortable = $sortable ?? true;
     $wide = $wide ?? false;
 @endphp
 
-<a17-inputframe label="{{ $label }}" name="browsers.{{ $name }}">
+<a17-inputframe label="{{ $label }}" name="browsers.{{ $name }}" note="{{ $fieldNote }}">
     <a17-browserfield
         @include('twill::partials.form.utils._field_name')
         item-label="{{ $itemLabel }}"

--- a/views/partials/form/_files.blade.php
+++ b/views/partials/form/_files.blade.php
@@ -2,6 +2,7 @@
     $max = $max ?? 1;
     $itemLabel = $itemLabel ?? strtolower($label);
     $note = $note ?? 'Add' . ($max > 1 ? " up to $max $itemLabel" : ' one ' . Str::singular($itemLabel));
+    $fieldNote = $fieldNote ?? '';
 @endphp
 
 <a17-locale
@@ -11,6 +12,7 @@
         itemLabel: '{{ $itemLabel }}',
         @include('twill::partials.form.utils._field_name', ['asAttributes' => true])
         note: '{{ $note }}',
+        fieldNote: '{{ $fieldNote }}',
         max: {{ $max }}
     }"
 ></a17-locale>

--- a/views/partials/form/_medias.blade.php
+++ b/views/partials/form/_medias.blade.php
@@ -2,6 +2,7 @@
     $max = $max ?? 1;
     $required = $required ?? false;
     $note = $note ?? '';
+    $fieldNote = $fieldNote ?? '';
     $withAddInfo = $withAddInfo ?? true;
     $withVideoUrl = $withVideoUrl ?? true;
     $withCaption = $withCaption ?? true;
@@ -34,7 +35,7 @@
     @endpush
     @endunless
 @else
-    <a17-inputframe label="{{ $label }}" name="medias.{{ $name }}" @if ($required) :required="true" @endif>
+    <a17-inputframe label="{{ $label }}" name="medias.{{ $name }}" @if ($required) :required="true" @endif @if ($fieldNote) note="{{ $fieldNote }}" @endif>
         @if($max > 1 || $max == 0)
             <a17-slideshow
                 @include('twill::partials.form.utils._field_name')


### PR DESCRIPTION
The note option is already supported but displays inside of the field, not to the right of its label like on regular fields. This adds a new fieldNote option to be able to use both locations.