### PR TITLE
New behavior to allow saving repeaters into json columns

### DIFF
--- a/src/Repositories/Behaviors/HandleJsonRepeaters.php
+++ b/src/Repositories/Behaviors/HandleJsonRepeaters.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace A17\Twill\Repositories\Behaviors;
+
+use Carbon\Carbon;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+
+/**
+ *
+ * Save repeaters in a json column instead of a new model.
+ *
+ * This trait is not intended to replace main repeaters but to give a quick
+ * and easy alternative for simple elements where creating a new table might be an overkill.
+ *
+ * Simply define an array with the repeater names on your repository:
+ * protected $jsonRepeaters = [ 'REPEATER_NAME_1', 'REPEATER_NAME_2', ... ]
+ *
+ * Names must be the same as the ones you added in your `repeaters` attribute on `config\twill.php`
+ *
+ * Supported: Input, WYSIWYG, textarea, browsers.
+ * Not supported: Medias, Files, repeaters.
+ *
+ */
+
+trait HandleJsonRepeaters
+{
+
+    /**
+     * @param \A17\Twill\Models\Model $object
+     * @param array $fields
+     * @return string[]
+     */
+    public function prepareFieldsBeforeSaveHandleJsonRepeaters($object, $fields)
+    {
+        foreach ($this->jsonRepeaters as $repeater) {
+            if (isset($fields['repeaters'][$repeater])) {
+                $fields[$repeater] = $fields['repeaters'][$repeater];
+            }
+        }
+
+        return $fields;
+    }
+
+    /**
+     * @param \A17\Twill\Models\Model $object
+     * @param array $fields
+     * @return string[]
+     */
+    public function getFormFieldsHandleJsonRepeaters($object, $fields)
+    {
+
+        foreach($this->jsonRepeaters as $repeater) {
+            if (isset($fields[$repeater]) && !empty($fields[$repeater])) {
+                $fields = $this->getJsonRepeater($fields, $repeater, $fields[$repeater]);
+            }
+        }
+
+        return $fields;
+    }
+
+    public function getJsonRepeater($fields, $repeaterName, $serializedData) {
+        $repeatersFields = [];
+        $repeatersBrowsers = [];
+        $repeatersConfig = config('twill.block_editor.repeaters');
+
+
+        foreach($serializedData as $index => $repeaterItem) {
+            $id = $repeaterItem['id'] ?? $index;
+
+            $repeaters[] = [
+                'id' => $id,
+                'type' => $repeatersConfig[$repeaterName]['component'],
+                'title' => $repeatersConfig[$repeaterName]['title'],
+            ];
+
+            if (isset($repeaterItem['browsers'])) {
+                foreach ($repeaterItem['browsers'] as $key => $values) {
+                    $repeatersBrowsers["blocks[$id][$key]"] = $values;
+                }
+            }
+
+            $itemFields = Arr::except($repeaterItem, ['id', 'repeaters', 'files', 'medias', 'browsers', 'blocks']);
+
+            foreach($itemFields as $index => $value) {
+                $repeatersFields[] = [
+                    'name' => "blocks[$id][$index]",
+                    'value' => $value
+                ];
+            }
+        }
+
+        $fields['repeaters'][$repeaterName] = $repeaters;
+        $fields['repeaterFields'][$repeaterName] = $repeatersFields;
+        $fields['repeaterBrowsers'][$repeaterName] = $repeatersBrowsers;
+
+        return $fields;
+    }
+
+}


### PR DESCRIPTION
This trait is not intended to replace main repeaters but to give a quick and easy alternative for simple elements where creating a new table might be an overkill.

**Open for discussion as to which UI elements to support.**

Supported: Input, WYSIWYG, text areas, browsers.
Not supported: Files, repeaters, medias.

1. Define the repeater in your `config/twill.php` file inside `block_editor.repeaters`.

2.  Add a json column to your table and define them in your model

```
protected $fillable = [
    'repeater_name_column',
];

protected $casts = [
    'repeater_name_column' => 'array'
];
```

3. Include the trait in your repository, use it, and define the attribute `jsonRepeaters` as an array with your repeater names:

```
use A17\Twill\Repositories\Behaviors\HandleJsonRepeaters;
// ...

protected $jsonRepeaters = [ 'REPEATER_NAME_1', 'REPEATER_NAME_2', ... ];
```

4. Use repeater as usual

@formField('repeater', ['type' => 'repeater_name_column'])
