### PR TITLE
[feature]Browser belongsTo

### DIFF
--- a/docs/.sections/crud-modules.md
+++ b/docs/.sections/crud-modules.md
@@ -372,15 +372,16 @@ public function hydrate($object, $fields)
         'bulkFeature' => false,
         'restore' => true,
         'bulkRestore' => true,
+        'forceDelete' => true,
+        'bulkForceDelete' => true,
         'delete' => true,
+        'duplicate' => false,
         'bulkDelete' => true,
         'reorder' => false,
         'permalink' => true,
         'bulkEdit' => true,
         'editInModal' => false,
-        'forceDelete' => true,
-        'bulkForceDelete' => true,
-        'duplicate' => true
+        'skipCreateModal' => false,
     ];
 
     /*

--- a/src/Repositories/Behaviors/HandleBrowsers.php
+++ b/src/Repositories/Behaviors/HandleBrowsers.php
@@ -123,7 +123,7 @@ trait HandleBrowsers
      */
     public function getFormFieldsForBrowser($object, $relation, $routePrefix = null, $titleKey = 'title', $moduleName = null)
     {
-        $fields = $object->$relation instanceof BelongsTo ? collect([$object->$relation]) : $object->$relation;
+        $fields = $object->$relation() instanceof BelongsTo ? collect([$object->$relation]) : $object->$relation;
         return $fields->map(function ($relatedElement) use ($titleKey, $routePrefix, $relation, $moduleName) {
             return [
                     'id' => $relatedElement->id,

--- a/src/Repositories/Behaviors/HandleBrowsers.php
+++ b/src/Repositories/Behaviors/HandleBrowsers.php
@@ -3,6 +3,9 @@
 namespace A17\Twill\Repositories\Behaviors;
 
 use A17\Twill\Models\Behaviors\HasMedias;
+use A17\Twill\Models\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 
 trait HandleBrowsers
@@ -48,7 +51,10 @@ trait HandleBrowsers
     public function getFormFieldsHandleBrowsers($object, $fields)
     {
         foreach ($this->getBrowsers() as $browser) {
-            $fields['browsers'][$browser['browserName']] = $this->getFormFieldsForBrowser($object, $browser['relation'], $browser['routePrefix'], $browser['titleKey'], $browser['moduleName']);
+            $relation =  $browser['relation'];
+            if(!empty($object->$relation)) {
+                $fields['browsers'][$browser['browserName']] = $this->getFormFieldsForBrowser($object, $relation, $browser['routePrefix'], $browser['titleKey'], $browser['moduleName']);
+            }
         }
 
         return $fields;
@@ -68,13 +74,21 @@ trait HandleBrowsers
         $browserName = $browserName ?? $relationship;
         $fieldsHasElements = isset($fields['browsers'][$browserName]) && !empty($fields['browsers'][$browserName]);
         $relatedElements = $fieldsHasElements ? $fields['browsers'][$browserName] : [];
+
         $relatedElementsWithPosition = [];
         $position = 1;
+
         foreach ($relatedElements as $relatedElement) {
             $relatedElementsWithPosition[$relatedElement['id']] = [$positionAttribute => $position++] + $pivotAttributes;
         }
 
-        $object->$relationship()->sync($relatedElementsWithPosition);
+        if($object->$relationship() instanceof BelongsTo) {
+            $foreignKey = $object->$relationship()->getForeignKeyName();
+            $id = Arr::get($relatedElements, '0.id', null);
+            $object->update([$foreignKey => $id]);
+        }else {
+            $object->$relationship()->sync($relatedElementsWithPosition);
+        }
     }
 
     /**
@@ -110,17 +124,19 @@ trait HandleBrowsers
      */
     public function getFormFieldsForBrowser($object, $relation, $routePrefix = null, $titleKey = 'title', $moduleName = null)
     {
-        return $object->$relation->map(function ($relatedElement) use ($titleKey, $routePrefix, $relation, $moduleName) {
+        $fields = $object->$relation instanceof Model ? collect([$object->$relation]) : $object->$relation;
+        return $fields->map(function ($relatedElement) use ($titleKey, $routePrefix, $relation, $moduleName) {
             return [
-                'id' => $relatedElement->id,
-                'name' => $relatedElement->titleInBrowser ?? $relatedElement->$titleKey,
-                'edit' => moduleRoute($moduleName ?? $relation, $routePrefix ?? '', 'edit', $relatedElement->id),
-                'endpointType' => $relatedElement->getMorphClass(),
-            ] + (classHasTrait($relatedElement, HasMedias::class) ? [
-                'thumbnail' => $relatedElement->defaultCmsImage(['w' => 100, 'h' => 100]),
-            ] : []);
+                    'id' => $relatedElement->id,
+                    'name' => $relatedElement->titleInBrowser ?? $relatedElement->$titleKey,
+                    'edit' => moduleRoute($moduleName ?? $relation, $routePrefix ?? '', 'edit', $relatedElement->id),
+                    'endpointType' => $relatedElement->getMorphClass(),
+                ] + (classHasTrait($relatedElement, HasMedias::class) ? [
+                    'thumbnail' => $relatedElement->defaultCmsImage(['w' => 100, 'h' => 100]),
+                ] : []);
         })->toArray();
     }
+
 
     /**
      * @param \A17\Twill\Models\Model $object
@@ -131,14 +147,14 @@ trait HandleBrowsers
     {
         return $object->getRelated($relation)->map(function ($relatedElement) {
             return ($relatedElement != null) ? [
-                'id' => $relatedElement->id,
-                'name' => $relatedElement->titleInBrowser ?? $relatedElement->title,
-                'endpointType' => $relatedElement->getMorphClass(),
-            ] + (empty($relatedElement->adminEditUrl) ? [] : [
-                'edit' => $relatedElement->adminEditUrl,
-            ]) + (classHasTrait($relatedElement, HasMedias::class) ? [
-                'thumbnail' => $relatedElement->defaultCmsImage(['w' => 100, 'h' => 100]),
-            ] : []) : [];
+                    'id' => $relatedElement->id,
+                    'name' => $relatedElement->titleInBrowser ?? $relatedElement->title,
+                    'endpointType' => $relatedElement->getMorphClass(),
+                ] + (empty($relatedElement->adminEditUrl) ? [] : [
+                    'edit' => $relatedElement->adminEditUrl,
+                ]) + (classHasTrait($relatedElement, HasMedias::class) ? [
+                    'thumbnail' => $relatedElement->defaultCmsImage(['w' => 100, 'h' => 100]),
+                ] : []) : [];
         })->reject(function ($item) {
             return empty($item);
         })->values()->toArray();

--- a/src/Repositories/Behaviors/HandleBrowsers.php
+++ b/src/Repositories/Behaviors/HandleBrowsers.php
@@ -3,7 +3,6 @@
 namespace A17\Twill\Repositories\Behaviors;
 
 use A17\Twill\Models\Behaviors\HasMedias;
-use A17\Twill\Models\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
@@ -124,7 +123,7 @@ trait HandleBrowsers
      */
     public function getFormFieldsForBrowser($object, $relation, $routePrefix = null, $titleKey = 'title', $moduleName = null)
     {
-        $fields = $object->$relation instanceof Model ? collect([$object->$relation]) : $object->$relation;
+        $fields = $object->$relation instanceof BelongsTo ? collect([$object->$relation]) : $object->$relation;
         return $fields->map(function ($relatedElement) use ($titleKey, $routePrefix, $relation, $moduleName) {
             return [
                     'id' => $relatedElement->id,


### PR DESCRIPTION
## Description
Add belongsTo for browser field 

A belongsTo relationship must be define in your model :

### Model
```php
<?php

namespace App\Models;

use A17\Twill\Models\Model;
use Illuminate\Database\Eloquent\Relations\BelongsTo;

class Product extends Model
{
    protected $fillable = [
        'product_category_id'
    ];


    /**
     * @return BelongsTo
     */
    public function productCategory(): BelongsTo
    {
        return $this->belongsTo(ProductCategory::class);
    }
}

```
### Repository
```php
    protected $browsers = [
        'productCategory' // relationship name from the model
    ];
```

### Form
```php
    @formField('browser', [
        'label' => 'Category',
        'max' => 1,
        'moduleName' => 'productCategories',
        'name' => 'productCategory'
    ])
```
