### PR TITLE
Skip modal to create record

### DIFF
--- a/frontend/js/components/TitleEditor.vue
+++ b/frontend/js/components/TitleEditor.vue
@@ -7,9 +7,10 @@
         </a>
         <span v-else>{{ customTitle ? customTitle : title }}</span>
       </h2>
-      <a v-if="permalink || customPermalink" :href="fullUrl" target="_blank" class="titleEditor__permalink f--small">
+      <a v-if="(permalink || customPermalink) && !showModal" :href="fullUrl" target="_blank" class="titleEditor__permalink f--small">
         <span class="f--note f--external f--underlined--o">{{ visibleUrl | prettierUrl }}</span>
       </a>
+      <span v-if="showModal" class="f--note f--external f--underlined--o">{{ visibleUrl | prettierUrl }}</span>
 
       <!-- Editing modal -->
       <a17-modal class="modal--form" ref="editModal" :title="modalTitle" :forceLock="disabled">
@@ -49,6 +50,10 @@
         type: String,
         default: 'Missing title'
       },
+      showModal: {
+        type: Boolean,
+        default: false
+      },
       name: {
         default: 'title'
       },
@@ -70,6 +75,9 @@
         disabled: false
       }
     },
+    mounted: function () {
+      this.showModal && this.$refs.editModal.open()
+    },
     computed: {
       titleEditorClasses: function () {
         return {
@@ -77,6 +85,7 @@
         }
       },
       mode: function () {
+        if (this.showModal) return 'done'
         return this.title.length > 0 ? 'update' : 'create'
       },
       fullUrl: function () {

--- a/frontend/js/components/modals/ModalValidationButtons.vue
+++ b/frontend/js/components/modals/ModalValidationButtons.vue
@@ -5,7 +5,8 @@
         <a17-button type="submit" name="create" variant="validate" :disabled="isDisabled">{{ $trans('modal.create.button', 'Create') }}</a17-button>
         <a17-button type="submit" name="create-another" v-if="!isDisabled" variant="aslink-grey"><span>{{ $trans('modal.create.create-another', 'Create and add another') }}</span></a17-button>
       </template>
-      <a17-button type="submit" name="update" v-else="" variant="validate" :disabled="isDisabled">{{ $trans('modal.update.button', 'Update') }}</a17-button>
+      <a17-button type="submit" name="update" v-else-if="mode === 'update'" variant="validate" :disabled="isDisabled">{{ $trans('modal.update.button', 'Update') }}</a17-button>
+      <a17-button type="submit" name="done" v-else="" variant="validate" :disabled="isDisabled">{{ $trans('modal.done.button', 'Done') }}</a17-button>
     </a17-inputframe>
     <label v-if="activePublishState" :for="publishedName" class="switcher__button" :class="switcherClasses">
       <span v-if="isChecked" class="switcher__label">{{ textEnabled }}</span>

--- a/frontend/js/store/modules/form.js
+++ b/frontend/js/store/modules/form.js
@@ -113,10 +113,9 @@ const mutations = {
   [FORM.UPDATE_FORM_FIELD] (state, field) {
     let fieldValue = field.locale ? {} : null
     const fieldIndex = getFieldIndex(state.fields, field)
-
     // Update existing form field
     if (fieldIndex !== -1) {
-      if (field.locale) fieldValue = state.fields[fieldIndex].value
+      if (field.locale) fieldValue = state.fields[fieldIndex].value || {}
       // remove existing field
       state.fields.splice(fieldIndex, 1)
     }
@@ -279,7 +278,9 @@ const actions = {
     // - created blocks and repeaters
     const data = getFormData(rootState)
 
-    api.put(state.saveUrl, data, function (successResponse) {
+    const method = rootState.publication.createWithoutModal ? 'post' : 'put'
+
+    api[method](state.saveUrl, data, function (successResponse) {
       commit(FORM.UPDATE_FORM_LOADING, false)
 
       if (successResponse.data.hasOwnProperty('redirect')) {

--- a/frontend/js/store/modules/publication.js
+++ b/frontend/js/store/modules/publication.js
@@ -11,6 +11,7 @@ const state = {
   endDate: window[process.env.VUE_APP_NAME].STORE.publication.endDate || null,
   visibility: window[process.env.VUE_APP_NAME].STORE.publication.visibility || false,
   reviewProcess: window[process.env.VUE_APP_NAME].STORE.publication.reviewProcess || [],
+  createWithoutModal: window[process.env.VUE_APP_NAME].STORE.publication.createWithoutModal || false,
   saveType: undefined,
   visibilityOptions: [
     {
@@ -99,6 +100,9 @@ const getters = {
     return state.reviewProcess.filter(reviewProcess => reviewProcess.checked)
   },
   getSubmitOptions: state => {
+    if (state.createWithoutModal) {
+      return state.submitOptions.draft
+    }
     return (state.published || !state.withPublicationToggle) ? state.submitOptions[state.publishSubmit] : state.submitOptions.draft
   },
   isEnabledSubmitOption: (state, getters) => name => {

--- a/views/layouts/form.blade.php
+++ b/views/layouts/form.blade.php
@@ -19,6 +19,7 @@
 @endpush
 
 @php
+    $editModalTitle = $createWithoutModal ? 'Enter Title' : null;
     $editor = $editor ?? false;
     $translate = $translate ?? false;
     $translateTitle = $translateTitle ?? $translate ?? false;
@@ -47,6 +48,7 @@
                     custom-title="{{ $customTitle ?? '' }}"
                     custom-permalink="{{ $customPermalink ?? '' }}"
                     slot="title"
+                    @if($createWithoutModal) :show-modal="true" @endif
                     @if(isset($editModalTitle)) modal-title="{{ $editModalTitle }}" @endif
                 >
                     <template slot="modal-form">
@@ -130,6 +132,7 @@
     window['{{ config('twill.js_namespace') }}'].STORE.publication = {
         withPublicationToggle: {{ json_encode(($publish ?? true) && isset($item) && $item->isFillable('published')) }},
         published: {{ isset($item) && $item->published ? 'true' : 'false' }},
+        createWithoutModal: '{{ $createWithoutModal }}',
         withPublicationTimeframe: {{ json_encode(($schedule ?? true) && isset($item) && $item->isFillable('publish_start_date')) }},
         publishedLabel: '{{ $customPublishedLabel ?? twillTrans('twill::lang.main.published') }}',
         draftLabel: '{{ $customDraftLabel ?? twillTrans('twill::lang.main.draft') }}',

--- a/views/layouts/listing.blade.php
+++ b/views/layouts/listing.blade.php
@@ -9,6 +9,7 @@
     $nested = $nested ?? false;
     $bulkEdit = $bulkEdit ?? true;
     $create = $create ?? false;
+    $skipCreateModal = $skipCreateModal ?? false;
 
     $requestFilter = json_decode(request()->get('filter'), true) ?? [];
 @endphp
@@ -78,7 +79,14 @@
 
                     @if($create)
                         <div slot="additional-actions">
-                            <a17-button variant="validate" size="small" v-on:click="create">{{ twillTrans('twill::lang.listing.add-new-button') }}</a17-button>
+                            <a17-button
+                                variant="validate"
+                                size="small"
+                                @if($skipCreateModal) href={{$createUrl}} el="a" @endif
+                                @if(!$skipCreateModal) v-on:click="create" @endif
+                            >
+                                {{ twillTrans('twill::lang.listing.add-new-button') }}
+                            </a17-button>
                             @foreach($filterLinks as $link)
                                 <a17-button el="a" href="{{ $link['url'] ?? '#' }}" download="{{ $link['download'] ?? '' }}" rel="{{ $link['rel'] ?? '' }}" target="{{ $link['target'] ?? '' }}" variant="small secondary">{{ $link['label'] }}</a17-button>
                             @endforeach
@@ -148,6 +156,7 @@
         forceDelete: '{{ $forceDeleteUrl }}',
         bulkForceDelete: '{{ $bulkForceDeleteUrl }}',
         reorder: '{{ $reorderUrl }}',
+        create: '{{ $createUrl }}',
         feature: '{{ $featureUrl }}',
         bulkFeature: '{{ $bulkFeatureUrl }}',
         bulkDelete: '{{ $bulkDeleteUrl }}'


### PR DESCRIPTION
This update adds an option for skipping the modal to create a record this allows developers support complex form fields when creating a record such as blocks, repeaters etc.

To use set `skipCreateModal` to true in the `$indexOption` of the admin Module Controller

       protected $indexOptions = [
          'skipCreateModal' => true
       ];
        

A new route is added to a module for showing the create form i.e `/module/create.` 
If a user visits `/module/create` when  `skipCreateModal` is set to false, the user is redirected to the listing page with the `openCreate=1`