### PR TITLE
"Create and add another" fix for macOS Safari/FF

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,3 +1,7 @@
+build:
+  environment:
+    php: 7.4.14
+
 checks:
   php:
     remove_extra_empty_lines: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: xenial
+dist: bionic
 language: php
 
 php:

--- a/frontend/js/components/modals/ModalValidationButtons.vue
+++ b/frontend/js/components/modals/ModalValidationButtons.vue
@@ -3,7 +3,7 @@
     <a17-inputframe>
       <template v-if="mode === 'create'">
         <a17-button type="submit" name="create" variant="validate" :disabled="isDisabled">{{ $trans('modal.create.button', 'Create') }}</a17-button>
-        <a17-button type="submit" name="create-another" v-if="!isDisabled" variant="aslink-grey"><span>{{ $trans('modal.create.create-another', 'Create and add another') }}</span></a17-button>
+        <a17-button type="submit" name="create-another" v-on:click.native="$event.currentTarget.focus()" v-if="!isDisabled" variant="aslink-grey"><span>{{ $trans('modal.create.create-another', 'Create and add another') }}</span></a17-button>
       </template>
       <a17-button type="submit" name="update" v-else-if="mode === 'update'" variant="validate" :disabled="isDisabled">{{ $trans('modal.update.button', 'Update') }}</a17-button>
       <a17-button type="submit" name="done" v-else="" variant="validate" :disabled="isDisabled">{{ $trans('modal.done.button', 'Done') }}</a17-button>


### PR DESCRIPTION
This PR is to fix a bug on the create modal component where "Create and add another" doesn't work as expected on macOS Safari & Firefox browsers. Instead of closing the current modal and opening another, the browser progresses to the edit screen as if you had just clicked the regular "Create" button instead.

[This is a fix for a bug specific to macOS it seems](https://bugzilla.mozilla.org/show_bug.cgi?id=1547926).

Chrome seems to be OK, but because of the way macOS handles window focus after mouse click, this line:
https://github.com/area17/twill/blob/9ead6d5c588243f2727906799e1d36c22d5c7c3c/frontend/js/components/modals/ModalCreate.vue#L87
... doesn't work as expected - you would expect `submitMode` to return the name of the button that was clicked upon form submission, but it returns the body element instead.

To fix this, I force focus inline on the secondary submit button present when the modal is in create mode. This makes `submitMode` correctly assign itself as either "create" or "create-another" etc.