### PR TITLE
Pass the block currently being rendered to the view

### DIFF
--- a/src/Http/Controllers/Admin/BlocksController.php
+++ b/src/Http/Controllers/Admin/BlocksController.php
@@ -90,7 +90,9 @@ class BlocksController extends Controller
         })->implode('');
 
         $view = $viewFactory->exists($config->get('twill.block_editor.block_single_layout'))
-        ? $viewFactory->make($config->get('twill.block_editor.block_single_layout'))
+        ? $viewFactory->make($config->get('twill.block_editor.block_single_layout'), [
+            'block' => $block,
+        ])
         : $viewFactory->make('twill::errors.block_layout', [
             'view' => $config->get('twill.block_editor.block_single_layout'),
         ]);


### PR DESCRIPTION
Allow the `block_single_layout` view to also render the block by itself, if needed.