### PR TITLE
Make hydrateHandleBlocks recursive

### DIFF
--- a/src/Http/Controllers/Admin/BlocksController.php
+++ b/src/Http/Controllers/Admin/BlocksController.php
@@ -38,29 +38,18 @@ class BlocksController extends Controller
 
         $block = $blockRepository->buildFromCmsArray($request->except('activeLanguage'));
 
-        foreach ($block['blocks'] as $childKey => $childBlocks) {
-            foreach ($childBlocks as $index => $childBlock) {
-                $childBlock = $blockRepository->buildFromCmsArray($childBlock, true);
-                $childBlock['child_key'] = $childKey;
-                $childBlock['position'] = $index + 1;
-
-                $childBlocksList->push($childBlock);
-            }
-        }
-
+        $childBlocksList = $this->getChildrenBlock($block, $blockRepository);
         $block['blocks'] = $childBlocksList;
+        $block['children'] = $childBlocksList;
 
         $newBlock = $blockRepository->createForPreview($block);
 
-        $newBlock->id = 1;
+        $blockId = 1;
+        $newBlock->id = $blockId;
 
         $blocksCollection->push($newBlock);
 
-        $block['blocks']->each(function ($childBlock) use ($newBlock, $blocksCollection, $blockRepository) {
-            $childBlock['parent_id'] = $newBlock->id;
-            $newChildBlock = $blockRepository->createForPreview($childBlock);
-            $blocksCollection->push($newChildBlock);
-        });
+        $this->getChildrenPreview($block['blocks'], $blocksCollection, $newBlock->id, $blockId, $blockRepository);
 
         $renderedBlocks = $blocksCollection->where('parent_id', null)->map(function ($block) use ($blocksCollection, $viewFactory, $config) {
             if ($config->get('twill.block_editor.block_preview_render_childs') ?? true) {
@@ -98,6 +87,39 @@ class BlocksController extends Controller
         $viewFactory->inject('content', $renderedBlocks);
 
         return html_entity_decode($view);
+    }
+
+    protected function getChildrenBlock($block, $blockRepository)
+    {
+        $childBlocksList = Collection::make();
+        foreach ($block['blocks'] as $childKey => $childBlocks) {
+            foreach ($childBlocks as $index => $childBlock) {
+                $childBlock = $blockRepository->buildFromCmsArray($childBlock, true);
+                $childBlock['child_key'] = $childKey;
+                $childBlock['position'] = $index + 1;
+                if (!empty($childBlock['blocks'])) {
+                    $childBlock['children'] = $this->getChildrenBlock($childBlock, $blockRepository);
+                }
+                $childBlocksList->push($childBlock);
+            }
+        }
+        return $childBlocksList;
+    }
+
+    protected function getChildrenPreview($blocks, $blocksCollection, $parentId, &$blockId, $blockRepository)
+    {
+        $blocks->each(function ($childBlock) use (&$blockId, $parentId, $blocksCollection, $blockRepository) {
+            $childBlock['parent_id'] = $parentId;
+            $blockId++;
+            $newChildBlock = $blockRepository->createForPreview($childBlock);
+            $newChildBlock->id = $blockId;
+            if (!empty($childBlock['children'])) {
+                $childrenCollection = Collection::make();
+                $this->getChildrenPreview($childBlock['children'], $childrenCollection, $newChildBlock->id, $blockId, $blockRepository);
+                $newChildBlock->setRelation('children', $childrenCollection);
+            }
+            $blocksCollection->push($newChildBlock);
+        });
     }
 
     /**

--- a/src/Repositories/Behaviors/HandleBlocks.php
+++ b/src/Repositories/Behaviors/HandleBlocks.php
@@ -107,7 +107,7 @@ trait HandleBlocks
     private function getBlocks($object, $fields)
     {
         $blocks = Collection::make();
-        if (isset($fields['blocks']) && is_iterable ($fields['blocks'])) {
+        if (isset($fields['blocks']) && is_iterable($fields['blocks'])) {
 
             foreach ($fields['blocks'] as $index => $block) {
                 $block = $this->buildBlock($block, $object);

--- a/src/Repositories/Behaviors/HandleBlocks.php
+++ b/src/Repositories/Behaviors/HandleBlocks.php
@@ -107,7 +107,7 @@ trait HandleBlocks
     private function getBlocks($object, $fields)
     {
         $blocks = Collection::make();
-        if (isset($fields['blocks']) && is_iterable($fields['blocks'])) {
+        if (isset($fields['blocks']) && is_array($fields['blocks'])) {
 
             foreach ($fields['blocks'] as $index => $block) {
                 $block = $this->buildBlock($block, $object);


### PR DESCRIPTION
If you put a repeater in a repeater the preview and editor will not work well because the hydrateHandleBlocks only handle the first set of children.

With these changes I made the hydrateHandleBlocks recursive so you can have an an unlimited number of nested blocks.

I've also updated the BlockController::preview to be recursive too.