### PR TITLE
Preserve blocks order when calling a block editor

### DIFF
--- a/src/Helpers/helpers.php
+++ b/src/Helpers/helpers.php
@@ -205,7 +205,7 @@ if (!function_exists('generate_list_of_allowed_blocks')) {
             return $block['source'] !== A17\Twill\Services\Blocks\Block::SOURCE_TWILL;
         });
 
-        return $blockList->filter(
+        $finalBlockList = $blockList->filter(
             function ($block) use ($blocks, $groups, $appBlocksList) {
                 if ($block['group'] === A17\Twill\Services\Blocks\Block::SOURCE_TWILL) {
                     if (!collect(
@@ -226,6 +226,15 @@ if (!function_exists('generate_list_of_allowed_blocks')) {
                 return (filled($blocks) ? collect($blocks)->contains($block['name']) : true)
                     && (filled($groups) ? collect($groups)->contains($block['group']) : true);
             }
-        )->toArray();
+        );
+
+        // Sort them by the original definition
+        $sorted = $finalBlockList->sortBy(function($b) use ($blocks) {
+            return collect($blocks)->search(function($id, $key) use ($b) {
+                return $id == $b['name'];
+            });
+        })->values()->toArray();
+
+        return $sorted;
     }
 }


### PR DESCRIPTION
Blocks are listed in a pseudo randomized way, we should preserve the order given when calling the block editor.