### PR TITLE
Fix scheme being added twice when APP_URL has the scheme

### DIFF
--- a/src/Http/Controllers/Admin/ModuleController.php
+++ b/src/Http/Controllers/Admin/ModuleController.php
@@ -1512,7 +1512,13 @@ abstract class ModuleController extends Controller
      */
     protected function getPermalinkBaseUrl()
     {
-        return $this->request->getScheme() . '://' . Config::get('app.url') . '/'
+        $appUrl = Config::get('app.url');
+
+        if (blank(parse_url($appUrl)['scheme'] ?? null)) {
+            $appUrl =  $this->request->getScheme() . '://' . $appUrl;
+        }
+
+        return $appUrl . '/'
             . ($this->moduleHas('translations') ? '{language}/' : '')
             . ($this->moduleHas('revisions') ? '{preview}/' : '')
             . ($this->permalinkBase ?? $this->moduleName)


### PR DESCRIPTION
If we add the scheme to `APP_URL` Twill's will add a second one: `https://https://...` to the permalinks.

Since the scheme on `APP_URL` is needed by Laravel to correctly build URLs on CLI, Queues, Scheduler, and maybe other non-web services, here's a quick fix for it.