### PR TITLE
Allow passing email and password directly on the command line

### DIFF
--- a/src/Commands/CreateSuperAdmin.php
+++ b/src/Commands/CreateSuperAdmin.php
@@ -14,7 +14,7 @@ class CreateSuperAdmin extends Command
      *
      * @var string
      */
-    protected $signature = 'twill:superadmin';
+    protected $signature = 'twill:superadmin {email?} {password?}';
 
     /**
      * The console command description.
@@ -76,6 +76,9 @@ class CreateSuperAdmin extends Command
      */
     private function setEmail()
     {
+        if (filled($email = $this->argument('email'))) {
+            return $email;
+        }
         $email = $this->ask('Enter an email');
         if ($this->validateEmail($email)) {
             return $email;
@@ -92,6 +95,9 @@ class CreateSuperAdmin extends Command
      */
     private function setPassword()
     {
+        if (filled($email = $this->argument('password'))) {
+            return $email;
+        }
         $password = $this->secret('Enter a password');
         if ($this->validatePassword($password)) {
             $confirmPassword = $this->secret('Confirm the password');


### PR DESCRIPTION
Needed this to ease things with Laravel Vapor, to create super admins via direct commands this way:

```
vapor command staging --command="php artisan twill:superadmin admin@area17.com password"
```