### PR TITLE
Add admin title tag suffix to config

### DIFF
--- a/config/twill.php
+++ b/config/twill.php
@@ -25,6 +25,16 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Application Admin Title Suffix
+    |--------------------------------------------------------------------------
+    |
+    | This value is added to the title tag of your Admin application.
+    |
+     */
+    'admin_app_title_suffix' => env('ADMIN_APP_TITLE_SUFFIX', 'Admin'),
+
+    /*
+    |--------------------------------------------------------------------------
     | Admin subdomain routing support
     |--------------------------------------------------------------------------
     |

--- a/views/partials/head.blade.php
+++ b/views/partials/head.blade.php
@@ -3,7 +3,7 @@
 <meta http-equiv="X-UA-Compatible" content="IE=Edge">
 <meta name="robots" content="noindex,nofollow" />
 
-<title>{{ config('app.name') }}</title>
+<title>{{ config('app.name') }} {{ config('twill.admin_app_title_suffix') }}</title>
 
 <!-- Fonts -->
 @if(app()->isProduction())


### PR DESCRIPTION
It would be helpful to have an indicator in the title tag of whether I'm in the admin panel or on the actual page. An addition to the header-partial and twill config would keep it simple but customisable.