### PR TITLE
Use vendor Twill manifest when public/ is missing

### DIFF
--- a/src/Helpers/frontend_helpers.php
+++ b/src/Helpers/frontend_helpers.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\Cache;
+use A17\Twill\Services\Assets\Twill as TwillAssets;
 
 if (!function_exists('revAsset')) {
     /**
@@ -35,40 +36,7 @@ if (!function_exists('twillAsset')) {
      */
     function twillAsset($file)
     {
-        if (app()->environment('local', 'development') && config('twill.dev_mode', false)) {
-            $devServerUrl = config('twill.dev_mode_url', 'http://localhost:8080');
-
-            try {
-                $manifest = json_decode(file_get_contents(
-                    $devServerUrl
-                    . '/'
-                    . config('twill.manifest_file', 'twill-manifest.json')
-                ), true);
-
-            } catch (\Exception $e) {
-                throw new \Exception('Twill dev assets manifest is missing. Make sure you are running the npm run serve command inside Twill.');
-            }
-
-            return $devServerUrl . ($manifest[$file] ?? ('/' . $file));
-        }
-
-        try {
-            $manifest = Cache::rememberForever('twill-manifest', function () {
-                return json_decode(file_get_contents(
-                    public_path(config('twill.public_directory', 'twill'))
-                    . '/'
-                    . config('twill.manifest_file', 'twill-manifest.json')
-                ), true);
-            });
-        } catch (\Exception $e) {
-            throw new \Exception('Twill assets manifest is missing. Make sure you published/updated Twill assets using the "php artisan twill:update" command.');
-        }
-
-        if (isset($manifest[$file])) {
-            return $manifest[$file];
-        }
-
-        return '/' . config('twill.public_directory', 'twill') . '/' . $file;
+        return app(TwillAssets::class)->asset($file);
     }
 }
 

--- a/src/Services/Assets/Twill.php
+++ b/src/Services/Assets/Twill.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace A17\Twill\Services\Assets;
+
+use Illuminate\Support\Facades\Cache;
+
+class Twill
+{
+    function asset($file)
+    {
+        return $this->devAsset($file) ?? $this->twillAsset($file);
+    }
+
+    public function twillAsset($file)
+    {
+        $manifest = $this->readManifest();
+
+        if (isset($manifest[$file])) {
+            return asset($manifest[$file]);
+        }
+
+        return asset(
+            '/' . config('twill.public_directory', 'twill') . '/' . $file,
+        );
+    }
+
+    public function getManifestFilename()
+    {
+        $fileName =
+            public_path(config('twill.public_directory', 'twill')) .
+            '/' .
+            config('twill.manifest_file', 'twill-manifest.json');
+
+        if (file_exists($fileName)) {
+            return $fileName;
+        }
+
+        return base_path(
+            'vendor/area17/twill/dist/assets/admin/twill-manifest.json',
+        );
+    }
+
+    public function devAsset($file)
+    {
+        if (!$this->devMode()) {
+            return null;
+        }
+
+        $devServerUrl = config('twill.dev_mode_url', 'http://localhost:8080');
+
+        try {
+            $manifest = $this->readJson(
+                $devServerUrl .
+                    '/' .
+                    config('twill.manifest_file', 'twill-manifest.json'),
+            );
+        } catch (\Exception $e) {
+            throw new \Exception(
+                'Twill dev assets manifest is missing. Make sure you are running the npm run serve command inside Twill.',
+            );
+        }
+
+        return $devServerUrl . ($manifest[$file] ?? '/' . $file);
+    }
+
+    /**
+     * @return mixed
+     */
+    private function readManifest()
+    {
+        try {
+            return Cache::rememberForever('twill-manifest', function () {
+                return $this->readJson($this->getManifestFilename());
+            });
+        } catch (\Exception $e) {
+            throw new \Exception(
+                'Twill assets manifest is missing. Make sure you published/updated Twill assets using the "php artisan twill:update" command.',
+            );
+        }
+    }
+
+    private function readJson($fileName)
+    {
+        return json_decode(file_get_contents($fileName), true);
+    }
+
+    private function devMode()
+    {
+        return app()->environment('local', 'development') &&
+            config('twill.dev_mode', false);
+    }
+}

--- a/src/Services/Assets/Twill.php
+++ b/src/Services/Assets/Twill.php
@@ -20,7 +20,7 @@ class Twill
         }
 
         return asset(
-            '/' . config('twill.public_directory', 'twill') . '/' . $file,
+            '/' . config('twill.public_directory', 'twill') . '/' . $file
         );
     }
 
@@ -36,7 +36,7 @@ class Twill
         }
 
         return base_path(
-            'vendor/area17/twill/dist/assets/admin/twill-manifest.json',
+            'vendor/area17/twill/dist/assets/admin/twill-manifest.json'
         );
     }
 
@@ -52,11 +52,11 @@ class Twill
             $manifest = $this->readJson(
                 $devServerUrl .
                     '/' .
-                    config('twill.manifest_file', 'twill-manifest.json'),
+                    config('twill.manifest_file', 'twill-manifest.json')
             );
         } catch (\Exception $e) {
             throw new \Exception(
-                'Twill dev assets manifest is missing. Make sure you are running the npm run serve command inside Twill.',
+                'Twill dev assets manifest is missing. Make sure you are running the npm run serve command inside Twill.'
             );
         }
 
@@ -74,7 +74,7 @@ class Twill
             });
         } catch (\Exception $e) {
             throw new \Exception(
-                'Twill assets manifest is missing. Make sure you published/updated Twill assets using the "php artisan twill:update" command.',
+                'Twill assets manifest is missing. Make sure you published/updated Twill assets using the "php artisan twill:update" command.'
             );
         }
     }


### PR DESCRIPTION
This is just a tweak to use `twill-manifest.json` from the vendor folder (which is source of `twill:install` and `twill:update`). 

Had to do this in order to improve our deployments on Laravel Vapor, since it pushes all files from /public to S3, including json files and clears the public folder.

In the process I also created an `Assets` class and refactored the `twillAssets()` helper function a bit, since it was also growing in complexity.