### PR TITLE
Fix twill throwing error on uploading file with cyrillic name

### DIFF
--- a/src/Helpers/media_library_helpers.php
+++ b/src/Helpers/media_library_helpers.php
@@ -50,6 +50,43 @@ if (!function_exists('bytesToHuman')) {
     }
 }
 
+if (!function_exists('cyrillicToLatin')) {
+    /**
+     * @param string $str
+     * @return bool|string
+     */
+    function cyrillicToLatin($str)
+    {
+      $tr = [
+        // Russian
+        "А" => "a", "Б" => "b", "В" => "v", "Г" => "g", "Д" => "d",
+        "Е" => "e", "Ё" => "yo", "Ж" => "zh", "З" => "z", "И" => "i",
+        "Й" => "j", "К" => "k", "Л" => "l", "М" => "m", "Н" => "n",
+        "О" => "o", "П" => "p", "Р" => "r", "С" => "s", "Т" => "t",
+        "У" => "u", "Ф" => "f", "Х" => "kh", "Ц" => "ts", "Ч" => "ch",
+        "Ш" => "sh", "Щ" => "sch", "Ъ" => "", "Ы" => "y", "Ь" => "",
+        "Э" => "e", "Ю" => "yu", "Я" => "ya", "а" => "a", "б" => "b",
+        "в" => "v", "г" => "g", "д" => "d", "е" => "e", "ё" => "yo",
+        "ж" => "zh", "з" => "z", "и" => "i", "й" => "j", "к" => "k",
+        "л" => "l", "м" => "m", "н" => "n", "о" => "o", "п" => "p",
+        "р" => "r", "с" => "s", "т" => "t", "у" => "u", "ф" => "f",
+        "х" => "kh", "ц" => "ts", "ч" => "ch", "ш" => "sh", "щ" => "sch",
+        "ъ" => "", "ы" => "y", "ь" => "", "э" => "e", "ю" => "yu",
+        "я" => "ya",
+        // Ukrainian
+        'Ґ' => 'G', 'Є' => 'Ye', 'І' => 'I', 'Ї' => 'Yi', 'ґ' => 'g',
+        'є' => 'ie', 'і' => 'i', 'ї' => 'i', 'і́' => 'i',
+        // Kazakh
+        'Ә' => 'A', 'Ғ' => 'G', 'Қ' => 'Q', 'Ң' => 'N', 'Ө' => 'O',
+        'Ұ' => 'U', 'Ү' => 'U', 'Һ' => 'H', 'І' => 'I', 'ә' => 'a',
+        'ғ' => 'g', 'қ' => 'q', 'ң' => 'n', 'ө' => 'o', 'ұ' => 'u',
+        'ү' => 'u', 'һ' => 'h', 'і' => 'i',
+      ];
+
+      return strtr($str, $tr);
+    }
+}
+
 if (!function_exists('replaceAccents')) {
     /**
      * @param string $str
@@ -57,7 +94,7 @@ if (!function_exists('replaceAccents')) {
      */
     function replaceAccents($str)
     {
-        return iconv('UTF-8', 'ASCII//TRANSLIT', $str);
+        return iconv('UTF-8', 'ASCII//TRANSLIT', cyrillicToLatin($str));
     }
 }
 


### PR DESCRIPTION
### The Problem
Uploading files named with cyrillic symbols fails with error `iconv(): Detected an illegal character in input string`.
![image](https://user-images.githubusercontent.com/11737104/90907616-03e42f00-e3f5-11ea-83a5-4e70ace42210.png)
![image](https://user-images.githubusercontent.com/11737104/90907727-2aa26580-e3f5-11ea-9feb-edb409626b5a.png)

### The Fix
I've added transliterator function that transliterates cyrillic symbols to latin.

