### PR TITLE
[2.x] Create items within a browser field

### DIFF
--- a/frontend/js/components/Browser.vue
+++ b/frontend/js/components/Browser.vue
@@ -12,7 +12,19 @@
                        @change="changeBrowserSource"/>
         </div>
         <div class="browser__search">
-          <a17-filter @submit="submitFilter"/>
+          <a17-filter @submit="submitFilter">
+            <div slot="additional-actions">
+              <a17-button
+                variant="validate"
+                size="small"
+                href=""
+                v-on:click="create"
+                v-if="allowCreate"
+              >
+                Create new item
+              </a17-button>
+            </div>
+          </a17-filter>
         </div>
       </div>
       <div class="browser__inner">
@@ -33,7 +45,7 @@
 
 <script>
   import { mapState } from 'vuex'
-  import { BROWSER } from '@/store/mutations'
+  import { BROWSER, MODALEDITION } from '@/store/mutations'
 
   import a17Filter from './Filter.vue'
   import a17ItemList from './ItemList.vue'
@@ -89,10 +101,20 @@
         endpointName: state => state.browser.endpointName,
         endpoints: state => state.browser.endpoints,
         browserTitle: state => state.browser.title,
-        selected: state => state.browser.selected
+        browserCreateUrl: state => state.browser.createUrl,
+        selected: state => state.browser.selected,
+        allowCreate: state => state.browser.allowCreate
       })
     },
     methods: {
+      create: function () {
+        const editionModal = `editionModal-${this.connector}`
+        if (this.$root.$refs[editionModal]) {
+          this.$store.commit(MODALEDITION.UPDATE_MODAL_ACTION, this.browserCreateUrl)
+          this.$store.commit(MODALEDITION.UPDATE_MODAL_MODE, 'create')
+          this.$root.$refs[editionModal].open()
+        }
+      },
       updateSelectedItems (item) {
         const keysToTest = this.multiSources ? ['id', 'endpointType'] : ['id']
         const availableItem = this.fullItems.some(sItem => keysToTest.every(key => sItem[key] === item[key]))

--- a/frontend/js/components/BrowserField.vue
+++ b/frontend/js/components/BrowserField.vue
@@ -53,6 +53,14 @@
         type: String,
         default: ''
       },
+      createUrl: {
+        type: String,
+        default: ''
+      },
+      allowCreate: {
+        type: Boolean,
+        default: false
+      },
       endpoints: {
         type: Array,
         default: () => []
@@ -143,6 +151,8 @@
         }
         this.$store.commit(BROWSER.UPDATE_BROWSER_MAX, this.max)
         this.$store.commit(BROWSER.UPDATE_BROWSER_TITLE, this.browserTitle)
+        this.$store.commit(BROWSER.UPDATE_BROWSER_CREATE_URL, this.createUrl)
+        this.$store.commit(BROWSER.UPDATE_ALLOW_CREATE, this.allowCreate)
 
         if (this.wide) {
           this.$root.$refs.browserWide.open(this.endpoints.length <= 0)

--- a/frontend/js/components/modals/ModalCreate.vue
+++ b/frontend/js/components/modals/ModalCreate.vue
@@ -1,11 +1,12 @@
 <template>
-  <a17-modal ref="modal" class="modal--form" :title="modalTitle" :forceClose="true">
+  <a17-modal ref="modal" class="modal--form" :title="modalTitle" :forceClose="true" @close="resetLang">
     <form :action="actionForm" @submit.prevent="submit">
       <slot></slot>
       <a17-modal-validation
         :mode="mode"
         :is-disable="createMode"
-        :active-publish-state="withPublicationToggle"
+        :fields-in-modal="fieldsInModal"
+        :active-publish-state="withPublicationToggle || showPublication"
         :is-publish="published"
         published-name="published"
         :textEnabled="publishedLabel"
@@ -22,12 +23,30 @@
   import ACTIONS from '@/store/actions'
   import a17ModalValidationButtons from './ModalValidationButtons.vue'
 
+  const CREATE_ANOTHER = 'create-another'
+
   export default {
     name: 'A17ModalCreate',
     props: {
       formCreate: {
         type: String,
         default: '#'
+      },
+      fieldsInModal: {
+        type: Boolean,
+        default: false
+      },
+      closeOnCreate: {
+        type: Boolean,
+        default: false
+      },
+      languages: {
+        type: Array,
+        default: () => []
+      },
+      showPublication: {
+        type: Boolean,
+        default: false
       },
       publishedLabel: {
         type: String,
@@ -50,7 +69,7 @@
         return this.mode === 'create'
       },
       actionForm: function () {
-        return this.createMode ? this.formCreate : this.action
+        return this.createMode && this.formCreate ? this.formCreate : this.action
       },
       modalTitle: function () {
         return this.createMode ? this.$trans('modal.create.title', 'Add new') : this.$trans('modal.update.title', 'Update')
@@ -59,23 +78,31 @@
         return !this.createMode && !!this.fieldValueByName('published')
       },
       withPublicationToggle: function () {
-        return this.columns.find(c => {
+        return this.columns && this.columns.find(c => {
           return c.name === 'published'
         }) !== undefined
       },
       ...mapState({
         action: state => state.modalEdition.action,
         mode: state => state.modalEdition.mode,
-        columns: state => state.datatable.columns
+        columns: state => state.datatable && state.datatable.columns
       }),
       ...mapGetters([
         'fieldValueByName'
       ])
     },
     methods: {
+      resetLang: function () {
+        const submitMode = document.activeElement.name
+        if (submitMode !== CREATE_ANOTHER) this.$store.commit(LANGUAGE.RESET_LANGUAGES)
+      },
       open: function () {
         if (this.createMode) {
-          this.$store.commit(LANGUAGE.RESET_LANGUAGES)
+          this.resetLang()
+        }
+
+        if (this.languages.length) {
+          this.$store.commit(LANGUAGE.REPLACE_LANGUAGES, this.languages)
         }
 
         this.$refs.modal.open()
@@ -85,18 +112,24 @@
 
         this.$store.commit(FORM.UPDATE_FORM_LOADING, true)
         const submitMode = document.activeElement.name
+        const action = this.fieldsInModal ? ACTIONS.CREATE_FORM_IN_MODAL : ACTIONS.UPDATE_FORM_IN_LISTING
 
         this.$nextTick(function () {
-          this.$store.dispatch(ACTIONS.UPDATE_FORM_IN_LISTING, {
+          this.$store.dispatch(action, {
             endpoint: this.actionForm,
             method: this.mode === 'create' ? 'post' : 'put',
-            redirect: submitMode !== 'create-another'
+            redirect: submitMode !== CREATE_ANOTHER && !this.closeOnCreate
           }).then(() => {
             if (self.$refs.modal) self.$refs.modal.close()
+            this.$store.commit(FORM.REMOVE_MODAL_FIELD, 'published')
 
             self.$nextTick(function () {
-              if (submitMode === 'create-another' && self.$refs.modal) self.$refs.modal.open()
-              if (this.mode === 'create') this.$store.commit(DATATABLE.UPDATE_DATATABLE_PAGE, 1)
+              if (submitMode === CREATE_ANOTHER && self.$refs.modal) {
+                self.$refs.modal.open()
+              } else {
+                this.resetLang()
+              }
+              if (this.mode === 'create' && !this.fieldsInModal) this.$store.commit(DATATABLE.UPDATE_DATATABLE_PAGE, 1)
               this.$emit('reload')
             })
           }, (errorResponse) => {

--- a/frontend/js/components/modals/ModalValidationButtons.vue
+++ b/frontend/js/components/modals/ModalValidationButtons.vue
@@ -32,6 +32,10 @@
         type: Boolean,
         default: false
       },
+      fieldsInModal: {
+        type: Boolean,
+        default: false
+      },
       activePublishState: {
         type: Boolean,
         default: false
@@ -66,7 +70,8 @@
     },
     watch: {
       published: function (value) {
-        this.$store.commit(FORM.UPDATE_FORM_FIELD, {
+        const action = this.fieldsInModal ? FORM.UPDATE_MODAL_FIELD : FORM.UPDATE_FORM_FIELD
+        this.$store.commit(action, {
           name: 'published',
           value: value
         })

--- a/frontend/js/main-form.js
+++ b/frontend/js/main-form.js
@@ -14,6 +14,7 @@ import openMediaLibrary from '@/behaviors/openMediaLibrary'
 import a17StickyNav from '@/components/StickyNav.vue'
 import a17TitleEditor from '@/components/TitleEditor.vue'
 import a17Langswitcher from '@/components/LangSwitcher.vue'
+import a17LangManager from '@/components/LangManager.vue'
 import a17Fieldset from '@/components/Fieldset.vue'
 import a17Publisher from '@/components/Publisher.vue'
 import a17PageNav from '@/components/PageNav.vue'
@@ -42,6 +43,8 @@ import a17Spinner from '@/components/Spinner.vue'
 // Add attributes
 import a17ModalAdd from '@/components/modals/ModalAdd.vue'
 
+import ModalCreate from '@/components/modals/ModalCreate.vue'
+
 // Store Modules
 import form from '@/store/modules/form'
 import publication from '@/store/modules/publication'
@@ -52,6 +55,7 @@ import browser from '@/store/modules/browser'
 import repeaters from '@/store/modules/repeaters'
 import parents from '@/store/modules/parents'
 import attributes from '@/store/modules/attributes'
+import modalEdition from '@/store/modules/modal-edition'
 
 // mixins
 import formatPermalink from '@/mixins/formatPermalink'
@@ -72,6 +76,8 @@ store.registerModule('repeaters', repeaters)
 store.registerModule('parents', parents)
 store.registerModule('attributes', attributes)
 
+store.registerModule('modalEdition', modalEdition)
+
 // Form components
 Vue.component('a17-fieldset', a17Fieldset)
 Vue.component('a17-publisher', a17Publisher)
@@ -79,6 +85,7 @@ Vue.component('a17-title-editor', a17TitleEditor)
 Vue.component('a17-content', a17Content)
 Vue.component('a17-page-nav', a17PageNav)
 Vue.component('a17-langswitcher', a17Langswitcher)
+Vue.component('a17-langmanager', a17LangManager)
 Vue.component('a17-sticky-nav', a17StickyNav)
 Vue.component('a17-spinner', a17Spinner)
 
@@ -101,6 +108,7 @@ Vue.component('a17-editor', a17Editor)
 
 // Add attributes
 Vue.component('a17-modal-add', a17ModalAdd)
+Vue.component('a17-modal-create', ModalCreate)
 
 // Blocks
 const importedBlocks = require.context('@/components/blocks/', true, /\.(js|vue)$/i)
@@ -154,6 +162,10 @@ window[process.env.VUE_APP_NAME].vm = window.vm = new Vue({
     ])
   },
   methods: {
+    reloadList: function () {
+      // reload datas
+      this.$refs.browser.$children[0].reloadList(true)
+    },
     submitForm: function (event) {
       if (!this.loading) {
         this.isFormUpdated = false

--- a/frontend/js/mixins/formatPermalink.js
+++ b/frontend/js/mixins/formatPermalink.js
@@ -12,6 +12,7 @@ export default {
   methods: {
     formatPermalink: function (newValue) {
       const permalinkRef = this.$refs.permalink
+      const inModal = permalinkRef && permalinkRef.$children[0].inModal
 
       if (!permalinkRef) return
 
@@ -37,8 +38,9 @@ export default {
           field.locale = this.currentLocale.value
         }
 
+        const action = inModal ? FORM.UPDATE_MODAL_FIELD : FORM.UPDATE_FORM_FIELD
         // Update value in the store
-        this.$store.commit(FORM.UPDATE_FORM_FIELD, field)
+        this.$store.commit(action, field)
       }
     }
   }

--- a/frontend/js/store/modules/browser.js
+++ b/frontend/js/store/modules/browser.js
@@ -5,8 +5,10 @@ const state = {
   connector: null,
   title: 'Attach related resources',
   endpoint: '',
+  createUrl: '',
   endpointName: '',
   endpoints: [],
+  allowCreate: false,
   max: 0,
   selected: window[process.env.VUE_APP_NAME].STORE.browser.selected || {}
 }
@@ -60,6 +62,12 @@ const mutations = {
   },
   [BROWSER.UPDATE_BROWSER_MAX] (state, newValue) {
     state.max = Math.max(0, newValue)
+  },
+  [BROWSER.UPDATE_BROWSER_CREATE_URL] (state, newValue) {
+    state.createUrl = newValue
+  },
+  [BROWSER.UPDATE_ALLOW_CREATE] (state, newValue) {
+    state.allowCreate = newValue
   },
   [BROWSER.UPDATE_BROWSER_CONNECTOR] (state, newValue) {
     if (newValue && newValue !== '') state.connector = newValue

--- a/frontend/js/store/mutations/browser.js
+++ b/frontend/js/store/mutations/browser.js
@@ -5,6 +5,8 @@ export const DESTROY_ITEM = 'destroySelectedItem'
 export const REORDER_ITEMS = 'reorderSelectedItems'
 export const UPDATE_BROWSER_MAX = 'updateBrowserMax'
 export const UPDATE_BROWSER_TITLE = 'updateBrowserTitle'
+export const UPDATE_BROWSER_CREATE_URL = 'updateBrowserCreateUrl'
+export const UPDATE_ALLOW_CREATE = 'updateAllowCreate'
 export const UPDATE_BROWSER_CONNECTOR = 'updateBrowserConnector'
 export const DESTROY_BROWSER_CONNECTOR = 'destroyBrowserConnector'
 export const UPDATE_BROWSER_ENDPOINT = 'updateBrowserEndpoint'
@@ -18,9 +20,11 @@ export default {
   DESTROY_ITEM,
   REORDER_ITEMS,
   UPDATE_BROWSER_MAX,
+  UPDATE_ALLOW_CREATE,
   UPDATE_BROWSER_TITLE,
   UPDATE_BROWSER_CONNECTOR,
   DESTROY_BROWSER_CONNECTOR,
+  UPDATE_BROWSER_CREATE_URL,
   UPDATE_BROWSER_ENDPOINT,
   DESTROY_BROWSER_ENDPOINT,
   UPDATE_BROWSER_ENDPOINTS,

--- a/src/Helpers/routes_helpers.php
+++ b/src/Helpers/routes_helpers.php
@@ -80,3 +80,20 @@ if (!function_exists('isActiveNavigation')) {
         return $urlsAreMatching;
     }
 }
+
+if (!function_exists('getPermalinkUrl'))
+{
+    /**
+     * @return string
+     */
+    function getPermalinkBaseUrl($repository, $moduleName)
+    {
+        $appUrl = config('app.url') .'/'. ($moduleName);
+
+        if (!blank(parse_url($appUrl)['scheme'] ?? null)) {
+            $appUrl = str_replace(['http://', 'https://'], '', $appUrl);
+        }
+
+        return rtrim($appUrl) . '/';
+    }
+}

--- a/src/Http/Controllers/Admin/ModuleController.php
+++ b/src/Http/Controllers/Admin/ModuleController.php
@@ -1434,6 +1434,7 @@ abstract class ModuleController extends Controller
             'permalink' => $this->getIndexOption('permalink'),
             'createWithoutModal' => !$item->id && $this->getIndexOption('skipCreateModal'),
             'form_fields' => $this->repository->getFormFields($item),
+            'browsersWithCreate' => $this->repository->getBrowsersWithCreate(),
             'baseUrl' => $baseUrl,
             'permalinkPrefix' => $this->getPermalinkPrefix($baseUrl),
             'saveUrl' => $item->id ? $this->getModuleRoute($item->id, 'update') : moduleRoute($this->moduleName, $this->routePrefix, 'store', [$this->submoduleParentId]),

--- a/views/layouts/form.blade.php
+++ b/views/layouts/form.blade.php
@@ -110,6 +110,27 @@
     <a17-modal class="modal--browser" ref="browserWide" mode="wide" :force-close="true">
         <a17-browser></a17-browser>
     </a17-modal>
+    @foreach ($browsersWithCreate as $browser)
+        @php
+          $fieldsInModal = $moduleName != $browser['moduleName'];
+          $titleIsTranslatable = count($browser['languages']) > 1;
+          $permalinkPrefix = $browser['permalinkPrefix'];
+        @endphp
+        <a17-modal-create
+            ref="editionModal-{{$browser['browserName']}}"
+            :fields-in-modal=true
+            :close-on-create=true
+            :show-publication="{{ json_encode(\Schema::hasColumn($browser['moduleName'], 'published')) }}"
+            :languages="{{ json_encode($browser['languages']) }}"
+            v-on:reload="reloadList"
+            form-create=""
+            @if ($customPublishedLabel ?? false) published-label="{{ $customPublishedLabel }}" @endif
+            @if ($customDraftLabel ?? false) draft-label="{{ $customDraftLabel }}" @endif
+        >
+            <a17-langmanager></a17-langmanager>
+            @partialView(($browser['moduleName'] ?? $name), 'create', ['renderForModal' => true, 'permalinkPrefix' => $permalinkPrefix, 'translateTitle' => $titleIsTranslatable])
+        </a17-modal-create>
+    @endforeach
     <a17-editor v-if="editor" ref="editor" bg-color="{{ config('twill.block_editor.background_color') ?? '#FFFFFF' }}"></a17-editor>
     <a17-previewer ref="preview"></a17-previewer>
         <a17-dialog ref="warningContentEditor" modal-title="{{ twillTrans('twill::lang.form.dialogs.delete.title') }}" confirm-label="{{ twillTrans('twill::lang.form.dialogs.delete.confirm') }}">

--- a/views/partials/form/_browser.blade.php
+++ b/views/partials/form/_browser.blade.php
@@ -1,6 +1,7 @@
 @php
     $name = $name ?? $moduleName;
     $label = $label ?? 'Missing browser label';
+    $browsersWithCreate = $browsersWithCreate ?? [];
 
     $endpointsFromModules = isset($modules) ? collect($modules)->map(function ($module) {
         return [
@@ -11,6 +12,8 @@
 
     $endpoints = $endpoints ?? $endpointsFromModules ?? [];
 
+    $createUrl = moduleRoute($moduleName, $routePrefix ?? null, 'store', []);
+
     $endpoint = $endpoint ?? (!empty($endpoints) ? null : moduleRoute($moduleName, $routePrefix ?? null, 'browser', $params ?? [], false));
 
     $max = $max ?? 1;
@@ -20,6 +23,16 @@
     $sortable = $sortable ?? true;
     $wide = $wide ?? false;
     $buttonOnTop = $buttonOnTop ?? false;
+
+    $allowCreate = collect($browsersWithCreate)->filter(function ($browser) use ($moduleName) {
+        if (is_array($browser)) {
+            return $moduleName === ($browser['moduleName'] ?: $browser['browserName']);
+        } else {
+            return $moduleName === $browser;
+        }
+    })->toArray();
+
+    $allowCreate = !!$allowCreate ?: false;
 @endphp
 
 <a17-inputframe label="{{ $label }}" name="browsers.{{ $name }}" note="{{ $fieldNote }}">
@@ -29,6 +42,8 @@
         :max="{{ $max }}"
         :wide="{{ json_encode($wide) }}"
         endpoint="{{ $endpoint }}"
+        create-url="{{ $createUrl }}"
+        :allow-create="{{ json_encode($allowCreate) }}"
         :endpoints="{{ json_encode($endpoints) }}"
         modal-title="{{ twillTrans('twill::lang.fields.browser.attach') . ' ' . strtolower($label) }}"
         :draggable="{{ json_encode($sortable) }}"


### PR DESCRIPTION
This Feature allows the developer to create new items within a browser field.

To enable the 'Create new item' button/feature, set either ```$browsers``` or ```$browsersWithCreate```  properties on the module repository:

```
   protected $browsers = [
           'jobs',
           'dogs',
           'cats'
    ];
```

OR 

   ```
 protected $browsersWithCreate = [
        'jobs',
        'dogs',
        'cats'
    ];
```
The properties should contain an array of browser names

The developer can also decide to customize the 'create' form by adding a new file ```create.blade.php``` in the views directory e.g views/admin/{module name}/create.blade.php. 

```
// Sample create.blade.php

@formField('input', [
    'name' => 'title',
    'label' => $titleFormKey === 'title' ? twillTrans('twill::lang.modal.title-field') : ucfirst($titleFormKey),
    'required' => true,
    'translated' => true,
    "fieldsInModal" => $fieldsInModal ?? false,
    'onChange' => 'formatPermalink'
])

@formField('input', [
    'name' => 'description',
    'label' => 'description',
    'translated' => true,
    "fieldsInModal" => $fieldsInModal ?? false,
    'required' => true,
])

@formField('input', [
    'name' => 'slug',
    'label' => twillTrans('twill::lang.modal.permalink-field'),
    'translated' => true,
    'ref' => 'permalink',
    'prefix' => $permalinkPrefix ?? ''
])
```