### PR TITLE
Settings with media files without media translations can no longer be saved in 2.1.0

### DIFF
--- a/src/Repositories/SettingRepository.php
+++ b/src/Repositories/SettingRepository.php
@@ -123,7 +123,7 @@ class SettingRepository extends ModuleRepository
                 }
             } else {
                 $medias =  [
-                    $role => Collection::make($settingsFields['medias'][$role])->mapWithKeys(function ($media, $key) {
+                    $role => Collection::make($settingsFields['medias'][$role])->map(function ($media) {
                         return json_decode($media, true);
                     })->values()->filter()->toArray(),
                 ];


### PR DESCRIPTION
It was probably result of copy-pasting in https://github.com/area17/twill/pull/620 but now it is impossible to save settings with media (without translations)

This is where the "map" was replaced with "mapWithKeys"

https://github.com/area17/twill/pull/620/commits/dd377405ff62170771baccebd9264a19ee70bccc#diff-66dd7c6f81a3f6bf7bcc99a9804893aaL106