### PR TITLE
Fix filesize limit uploader error display

### DIFF
--- a/frontend/js/components/media-library/Uploader.vue
+++ b/frontend/js/components/media-library/Uploader.vue
@@ -234,7 +234,7 @@
           this.loadingError(this.loadingMedias[index])
         } else {
           const media = {
-            id: this._uploader.methods.getUuid(id),
+            id: id ? this._uploader.methods.getUuid(id) : Math.floor(Math.random() * 1000),
             name: sanitizeFilename(name),
             progress: 0,
             error: true,


### PR DESCRIPTION
When the size limit validation is triggered the id is null so getUuid was failing. This change generates a random id for the error to display successfully.