### PR TITLE
Select field - fix vue.js error 

### DIFF
--- a/views/partials/form/utils/_selector_input_store.blade.php
+++ b/views/partials/form/utils/_selector_input_store.blade.php
@@ -9,6 +9,7 @@ window['{{ config('twill.js_namespace') }}'].STORE.form.fields.push({
                     @endphp
                 @endif
                 @if (is_numeric($formFieldsValue)) {{ $formFieldsValue }}
+                @elseif(is_string($formFieldsValue)) '{{ $formFieldsValue }}'
                 @else {!! $formFieldsValue !!}
                 @endif
            @else


### PR DESCRIPTION
Check if $formFieldsValue is a string, if so we escape it correctly. Didn't find any conflicts in my app but let me know. 
Fixes #175 