### PR TITLE
Deep nested modules

### DIFF
--- a/src/Helpers/routes_helpers.php
+++ b/src/Helpers/routes_helpers.php
@@ -17,6 +17,11 @@ if (!function_exists('moduleRoute')) {
         // Fix module name case
         $moduleName = Str::camel($moduleName);
 
+        // Nested module, pass in current parameters for deeply nested modules
+        if (Str::contains($moduleName, '.')) {
+            $parameters = array_merge(Route::current()->parameters(), $parameters);
+        }
+
         // Create base route name
         $routeName = 'admin.' . ($prefix ? $prefix . '.' : '');
 

--- a/src/Http/Controllers/Admin/ModuleController.php
+++ b/src/Http/Controllers/Admin/ModuleController.php
@@ -1040,8 +1040,9 @@ abstract class ModuleController extends Controller
         if (isset($column['nested']) && $column['nested']) {
             $field = $column['nested'];
             $nestedCount = $item->{$column['nested']}->count();
+            $module = Str::singular(last(explode('.', $this->moduleName)));
             $value = '<a href="';
-            $value .= moduleRoute("$this->moduleName.$field", $this->routePrefix, 'index', [$item[$this->identifierColumnKey]]);
+            $value .= moduleRoute("$this->moduleName.$field", $this->routePrefix, 'index', [$module => $item[$this->identifierColumnKey]]);
             $value .= '">' . $nestedCount . " " . (strtolower($nestedCount > 1
                 ? Str::plural($column['title'])
                 : Str::singular($column['title']))) . '</a>';
@@ -1465,10 +1466,10 @@ abstract class ModuleController extends Controller
             'availableRepeaters' => $this->getRepeaterList()->toJson(),
             'revisions' => $this->moduleHas('revisions') ? $item->revisionsArray() : null,
         ] + (Route::has($previewRouteName) && $item[$this->identifierColumnKey] ? [
-            'previewUrl' => moduleRoute($this->moduleName, $this->routePrefix, 'preview', $item[$this->identifierColumnKey]),
+            'previewUrl' => moduleRoute($this->moduleName, $this->routePrefix, 'preview', [$item[$this->identifierColumnKey]]),
         ] : [])
              + (Route::has($restoreRouteName) && $item[$this->identifierColumnKey] ? [
-            'restoreUrl' => moduleRoute($this->moduleName, $this->routePrefix, 'restoreRevision', $item[$this->identifierColumnKey]),
+            'restoreUrl' => moduleRoute($this->moduleName, $this->routePrefix, 'restoreRevision', [$item[$this->identifierColumnKey]]),
         ] : []);
 
         return array_replace_recursive($data, $this->formData($this->request));
@@ -1636,12 +1637,7 @@ abstract class ModuleController extends Controller
      */
     protected function getModuleRoute($id, $action)
     {
-        return moduleRoute(
-            $this->moduleName,
-            $this->routePrefix,
-            $action,
-            array_merge($this->submodule ? [$this->submoduleParentId] : [], [$id])
-        );
+        return moduleRoute($this->moduleName, $this->routePrefix, $action, [$id]);
     }
 
     /**

--- a/src/Http/Controllers/Admin/ModuleController.php
+++ b/src/Http/Controllers/Admin/ModuleController.php
@@ -417,7 +417,7 @@ abstract class ModuleController extends Controller
             $this->moduleName,
             $this->routePrefix,
             'edit',
-            [Str::singular(last(explode('.', $this->moduleName))) => $item->id]
+            [Str::singular(last(explode('.', $this->moduleName))) => $item[$this->identifierColumnKey]]
         ));
     }
 

--- a/src/Http/Controllers/Admin/ModuleController.php
+++ b/src/Http/Controllers/Admin/ModuleController.php
@@ -1600,7 +1600,9 @@ abstract class ModuleController extends Controller
      */
     protected function getParentModuleForeignKey()
     {
-        return Str::singular(explode('.', $this->moduleName)[0]) . '_id';
+        $moduleParts = explode('.', $this->moduleName);
+
+        return Str::singular($moduleParts[count($moduleParts) - 2]) . '_id';
     }
 
     /**

--- a/src/Http/Controllers/Admin/ModuleController.php
+++ b/src/Http/Controllers/Admin/ModuleController.php
@@ -450,8 +450,8 @@ abstract class ModuleController extends Controller
 
         if ($this->getIndexOption('editInModal')) {
             return $this->request->ajax()
-                ? Response::json($this->modalFormData($id))
-                : Redirect::to(moduleRoute($this->moduleName, $this->routePrefix, 'index'));
+            ? Response::json($this->modalFormData($id))
+            : Redirect::to(moduleRoute($this->moduleName, $this->routePrefix, 'index'));
         }
 
         $this->setBackLink();


### PR DESCRIPTION
This PR allows deep nesting for submodules. I am not sure if this is something that is highly requested, I could not find a similar PR or issue regarding this. Currently, Twill allows a single nested module, but it's possible a project may require further nesting as I have found. Consider the following modules and their relationships:

- client
- clients have many projects (intranet, reporting portal, customer portal etc)
- projects have many applications (e.g. website, mobile application etc)

So, as Laravel nested resources allow, you could have a route as such:
/clients/3/projects/5/applications/2

I have made the required changes however it might need some extra testing? I tried it out on a project I'm using with Twill and I could get these changes to work regarding routing, creating, editing, deleting, etc. I am fairly new to contributing to open source so please bear with me if you need more coverage. I am also new to unit testing, so if anyone could help me out in this regard that would be much appreciated, if required.

The syntax is essentially how the docs portray a regular submodule, you just add the extra modules in the nest with dot notation, for example:
```php
// ClientProjectApplicationController.php
<?php

namespace App\Http\Controllers\Admin;

use A17\Twill\Http\Controllers\Admin\ModuleController;

class ClientProjectApplicationController extends ModuleController
{
    protected $modelName = 'Application';
    protected $moduleName = 'clients.projects.applications';
}
```
```php
<?php
Route::module('clients');
Route::module('clients.projects');
Route::module('clients.projects.applications');
```

And then views also take the same breadth:
`resources/views/admin/clients/projects/applications`

A lot of the changes to support this deep nesting lies in the arguments for controller actions - as the method for retrieving an ID depended on there being strictly 1-2 parameters coming from the route. This is limiting because this assumes there would only ever be 1 level nested. Now, these controller actions depend on the Illuminate\Http\Request class to gather the route and its array of parameters to predictably determine the nesting level and its parents ID. If this imposes a security risk I am not aware of, please let me know, and we will work to a better solution.