### PR TITLE
Improve tree reorder algorithm for nested modules

### DIFF
--- a/tests/stubs/modules/categories/Category.php
+++ b/tests/stubs/modules/categories/Category.php
@@ -30,49 +30,47 @@ class Category extends Model
     // add checkbox fields names here (published toggle is itself a checkbox)
     public $checkboxes = ['published'];
 
-    public static function saveTreeFromIds($nodesArray)
+    public static function saveTreeFromIds($nodeTree)
     {
-        $parentNodes = self::find(array_pluck($nodesArray, 'id'));
+        $nodeModels = self::all();
+        $nodeArrays = self::flattenTree($nodeTree);
 
-        if (is_array($nodesArray)) {
-            $position = 1;
-            foreach ($nodesArray as $nodeArray) {
-                $node = $parentNodes->where('id', $nodeArray['id'])->first();
-                $node->position = $position++;
-                $node->saveAsRoot();
-            }
-        }
+        foreach ($nodeArrays as $nodeArray) {
+            $nodeModel = $nodeModels->where('id', $nodeArray['id'])->first();
 
-        $parentNodes = self::find(array_pluck($nodesArray, 'id'));
-
-        self::rebuildTree($nodesArray, $parentNodes);
-    }
-
-    public static function rebuildTree($nodesArray, $parentNodes)
-    {
-        if (is_array($nodesArray)) {
-            foreach ($nodesArray as $nodeArray) {
-                $parent = $parentNodes->where('id', $nodeArray['id'])->first();
-                if (
-                    isset($nodeArray['children']) &&
-                    is_array($nodeArray['children'])
-                ) {
-                    $position = 1;
-                    $nodes = self::find(
-                        array_pluck($nodeArray['children'], 'id')
-                    );
-                    foreach ($nodeArray['children'] as $child) {
-                        //append the children to their (old/new)parents
-                        $descendant = $nodes
-                            ->where('id', $child['id'])
-                            ->first();
-                        $descendant->position = $position++;
-                        $descendant->parent_id = $parent->id;
-                        $descendant->save();
-                        self::rebuildTree($nodeArray['children'], $nodes);
-                    }
+            if ($nodeArray['parent_id'] === null) {
+                if (!$nodeModel->isRoot() || $nodeModel->position !== $nodeArray['position']) {
+                    $nodeModel->position = $nodeArray['position'];
+                    $nodeModel->saveAsRoot();
+                }
+            } else {
+                if ($nodeModel->position !== $nodeArray['position'] || $nodeModel->parent_id !== $nodeArray['parent_id']) {
+                    $nodeModel->position = $nodeArray['position'];
+                    $nodeModel->parent_id = $nodeArray['parent_id'];
+                    $nodeModel->save();
                 }
             }
         }
+    }
+
+    public static function flattenTree(array $nodeTree, int $parentId = null)
+    {
+        $nodeArrays = [];
+        $position = 0;
+
+        foreach ($nodeTree as $node) {
+            $nodeArrays[] = [
+                'id' => $node['id'],
+                'position' => $position++,
+                'parent_id' => $parentId,
+            ];
+
+            if (count($node['children']) > 0) {
+                $childArrays = self::flattenTree($node['children'], $node['id']);
+                $nodeArrays = array_merge($nodeArrays, $childArrays);
+            }
+        }
+
+        return $nodeArrays;
     }
 }


### PR DESCRIPTION
We recently started running into trouble (timeouts, editors noticing that pages haven't been reordered after refresh, etc.) with our nested module reorder algorithm. It seems that the number of pages in our website has grown too large for the current algorithm to handle comfortably. The algorithm in our website's codebase is almost identical to the one currently described here:

https://twill.io/docs/#nested-module

We decided to rewrite this algorithm to reduce the number of database calls that it needs to make. With this new code, there should be fewer `save()`, `saveAsRoot()`, and `self::find()` calls happening. The trade-off is that there is now an `all()` call, which could cause memory issues if there is truly a massive amount of items (thousands). But for a middling number of items (hundreds), this new algorithm should behave better than the old one.

We are submitting this PR to give back to Twill and to get a sanity check on our approach. It seems to be working well for us, but it'd be nice to get another pair of eyes on the code. Thanks!