### PR TITLE
Add fallback for adminEditUrl in browser fields

### DIFF
--- a/src/Repositories/Behaviors/HandleBlocks.php
+++ b/src/Repositories/Behaviors/HandleBlocks.php
@@ -282,7 +282,12 @@ trait HandleBlocks
                 $items = $this->getFormFieldsForRelatedBrowser($block, $relation);
                 foreach ($items as &$item) {
                     if (!isset($item['edit'])) {
-                        $item['edit'] = moduleRoute($relation, config('twill.block_editor.browser_route_prefixes.' . $relation), 'edit', $item['id']);
+                        $item['edit'] = moduleRoute(
+                            $relation,
+                            config('twill.block_editor.browser_route_prefixes.' . $relation),
+                            'edit',
+                            $item['id']
+                        );
                     }
                 }
             } else {

--- a/src/Repositories/Behaviors/HandleBlocks.php
+++ b/src/Repositories/Behaviors/HandleBlocks.php
@@ -279,7 +279,12 @@ trait HandleBlocks
     {
         return Collection::make($block['content']['browsers'])->mapWithKeys(function ($ids, $relation) use ($block) {
             if (Schema::hasTable(config('twill.related_table', 'twill_related')) && $block->getRelated($relation)->isNotEmpty()) {
-                $items = $this->getFormFieldsForRelatedBrowser($block, $relation);;
+                $items = $this->getFormFieldsForRelatedBrowser($block, $relation);
+                foreach ($items as &$item) {
+                    if (!isset($item['edit'])) {
+                        $item['edit'] = moduleRoute($relation, config('twill.block_editor.browser_route_prefixes.' . $relation), 'edit', $item['id']);
+                    }
+                }
             } else {
                 $relationRepository = $this->getModelRepository($relation);
                 $relatedItems = $relationRepository->get([], ['id' => $ids], [], -1);


### PR DESCRIPTION
We recently updated a site from Twill 1.2 to Twill 2.x and noticed problems with pages/modules that had browser fields. Those pages could not be saved/updated any more and always threw an error. We realised that the `related` table seemed to be an issue, as it seems to not have been in use in Twill 1. A simple script added the missing relations in the table, which fixed the saving-problem. However, we then noticed that the edit-links of browser field entries in the form view of those pages/modules were missing. With a bit of research I found out that the `edit`/`adminEditUrl` attribute in the related element was indeed not set, if the `related` table was in use. 
The proposed code change provides a simple check if the attribute is present and adds it if not.

I guess this change is very niche but as it doesn't seem to interfere with anything else, a pull request might be helpful to one or the other.