### PR TITLE
Allow generation of Modules and Capsules using different base classes

### DIFF
--- a/config/twill.php
+++ b/config/twill.php
@@ -196,4 +196,25 @@ return [
         'zh-Hans',
         'ru',
     ],
+
+
+    /*
+    |--------------------------------------------------------------------------
+    | Base classes for automatic generation of Modules and Capsules
+    |--------------------------------------------------------------------------
+    |
+     */
+    'base_model' => A17\Twill\Models\Model::class,
+
+    'base_translation_model' => A17\Twill\Models\Model::class,
+
+    'base_slug_model' => A17\Twill\Models\Model::class,
+
+    'base_revision_model' => A17\Twill\Models\Revision::class,
+
+    'base_repository' => A17\Twill\Repositories\ModuleRepository::class,
+
+    'base_controller' => A17\Twill\Http\Controllers\Admin\ModuleController::class,
+
+    'base_request' => A17\Twill\Http\Requests\Admin\Request::class,
 ];

--- a/src/Commands/ModuleMake.php
+++ b/src/Commands/ModuleMake.php
@@ -337,8 +337,8 @@ class ModuleMake extends Command
             $modelTranslationClassName = $modelName . 'Translation';
 
             $stub = str_replace(
-                ['{{modelTranslationClassName}}', '{{modelClassWithNamespace}}', '{{modelClassName}}', '{{namespace}}'],
-                [$modelTranslationClassName, $modelClassName, $modelName, $this->namespace('models', 'Models\Translations')],
+                ['{{modelTranslationClassName}}', '{{modelClassWithNamespace}}', '{{modelClassName}}', '{{namespace}}', '{{baseTranslationModel}}'],
+                [$modelTranslationClassName, $modelClassName, $modelName, $this->namespace('models', 'Models\Translations'), config('twill.base_translation_model')],
                 $this->files->get(__DIR__ . '/stubs/model_translation.stub')
             );
 
@@ -351,8 +351,8 @@ class ModuleMake extends Command
             $modelSlugClassName = $modelName . 'Slug';
 
             $stub = str_replace(
-                ['{{modelSlugClassName}}', '{{modelClassWithNamespace}}', '{{modelName}}', '{{namespace}}'],
-                [$modelSlugClassName, $modelClassName, Str::snake($modelName), $this->namespace('models', 'Models\Slugs')],
+                ['{{modelSlugClassName}}', '{{modelClassWithNamespace}}', '{{modelName}}', '{{namespace}}', '{{baseSlugModel}}'],
+                [$modelSlugClassName, $modelClassName, Str::snake($modelName), $this->namespace('models', 'Models\Slugs'), config('twill.base_slug_model')],
                 $this->files->get(__DIR__ . '/stubs/model_slug.stub')
             );
 
@@ -365,8 +365,8 @@ class ModuleMake extends Command
             $modelRevisionClassName = $modelName . 'Revision';
 
             $stub = str_replace(
-                ['{{modelRevisionClassName}}', '{{modelClassWithNamespace}}', '{{modelName}}', '{{namespace}}'],
-                [$modelRevisionClassName, $modelClassName, Str::snake($modelName), $this->namespace('models', 'Models\Revisions')],
+                ['{{modelRevisionClassName}}', '{{modelClassWithNamespace}}', '{{modelName}}', '{{namespace}}', '{{baseRevisionModel}}'],
+                [$modelRevisionClassName, $modelClassName, Str::snake($modelName), $this->namespace('models', 'Models\Revisions'), config('twill.base_revision_model')],
                 $this->files->get(__DIR__ . '/stubs/model_revision.stub')
             );
 
@@ -397,12 +397,14 @@ class ModuleMake extends Command
             '{{modelImports}}',
             '{{modelImplements}}',
             '{{namespace}}',
+            '{{baseModel}}',
         ], [
             $modelName,
             $activeModelTraitsString,
             $activeModelTraitsImports,
             $activeModelImplements,
             $this->namespace('models', 'Models'),
+            config('twill.base_model'),
         ], $this->files->get(__DIR__ . '/stubs/model.stub'));
 
         $stub = $this->renderStubForOption($stub, 'hasTranslation', $this->translatable);
