### PR TITLE
Fix child module redirect when adding new records in Laravel 6 / 7

### DIFF
--- a/src/Http/Controllers/Admin/ModuleController.php
+++ b/src/Http/Controllers/Admin/ModuleController.php
@@ -365,11 +365,22 @@ abstract class ModuleController extends Controller
             return $this->respondWithSuccess('Content saved. All good!');
         }
 
+        if ($parentModuleId) {
+            $params = [
+                Str::singular(explode('.', $this->moduleName)[0]) => $parentModuleId,
+                Str::singular(explode('.', $this->moduleName)[1]) => $item->id,
+            ];
+        } else {
+            $params = [
+                Str::singular($this->moduleName) => $item->id,
+            ];
+        }
+
         return $this->respondWithRedirect(moduleRoute(
             $this->moduleName,
             $this->routePrefix,
             'edit',
-            array_filter([$parentModuleId]) + [Str::singular($this->moduleName) => $item->id]
+            $params
         ));
     }
 


### PR DESCRIPTION
When using a child module with the dot notation, like `pages.sections`, parameters of the route to redirect to after creating child records were not working starting in Laravel 6 because of a change in the framework. This has been tested to work in Laravel < 6.