### PR TITLE
Dont unescape options

### DIFF
--- a/views/partials/form/_multi_select.blade.php
+++ b/views/partials/form/_multi_select.blade.php
@@ -39,7 +39,7 @@
     <a17-vselect
         label="{{ $label }}"
         @include('twill::partials.form.utils._field_name')
-        :options='{!! json_encode($options) !!}'
+        :options="{{ json_encode($options) }}"
         @if ($emptyText ?? false) empty-text="{{ $emptyText }}" @endif
         @if ($placeholder ?? false) placeholder="{{ $placeholder }}" @endif
         @if ($inModal) :in-modal="true" @endif


### PR DESCRIPTION
HTML is valid when `$options` is unescaped, resulting in vue component not loading properly.