@@ -460,8 +462,8 @@ class ModuleMake extends Command
         $activeRepositoryTraitsImports = empty($activeRepositoryTraits) ? '' : "use A17\Twill\Repositories\Behaviors\\" . implode(";\nuse A17\Twill\Repositories\Behaviors\\", $activeRepositoryTraits) . ";";
 
         $stub = str_replace(
-            ['{{repositoryClassName}}', '{{modelName}}', '{{repositoryTraits}}', '{{repositoryImports}}', '{{namespace}}', '{{modelClass}}'],
-            [$repositoryClassName, $modelName, $activeRepositoryTraitsString, $activeRepositoryTraitsImports, $this->namespace('repositories', 'Repositories'), $modelClass],
+            ['{{repositoryClassName}}', '{{modelName}}', '{{repositoryTraits}}', '{{repositoryImports}}', '{{namespace}}', '{{modelClass}}', '{{baseRepository}}'],
+            [$repositoryClassName, $modelName, $activeRepositoryTraitsString, $activeRepositoryTraitsImports, $this->namespace('repositories', 'Repositories'), $modelClass, config('twill.base_repository')],
             $this->files->get(__DIR__ . '/stubs/repository.stub')
         );
 
@@ -487,8 +489,8 @@ class ModuleMake extends Command
         $this->makeTwillDirectory($dir);
 
         $stub = str_replace(
-            ['{{moduleName}}', '{{controllerClassName}}', '{{namespace}}'],
-            [$moduleName, $controllerClassName, $this->namespace('controllers', 'Http\Controllers\Admin')],
+            ['{{moduleName}}', '{{controllerClassName}}', '{{namespace}}', '{{baseController}}'],
+            [$moduleName, $controllerClassName, $this->namespace('controllers', 'Http\Controllers\Admin'), config('twill.base_controller')],
             $this->files->get(__DIR__ . '/stubs/controller.stub')
         );
 
@@ -513,8 +515,8 @@ class ModuleMake extends Command
         $requestClassName = $modelName . 'Request';
 
         $stub = str_replace(
-            ['{{requestClassName}}', '{{namespace}}'],
-            [$requestClassName, $this->namespace('requests', 'Http\Requests\Admin')],
+            ['{{requestClassName}}', '{{namespace}}', '{{baseRequest}}'],
+            [$requestClassName, $this->namespace('requests', 'Http\Requests\Admin'), config('twill.base_request')],
             $this->files->get(__DIR__ . '/stubs/request.stub')
         );
 

--- a/src/Commands/stubs/controller.stub
+++ b/src/Commands/stubs/controller.stub
@@ -2,7 +2,7 @@
 
 namespace {{namespace}};
 
-use A17\Twill\Http\Controllers\Admin\ModuleController;
+use {{baseController}};
 
 class {{controllerClassName}} extends ModuleController
 {

--- a/src/Commands/stubs/model.stub
+++ b/src/Commands/stubs/model.stub
@@ -3,7 +3,7 @@
 namespace {{namespace}};
 
 {{modelImports}}
-use A17\Twill\Models\Model;
+use {{baseModel}};
 
 class {{modelClassName}} extends Model {{modelImplements}}
 {

--- a/src/Commands/stubs/model_revision.stub
+++ b/src/Commands/stubs/model_revision.stub
@@ -2,7 +2,7 @@
 
 namespace {{namespace}};
 
-use A17\Twill\Models\Revision;
+use {{baseRevisionModel}};
 
 class {{modelRevisionClassName}} extends Revision
 {

--- a/src/Commands/stubs/model_slug.stub
+++ b/src/Commands/stubs/model_slug.stub
@@ -2,7 +2,7 @@
 
 namespace {{namespace}};
 
-use A17\Twill\Models\Model;
+use {{baseSlugModel}};
 
 class {{modelSlugClassName}} extends Model
 {

--- a/src/Commands/stubs/model_translation.stub
+++ b/src/Commands/stubs/model_translation.stub
@@ -2,7 +2,7 @@
 
 namespace {{namespace}};
 
-use A17\Twill\Models\Model;
+use {{baseTranslationModel}};
 use {{modelClassWithNamespace}};
 
 class {{modelTranslationClassName}} extends Model

--- a/src/Commands/stubs/repository.stub
+++ b/src/Commands/stubs/repository.stub
@@ -3,7 +3,7 @@
 namespace {{namespace}};
 
 {{repositoryImports}}
-use A17\Twill\Repositories\ModuleRepository;
+use {{baseRepository}};
 use {{modelClass}};
 
 class {{repositoryClassName}} extends ModuleRepository

--- a/src/Commands/stubs/request.stub
+++ b/src/Commands/stubs/request.stub
@@ -2,7 +2,7 @@
 
 namespace {{namespace}};
 
-use A17\Twill\Http\Requests\Admin\Request;
+use {{baseRequest}};
 
 class {{requestClassName}} extends Request
 {


### PR DESCRIPTION
Well, it does exactly what the title says: allows people to use custom base classes for models, repositories, controllers and form requests, automatically generating Modules and Capsules with them already.