### PR TITLE
Wrap selector input string field values in quotes

### DIFF
--- a/views/partials/form/utils/_selector_input_store.blade.php
+++ b/views/partials/form/utils/_selector_input_store.blade.php
@@ -9,6 +9,7 @@ window['{{ config('twill.js_namespace') }}'].STORE.form.fields.push({
                     @endphp
                 @endif
                 @if (is_numeric($formFieldsValue)) {{ $formFieldsValue }}
+                @elseif(is_string($formFieldsValue)) '{{ $formFieldsValue }}'
                 @else {!! $formFieldsValue !!}
                 @endif
            @else


### PR DESCRIPTION
This PR adds support for selector input string values.

Before this change, using string values in selectors would output the following store code: 

```js
window['TWILL'].STORE.form.fields.push({
    name: 'type',
    value: primary
})
```

and throw the following error:
```
Uncaught ReferenceError: primary is not defined
```