### PR TITLE
Fix drop index error on mediables table

### DIFF
--- a/migrations/default/2020_02_09_000011_add_locale_column_to_twill_default-mediables.php
+++ b/migrations/default/2020_02_09_000011_add_locale_column_to_twill_default-mediables.php
@@ -16,9 +16,11 @@ class AddLocaleColumnToTwillDefaultMediables extends Migration
 
     public function down()
     {
-        if (Schema::hasTable(config('twill.mediables_table', 'twill_mediables')) && Schema::hasColumn(config('twill.mediables_table', 'twill_mediables'), 'locale')) {
-            Schema::table(config('twill.mediables_table', 'twill_mediables'), function (Blueprint $table) {
-                $table->dropIndex('mediables_locale_index');
+        $twillMediablesTable = config('twill.mediables_table', 'twill_mediables');
+
+        if (Schema::hasTable($twillMediablesTable) && Schema::hasColumn($twillMediablesTable, 'locale')) {
+            Schema::table($twillMediablesTable, function (Blueprint $table) use ($twillMediablesTable) {
+                $table->dropIndex($twillMediablesTable . '_locale_index');
                 $table->dropColumn('locale');
             });
         }


### PR DESCRIPTION
If the mediables table isn't using the default table name, the "mediables_locale_index" won't be called that.