### PR TITLE
Artisan make:module (deprecated) should prompt for input

### DIFF
--- a/src/Commands/ModuleMakeDeprecated.php
+++ b/src/Commands/ModuleMakeDeprecated.php
@@ -35,9 +35,15 @@ class ModuleMakeDeprecated extends Command
      */
     public function handle()
     {
+        $options = collect($this->options());
+
+        if (!$options['no-interaction']) {
+            $options = $options->except('no-interaction');
+        }
+
         $this->call('twill:make:module', [
             'moduleName' => $this->argument('moduleName'),
-        ] + collect($this->options())->mapWithKeys(function ($value, $key) {
+        ] + $options->mapWithKeys(function ($value, $key) {
             return ["--{$key}" => $value];
         })->toArray());
     }


### PR DESCRIPTION
There is a bug in Laravel when passing `options()` programatically where if the `no-interaction` option is present in the ArrayInput, the framework will run the command as no-interaction. I have created a PR for it here: [#33950](https://github.com/laravel/framework/pull/33950). This presents an issue with the `artisan twill:module` deprecated command as no matter what features you would like included with the module, it will enable all of them as if it was default. No prompts are shown.

As per the current documentation, it is advised to use `artisan twill:module` rather than `artisan twill:make:module` which is the latest and working command. Regardless, this PR should act as a workaround for the issue.

With this PR, the prompts should now show for the user to confirm which features they would like in their new module.