### PR TITLE
Add confirmation to checkbox and radio

### DIFF
--- a/frontend/js/components/SingleCheckbox.vue
+++ b/frontend/js/components/SingleCheckbox.vue
@@ -8,8 +8,8 @@
     </div>
     <template v-if="requireConfirmation">
       <a17-dialog ref="warningConfirm" modal-title="Confirm" confirm-label="Confirm">
-        <p class="modal--tiny-title"><strong>{{ warningConfirmTitle }}</strong></p>
-        <p>{{ warningConfirmMessage }}</p>
+        <p class="modal--tiny-title"><strong>{{ confirmTitleText }}</strong></p>
+        <p>{{ confirmMessageText }}</p>
       </a17-dialog>
     </template>
   </a17-inputframe>
@@ -17,12 +17,13 @@
 
 <script>
   import randKeyMixin from '@/mixins/randKey'
-  import InputframeMixin from '@/mixins/inputFrame'
   import FormStoreMixin from '@/mixins/formStore'
+  import InputframeMixin from '@/mixins/inputFrame'
+  import ConfirmationMixin from '@/mixins/confirmationMixin'
 
   export default {
     name: 'A17SingleCheckbox',
-    mixins: [randKeyMixin, InputframeMixin, FormStoreMixin],
+    mixins: [randKeyMixin, InputframeMixin, FormStoreMixin, ConfirmationMixin],
     props: {
       name: {
         type: String,
@@ -31,18 +32,6 @@
       initialValue: {
         type: Boolean,
         default: true // bold
-      },
-      requireConfirmation: {
-        type: Boolean,
-        default: false
-      },
-      confirmMessageText: {
-        type: String,
-        default: ''
-      },
-      confirmTitleText: {
-        type: String,
-        default: ''
       },
       theme: {
         type: String,
@@ -61,12 +50,6 @@
     computed: {
       uniqId: function () {
         return this.name + '_' + this.randKey
-      },
-      warningConfirmMessage: function () {
-        return this.confirmMessageText || 'Are you sure you want to change this option ?'
-      },
-      warningConfirmTitle: function () {
-        return this.confirmTitleText || 'Confirm selection'
       },
       checkboxClasses: function () {
         return [

--- a/frontend/js/components/SingleCheckbox.vue
+++ b/frontend/js/components/SingleCheckbox.vue
@@ -6,6 +6,12 @@
         <label class="checkbox__label" :for="uniqId" @click.prevent="changeCheckbox">{{ label }} <span class="checkbox__icon"><span v-svg symbol="check"></span></span></label>
       </span>
     </div>
+    <template v-if="requireConfirmation">
+      <a17-dialog ref="warningConfirm" modal-title="Confirm" confirm-label="Confirm">
+        <p class="modal--tiny-title"><strong>{{ warningConfirmTitle }}</strong></p>
+        <p>{{ warningConfirmMessage }}</p>
+      </a17-dialog>
+    </template>
   </a17-inputframe>
 </template>
 
@@ -26,6 +32,18 @@
         type: Boolean,
         default: true // bold
       },
+      requireConfirmation: {
+        type: Boolean,
+        default: false
+      },
+      confirmMessageText: {
+        type: String,
+        default: ''
+      },
+      confirmTitleText: {
+        type: String,
+        default: ''
+      },
       theme: {
         type: String,
         default: '' // bold
@@ -43,6 +61,12 @@
     computed: {
       uniqId: function () {
         return this.name + '_' + this.randKey
+      },
+      warningConfirmMessage: function () {
+        return this.confirmMessageText || 'Are you sure you want to change this option ?'
+      },
+      warningConfirmTitle: function () {
+        return this.confirmTitleText || 'Confirm selection'
       },
       checkboxClasses: function () {
         return [
@@ -68,7 +92,13 @@
         this.checkedValue = newValue
       },
       changeCheckbox: function () {
-        this.checkedValue = !this.checkedValue
+        if (this.requireConfirmation) {
+          this.$refs.warningConfirm.open(() => {
+            this.checkedValue = !this.checkedValue
+          })
+        } else {
+          this.checkedValue = !this.checkedValue
+        }
       }
     }
   }

--- a/frontend/js/components/SingleSelect.vue
+++ b/frontend/js/components/SingleSelect.vue
@@ -21,8 +21,8 @@
     </template>
     <template v-if="requireConfirmation">
       <a17-dialog ref="warningConfirm" modal-title="Confirm" confirm-label="Confirm">
-        <p class="modal--tiny-title"><strong>{{ warningConfirmTitle }}</strong></p>
-        <p>{{ warningConfirmMessage }}</p>
+        <p class="modal--tiny-title"><strong>{{ confirmTitleText }}</strong></p>
+        <p>{{ confirmMessageText }}</p>
       </a17-dialog>
     </template>
   </div>
@@ -33,24 +33,13 @@
   import FormStoreMixin from '@/mixins/formStore'
   import InputframeMixin from '@/mixins/inputFrame'
   import AttributesMixin from '@/mixins/addAttributes'
+  import ConfirmationMixin from '@/mixins/confirmationMixin'
 
   export default {
     name: 'A17Singleselect',
-    mixins: [randKeyMixin, InputframeMixin, FormStoreMixin, AttributesMixin],
+    mixins: [randKeyMixin, InputframeMixin, FormStoreMixin, AttributesMixin, ConfirmationMixin],
     props: {
       name: {
-        type: String,
-        default: ''
-      },
-      requireConfirmation: {
-        type: Boolean,
-        default: false
-      },
-      confirmMessageText: {
-        type: String,
-        default: ''
-      },
-      confirmTitleText: {
         type: String,
         default: ''
       },
@@ -84,12 +73,6 @@
           this.grid ? 'singleselector--grid' : '',
           this.inline ? 'singleselector--inline' : ''
         ]
-      },
-      warningConfirmMessage: function () {
-        return this.confirmMessageText || 'Are you sure you want to change this option ?'
-      },
-      warningConfirmTitle: function () {
-        return this.confirmTitleText || 'Confirm selection'
       },
       selectedValue: {
         get: function () {

--- a/frontend/js/components/SingleSelect.vue
+++ b/frontend/js/components/SingleSelect.vue
@@ -19,6 +19,12 @@
         <slot name="addModal"></slot>
       </a17-modal-add>
     </template>
+    <template v-if="requireConfirmation">
+      <a17-dialog ref="warningConfirm" modal-title="Confirm" confirm-label="Confirm">
+        <p class="modal--tiny-title"><strong>{{ warningConfirmTitle }}</strong></p>
+        <p>{{ warningConfirmMessage }}</p>
+      </a17-dialog>
+    </template>
   </div>
 </template>
 
@@ -33,6 +39,18 @@
     mixins: [randKeyMixin, InputframeMixin, FormStoreMixin, AttributesMixin],
     props: {
       name: {
+        type: String,
+        default: ''
+      },
+      requireConfirmation: {
+        type: Boolean,
+        default: false
+      },
+      confirmMessageText: {
+        type: String,
+        default: ''
+      },
+      confirmTitleText: {
         type: String,
         default: ''
       },
@@ -67,6 +85,12 @@
           this.inline ? 'singleselector--inline' : ''
         ]
       },
+      warningConfirmMessage: function () {
+        return this.confirmMessageText || 'Are you sure you want to change this option ?'
+      },
+      warningConfirmTitle: function () {
+        return this.confirmTitleText || 'Confirm selection'
+      },
       selectedValue: {
         get: function () {
           return this.value
@@ -89,7 +113,13 @@
         }
       },
       changeRadio: function (value) {
-        this.selectedValue = value
+        if (this.requireConfirmation) {
+          this.$refs.warningConfirm.open(() => {
+            this.selectedValue = value
+          })
+        } else {
+          this.selectedValue = value
+        }
       },
       uniqId: function (value, index) {
         return this.name + '_' + value + '-' + (this.randKey * (index + 1))

--- a/frontend/js/mixins/confirmationMixin.js
+++ b/frontend/js/mixins/confirmationMixin.js
@@ -1,0 +1,16 @@
+export default {
+  props: {
+    requireConfirmation: {
+      type: Boolean,
+      default: false
+    },
+    confirmMessageText: {
+      type: String,
+      default: 'Are you sure you want to change this option ?'
+    },
+    confirmTitleText: {
+      type: String,
+      default: 'Confirm selection'
+    }
+  }
+}

--- a/views/partials/form/_checkbox.blade.php
+++ b/views/partials/form/_checkbox.blade.php
@@ -4,6 +4,9 @@
     $default = $default ?? false;
     $inModal = $fieldsInModal ?? false;
     $disabled = $disabled ?? false;
+    $confirmMessageText = $confirmMessageText ?? '';
+    $confirmTitleText = $confirmTitleText ?? '';
+    $requireConfirmation = $requireConfirmation ?? false;
 @endphp
 
 <a17-singlecheckbox
@@ -12,6 +15,9 @@
     :initial-value="{{ $default ? 'true' : 'false' }}"
     @if ($note) note='{{ $note }}' @endif
     @if ($disabled) disabled @endif
+    @if ($requireConfirmation) :require-confirmation="true" @endif
+    @if ($confirmMessageText) confirm-message-text="{{ $confirmMessageText }}"  @endif
+    @if ($confirmTitleText) confirm-title-text="{{ $confirmTitleText }}"  @endif
     :has-default-store="true"
     in-store="currentValue"
 ></a17-singlecheckbox>

--- a/views/partials/form/_radios.blade.php
+++ b/views/partials/form/_radios.blade.php
@@ -16,6 +16,9 @@
     $moduleName = $moduleName ?? null;
     $storeUrl = $storeUrl ?? '';
     $inModal = $fieldsInModal ?? false;
+    $confirmMessageText = $confirmMessageText ?? '';
+    $confirmTitleText = $confirmTitleText ?? '';
+    $requireConfirmation = $requireConfirmation ?? false;
 @endphp
 
 <a17-singleselect
@@ -28,7 +31,10 @@
     @if ($required) :required="true" @endif
     @if ($inModal) :in-modal="true" @endif
     @if ($addNew) add-new='{{ $storeUrl }}' @elseif ($note) note='{{ $note }}' @endif
+    @if ($confirmMessageText) confirm-message-text="{{ $confirmMessageText }}"  @endif
+    @if ($confirmTitleText) confirm-title-text="{{ $confirmTitleText }}"  @endif
     :has-default-store="true"
+    @if ($requireConfirmation) :require-confirmation="true" @endif
     in-store="value"
 >
     @if($addNew)


### PR DESCRIPTION
This adds the ability for developers to enable a confirmation dialog on a checkbox or radio field.

````
@formField('radios', [
        'name' => 'discipline',
        'label' => 'Discipline',
        'default' => 'civic',
        'inline' => true,
        'requireConfirmation' => true,
        'confirmMessageText' => 'are you sure you want to change option ?',
        'confirmTitleText' => 'confirm change',
        'options' => [
            [
                'value' => 'arts',
                'label' => 'Arts & Culture'
            ],
            [
                'value' => 'finance',
                'label' => 'Banking & Finance'
            ],
            [
                'value' => 'civic',
                'label' => 'Civic & Public'
            ],
        ]
    ])
````

confirmMessageText and confirmTitleText are optional 