### PR TITLE
Fix issues with wrong view name in frontend helper

### DIFF
--- a/src/Helpers/frontend_helpers.php
+++ b/src/Helpers/frontend_helpers.php
@@ -61,7 +61,7 @@ if (!function_exists('icon')) {
 if (!function_exists('twillViewName')) {
     function twillViewName($module, $suffix)
     {
-        $view = "'admin.'.$module.'.{$suffix}'";
+        $view = "admin.{$module}.{$suffix}";
 
         if (view()->exists($view)) {
             return $view;


### PR DESCRIPTION
## Description

View name in frontend helper was returning broken view path.

`twillViewName` was returning `"'admin.'.pages.'.create'"` instead of `"admin.pages.create"`.

## Related Issues

–