### PR TITLE
Add Glide cloud sources to allow Glide and S3 integration

### DIFF
--- a/src/Services/Cloud/Aws.php
+++ b/src/Services/Cloud/Aws.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace A17\Twill\Services\Cloud;
+
+use Aws\S3\S3Client;
+use Illuminate\Support\Str;
+use League\Flysystem\Filesystem;
+use League\Flysystem\AwsS3v3\AwsS3Adapter;
+
+class Aws
+{
+    public function filesystemFactory($source)
+    {
+        $config = $this->getConfigFor($source);
+
+        $client = new S3Client($config);
+
+        $adapter = new AwsS3Adapter($client, $config['bucket'], $config['root']);
+
+        return new Filesystem($adapter);
+    }
+
+    public function getConfigFor($disk)
+    {
+        return [
+            'credentials' => [
+                'key' => $this->config($disk, 'key'),
+
+                'secret' => $this->config($disk, 'secret'),
+            ],
+
+            'region' => $this->config($disk, 'region'),
+
+            'root' => $this->config($disk, 'root', ''),
+
+            'bucket' => $this->config($disk, 'bucket'),
+
+            'version' => $this->config($disk, 'version', 'latest'),
+        ];
+    }
+
+    public function config($disk, $key, $default = null)
+    {
+        $env1 = Str::upper(Str::snake($disk));
+
+        $env2 = $env1 === 'AWS' ? 'S3' : 'AWS';
+
+        $envSuffix = Str::upper($key);
+
+        if (filled($value = config("filesystems.disks.{$disk}.{$key}"))) {
+            return $value;
+        }
+
+        return env("{$env1}_{$envSuffix}", env("{$env2}_{$envSuffix}", $default));
+    }
+}

--- a/src/Services/Cloud/Azure.php
+++ b/src/Services/Cloud/Azure.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace A17\Twill\Services\Cloud;
+
+use Exception;
+
+class Azure
+{
+    public function filesystemFactory($prefix)
+    {
+        throw new Exception('Azure is not implemented yey.');
+    }
+}

--- a/src/Services/Cloud/Glide.php
+++ b/src/Services/Cloud/Glide.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace A17\Twill\Services\Cloud;
+
+use Exception;
+
+class Glide
+{
+    function makeCloudSource($source = null)
+    {
+        if (blank($source)) {
+            throw new Exception(
+                'Glide source was not set, please set your GLIDE_SOURCE environment variable or pass the source.'
+            );
+        }
+
+        if ($source == 's3' || $source == 'aws') {
+            return app(Aws::class)->filesystemFactory($source);
+        }
+
+        if ($source == 'azure') {
+            return app(Azure::class)->filesystemFactory($source);
+        }
+
+        return $source;
+    }
+}


### PR DESCRIPTION
To make Glide and S3 and Azure (not implemented yet) work together we just need to add this to `config/twill.php`:

```php
'glide' => [
    'source' => app(A17\Twill\Services\Cloud\Glide::class)->makeCloudSource(
        env('GLIDE_SOURCE', 's3')
    ),
],
```

The parameter is a drive, so if a drive is already configured it will use the drive configuration, otherwise it will use `S3_*` or `AWS_*` from the `.env` file.

The tricky thing here is that Laravel `config` is not fully available when `config/twill.php` is being loaded. So, it will usually get info from the `.env` file, unless developers use this to configure Glide dynamically, further in the application lifecycle.