### PR TITLE
Allow files in s3 buckets with root directories to not have their root directory paths duplicated

### DIFF
--- a/src/Repositories/FileRepository.php
+++ b/src/Repositories/FileRepository.php
@@ -48,9 +48,16 @@ class FileRepository extends ModuleRepository
      */
     public function prepareFieldsBeforeCreate($fields)
     {
-        if (!isset($fields['size'])) {
-            $fields['size'] = Storage::disk(Config::get('twill.file_library.disk'))->size($fields['uuid']);
-        }
+            // if a disk has a root other than / set it'll be re-applied when calculating the file path so we need to strip it here...
+            $diskName = config('twill.file_library.disk');
+            $diskConfig = config('filesystems.disks.'.$diskName);
+            $diskRoot = $diskConfig['root'] ?? false;
+
+            if($diskConfig['driver'] === 's3' && $diskRoot){
+                $fields['uuid'] = ltrim($fields['uuid'], $diskRoot);
+            }
+
+            $fields['size'] = Storage::disk($diskName)->size($fields['uuid']);
 
         return $fields;
     }


### PR DESCRIPTION
If an s3 disk has a root directory that isn't / the root directory will be reapplied when calculating the file path. So in those instances we need to strip the duplicated disk root.