### PR TITLE
List all blocks including repeaters

### DIFF
--- a/src/Repositories/Behaviors/HandleBlocks.php
+++ b/src/Repositories/Behaviors/HandleBlocks.php
@@ -170,7 +170,7 @@ trait HandleBlocks
 
         if ($object->has('blocks')) {
 
-            $blocksList = app(BlockCollection::class)->getBlockList()->keyBy('name');
+            $blocksList = app(BlockCollection::class)->list()->keyBy('name');
 
             foreach ($object->blocks as $block) {
 


### PR DESCRIPTION
Fixes a bug where blocks wouldn't render previously stored repeater fields even though they were in the database