### PR TITLE
Wysiwyg with Quill : set default styling for italic and underline in the editor

### DIFF
--- a/frontend/js/components/Wysiwyg.vue
+++ b/frontend/js/components/Wysiwyg.vue
@@ -368,6 +368,14 @@
         font-weight:700;
       }
 
+      i, p i, li i, em, p em, li em {
+        font-style: italic;
+      }
+
+      u, p u, li u {
+        text-decoration: underline;
+      }
+
       p, ul, ol, h1, h2, h3, h4, h5 {
         margin-bottom: 1em;
       }


### PR DESCRIPTION
Right now italic texts are not showing italicized in the editor if the text is inside a list (`ul > li`).