### PR TITLE
chore(admin.stub): Easier to use starter route

### DIFF
--- a/src/Commands/stubs/admin.stub
+++ b/src/Commands/stubs/admin.stub
@@ -1,3 +1,6 @@
 <?php
 
-// Register Twill routes here (eg. Route::module('posts'))
+use Illuminate\Support\Facades\Route;
+
+// Register Twill routes here eg.
+// Route::module('posts');


### PR DESCRIPTION
Included the default Route facade for better intellisense and added the `Route::module('posts');` on a seperate line with a semi colon so you can just clear the text comment and uncomment the starter route.

Yes, I'm really that lazy.