### PR TITLE
Allow renaming tag tables

### DIFF
--- a/config/twill.php
+++ b/config/twill.php
@@ -123,6 +123,8 @@ return [
     'files_table' => 'files',
     'fileables_table' => 'fileables',
     'related_table' => 'related',
+    'tags_table' => 'tags',
+    'tagged_table' => 'tagged',
 
     /*
     |--------------------------------------------------------------------------

--- a/docs/.sections/getting-started/configuration.md
+++ b/docs/.sections/getting-started/configuration.md
@@ -119,6 +119,8 @@ return [
     'files_table' => 'files',
     'fileables_table' => 'fileables',
     'related_table' => 'related',
+    'tags_table' => 'tags',
+    'tagged_table' => 'tagged',
 ];
 ```
 

--- a/migrations/default/2020_02_09_000006_create_twill_default_tags_tables.php
+++ b/migrations/default/2020_02_09_000006_create_twill_default_tags_tables.php
@@ -13,8 +13,10 @@ class CreateTwillDefaultTagsTables extends Migration
      */
     public function up()
     {
-        if (!Schema::hasTable('tagged')) {
-            Schema::create('tagged', function (Blueprint $table) {
+        $twillTaggedTable = config('twill.tagged_table', 'tagged');
+
+        if (!Schema::hasTable($twillTaggedTable)) {
+            Schema::create($twillTaggedTable, function (Blueprint $table) {
                 $table->{twillIncrementsMethod()}('id');
                 $table->string('taggable_type');
                 $table->integer('taggable_id')->unsigned();
@@ -23,8 +25,11 @@ class CreateTwillDefaultTagsTables extends Migration
             });
         }
 
-        if (!Schema::hasTable('tags')) {
-            Schema::create('tags', function (Blueprint $table) {
+
+        $twillTagsTable = config('twill.tags_table', 'tags');
+
+        if (!Schema::hasTable($twillTagsTable)) {
+            Schema::create($twillTagsTable, function (Blueprint $table) {
                 $table->{twillIncrementsMethod()}('id');
                 $table->string('namespace');
                 $table->string('slug');
@@ -41,7 +46,7 @@ class CreateTwillDefaultTagsTables extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('tagged');
-        Schema::dropIfExists('tags');
+        Schema::dropIfExists(config('twill.tags_table', 'tags'));
+        Schema::dropIfExists(config('twill.tagged_table', 'tagged'));
     }
 }

--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -8,6 +8,7 @@ use Carbon\Carbon;
 use Cartalyst\Tags\TaggableInterface;
 use Cartalyst\Tags\TaggableTrait;
 use Illuminate\Database\Eloquent\Model as BaseModel;
+use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Str;
 
@@ -94,5 +95,24 @@ abstract class Model extends BaseModel implements TaggableInterface
     public function getTranslatedAttributes()
     {
         return $this->translatedAttributes ?? [];
+    }
+
+    protected static function bootTaggableTrait()
+    {
+        static::$tagsModel = Tag::class;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function tags(): MorphToMany
+    {
+        return $this->morphToMany(
+            static::$tagsModel,
+            'taggable',
+            config('twill.tagged_table', 'tagged'),
+            'taggable_id',
+            'tag_id'
+        );
     }
 }

--- a/src/Models/Tag.php
+++ b/src/Models/Tag.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace A17\Twill\Models;
+
+use Cartalyst\Tags\IlluminateTag;
+
+class Tag extends IlluminateTag
+{
+    protected static $taggedModel = Tagged::class;
+
+    public function getTable()
+    {
+        return config('twill.tags_table', 'tags');
+    }
+}

--- a/src/Models/Tagged.php
+++ b/src/Models/Tagged.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace A17\Twill\Models;
+
+use Cartalyst\Tags\IlluminateTagged;
+
+class Tagged extends IlluminateTagged
+{
+    public function getTable()
+    {
+        return config('twill.tagged_table', 'tagged');
+    }
+}


### PR DESCRIPTION
Allow renaming "tags" and "tagged", which are both probably pretty commonly used names in an existing project.

This follows the patterns from 7fced6057183e624b0acdf0805f4513b1d9b9623

Fixes #796 