### PR TITLE
Nested module permalink

### DIFF
--- a/frontend/js/components/Textfield.vue
+++ b/frontend/js/components/Textfield.vue
@@ -319,6 +319,7 @@
     user-select:none;
     color:$color__icons;
     pointer-events: none;
+    white-space: nowrap;
   }
 
   .input__limit {

--- a/src/Http/Controllers/Admin/ModuleController.php
+++ b/src/Http/Controllers/Admin/ModuleController.php
@@ -1660,7 +1660,7 @@ abstract class ModuleController extends Controller
         return $appUrl . '/'
             . ($this->moduleHas('translations') ? '{language}/' : '')
             . ($this->moduleHas('revisions') ? '{preview}/' : '')
-            . $this->getModulePermalinkBase()
+            . ($this->permalinkBase ?? $this->getModulePermalinkBase())
             . (isset($this->permalinkBase) && empty($this->permalinkBase) ? '' : '/');
     }
 


### PR DESCRIPTION
Currently, Twill creates a preview of the permalink in modals/edit pages by taking the `$moduleName` property from the module controller. This is fine for standalone modules, but nested modules don't show a proper permalink base. Instead, what is shown is just the delimited nested resource name, e.g. example.com/parent.child/my-slug rather than example.com/parent/parent-slug/child/my-slug.

This PR aims to fix this issue by resolving the model for the parent modules and getting its slugs from there (if possible, just the ID if not) and building a permalink preview based on the order of the nested string. Perhaps it assumes quite a lot about the developers structure of their project from the app/model perspective, but I have tried to make it as unopinionated as possible. Any help would be appreciated on improving the resolving etc.

I noticed a small styling bug that came with this fix due to the lengthier permalinks in the create modal. The base that comes before the auto-generated slug wraps onto a new line inside the "input wrapper" box when it reaches >52 chars. Adding a CSS rule for `white-space: nowrap` seems to fix this on `.input__prefix`, and thankfully it doesn't overlap the slug text. Not sure why it wraps in the first place.