### PR TITLE
Move trait to the base model

### DIFF
--- a/src/Models/Behaviors/HasTranslation.php
+++ b/src/Models/Behaviors/HasTranslation.php
@@ -4,11 +4,10 @@ namespace A17\Twill\Models\Behaviors;
 
 use Astrotomic\Translatable\Translatable;
 use Illuminate\Database\Query\JoinClause;
-use A17\Twill\Services\Capsules\HasCapsules;
 
 trait HasTranslation
 {
-    use Translatable, HasCapsules;
+    use Translatable;
 
     public function getTranslationModelNameDefault()
     {

--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -3,6 +3,7 @@
 namespace A17\Twill\Models;
 
 use A17\Twill\Models\Behaviors\HasPresenter;
+use A17\Twill\Services\Capsules\HasCapsules;
 use A17\Twill\Models\Behaviors\IsTranslatable;
 use Carbon\Carbon;
 use Cartalyst\Tags\TaggableInterface;
@@ -14,7 +15,7 @@ use Illuminate\Support\Str;
 
 abstract class Model extends BaseModel implements TaggableInterface
 {
-    use HasPresenter, SoftDeletes, TaggableTrait, IsTranslatable;
+    use HasPresenter, SoftDeletes, TaggableTrait, IsTranslatable, HasCapsules;
 
     public $timestamps = true;
 


### PR DESCRIPTION
When a Capsule is generated without translations it was erroring with

```
Call to undefined method App\Twill\Capsules\Pages\Models\Page::getCapsuleRevisionClass()
```

Closes https://github.com/area17/twill/issues/905