### PR TITLE
Respect of activeCrop value in medias form-field

### DIFF
--- a/docs/.sections/crud-modules.md
+++ b/docs/.sections/crud-modules.md
@@ -372,15 +372,16 @@ public function hydrate($object, $fields)
         'bulkFeature' => false,
         'restore' => true,
         'bulkRestore' => true,
+        'forceDelete' => true,
+        'bulkForceDelete' => true,
         'delete' => true,
+        'duplicate' => false,
         'bulkDelete' => true,
         'reorder' => false,
         'permalink' => true,
         'bulkEdit' => true,
         'editInModal' => false,
-        'forceDelete' => true,
-        'bulkForceDelete' => true,
-        'duplicate' => true
+        'skipCreateModal' => false,
     ];
 
     /*

--- a/frontend/js/components/MediaField.vue
+++ b/frontend/js/components/MediaField.vue
@@ -20,7 +20,7 @@
           <li class="f--small" v-if="media.width + media.height">{{ $trans('fields.medias.original-dimensions') }}: {{ media.width }}&nbsp;&times;&nbsp;{{
             media.height }}
           </li>
-          <li class="f--small media__crop-link" v-if="cropInfos" @click="openCropMedia">
+          <li class="f--small media__crop-link" v-if="cropInfos && activeCrop" @click="openCropMedia">
               <p class="f--small f--note hide--xsmall"
                  v-for="(cropInfo, index) in cropInfos"
                  :key="index">

--- a/src/Repositories/Behaviors/HandleBrowsers.php
+++ b/src/Repositories/Behaviors/HandleBrowsers.php
@@ -123,7 +123,7 @@ trait HandleBrowsers
      */
     public function getFormFieldsForBrowser($object, $relation, $routePrefix = null, $titleKey = 'title', $moduleName = null)
     {
-        $fields = $object->$relation instanceof BelongsTo ? collect([$object->$relation]) : $object->$relation;
+        $fields = $object->$relation() instanceof BelongsTo ? collect([$object->$relation]) : $object->$relation;
         return $fields->map(function ($relatedElement) use ($titleKey, $routePrefix, $relation, $moduleName) {
             return [
                     'id' => $relatedElement->id,

--- a/src/Repositories/Behaviors/HandleBrowsers.php
+++ b/src/Repositories/Behaviors/HandleBrowsers.php
@@ -3,6 +3,9 @@
 namespace A17\Twill\Repositories\Behaviors;
 
 use A17\Twill\Models\Behaviors\HasMedias;
+use A17\Twill\Models\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 
 trait HandleBrowsers
@@ -48,7 +51,10 @@ trait HandleBrowsers
     public function getFormFieldsHandleBrowsers($object, $fields)
     {
         foreach ($this->getBrowsers() as $browser) {
-            $fields['browsers'][$browser['browserName']] = $this->getFormFieldsForBrowser($object, $browser['relation'], $browser['routePrefix'], $browser['titleKey'], $browser['moduleName']);
+            $relation =  $browser['relation'];
+            if(!empty($object->$relation)) {
+                $fields['browsers'][$browser['browserName']] = $this->getFormFieldsForBrowser($object, $relation, $browser['routePrefix'], $browser['titleKey'], $browser['moduleName']);
+            }
         }
 
         return $fields;
@@ -68,13 +74,21 @@ trait HandleBrowsers
         $browserName = $browserName ?? $relationship;
         $fieldsHasElements = isset($fields['browsers'][$browserName]) && !empty($fields['browsers'][$browserName]);
         $relatedElements = $fieldsHasElements ? $fields['browsers'][$browserName] : [];
+
         $relatedElementsWithPosition = [];
         $position = 1;
+
         foreach ($relatedElements as $relatedElement) {
             $relatedElementsWithPosition[$relatedElement['id']] = [$positionAttribute => $position++] + $pivotAttributes;
         }
 
-        $object->$relationship()->sync($relatedElementsWithPosition);
+        if($object->$relationship() instanceof BelongsTo) {
+            $foreignKey = $object->$relationship()->getForeignKeyName();
+            $id = Arr::get($relatedElements, '0.id', null);
+            $object->update([$foreignKey => $id]);
+        }else {
+            $object->$relationship()->sync($relatedElementsWithPosition);
+        }
     }
 
     /**
@@ -110,17 +124,19 @@ trait HandleBrowsers
      */
     public function getFormFieldsForBrowser($object, $relation, $routePrefix = null, $titleKey = 'title', $moduleName = null)
     {
-        return $object->$relation->map(function ($relatedElement) use ($titleKey, $routePrefix, $relation, $moduleName) {
+        $fields = $object->$relation instanceof Model ? collect([$object->$relation]) : $object->$relation;
+        return $fields->map(function ($relatedElement) use ($titleKey, $routePrefix, $relation, $moduleName) {
             return [
-                'id' => $relatedElement->id,
-                'name' => $relatedElement->titleInBrowser ?? $relatedElement->$titleKey,
-                'edit' => moduleRoute($moduleName ?? $relation, $routePrefix ?? '', 'edit', $relatedElement->id),
-                'endpointType' => $relatedElement->getMorphClass(),
-            ] + (classHasTrait($relatedElement, HasMedias::class) ? [
-                'thumbnail' => $relatedElement->defaultCmsImage(['w' => 100, 'h' => 100]),
-            ] : []);
+                    'id' => $relatedElement->id,
+                    'name' => $relatedElement->titleInBrowser ?? $relatedElement->$titleKey,
+                    'edit' => moduleRoute($moduleName ?? $relation, $routePrefix ?? '', 'edit', $relatedElement->id),
+                    'endpointType' => $relatedElement->getMorphClass(),
+                ] + (classHasTrait($relatedElement, HasMedias::class) ? [
+                    'thumbnail' => $relatedElement->defaultCmsImage(['w' => 100, 'h' => 100]),
+                ] : []);
         })->toArray();
     }
+
 
     /**
      * @param \A17\Twill\Models\Model $object
@@ -131,14 +147,14 @@ trait HandleBrowsers
     {
         return $object->getRelated($relation)->map(function ($relatedElement) {
             return ($relatedElement != null) ? [
-                'id' => $relatedElement->id,
-                'name' => $relatedElement->titleInBrowser ?? $relatedElement->title,
-                'endpointType' => $relatedElement->getMorphClass(),
-            ] + (empty($relatedElement->adminEditUrl) ? [] : [
-                'edit' => $relatedElement->adminEditUrl,
-            ]) + (classHasTrait($relatedElement, HasMedias::class) ? [
-                'thumbnail' => $relatedElement->defaultCmsImage(['w' => 100, 'h' => 100]),
-            ] : []) : [];
+                    'id' => $relatedElement->id,
+                    'name' => $relatedElement->titleInBrowser ?? $relatedElement->title,
+                    'endpointType' => $relatedElement->getMorphClass(),
+                ] + (empty($relatedElement->adminEditUrl) ? [] : [
+                    'edit' => $relatedElement->adminEditUrl,
+                ]) + (classHasTrait($relatedElement, HasMedias::class) ? [
+                    'thumbnail' => $relatedElement->defaultCmsImage(['w' => 100, 'h' => 100]),
+                ] : []) : [];
         })->reject(function ($item) {
             return empty($item);
         })->values()->toArray();

--- a/src/Repositories/Behaviors/HandleBrowsers.php
+++ b/src/Repositories/Behaviors/HandleBrowsers.php
@@ -3,7 +3,6 @@
 namespace A17\Twill\Repositories\Behaviors;
 
 use A17\Twill\Models\Behaviors\HasMedias;
-use A17\Twill\Models\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
@@ -124,7 +123,7 @@ trait HandleBrowsers
      */
     public function getFormFieldsForBrowser($object, $relation, $routePrefix = null, $titleKey = 'title', $moduleName = null)
     {
-        $fields = $object->$relation instanceof Model ? collect([$object->$relation]) : $object->$relation;
+        $fields = $object->$relation instanceof BelongsTo ? collect([$object->$relation]) : $object->$relation;
         return $fields->map(function ($relatedElement) use ($titleKey, $routePrefix, $relation, $moduleName) {
             return [
                     'id' => $relatedElement->id,

--- a/views/partials/form/_medias.blade.php
+++ b/views/partials/form/_medias.blade.php
@@ -63,7 +63,7 @@
             @if ($altTextMaxLength) :alt-text-max-length="{{ $altTextMaxLength }}" @endif
             @if ($captionMaxLength) :caption-max-length="{{ $captionMaxLength }}" @endif
             @if ($buttonOnTop) :button-on-top="true" @endif
-            @if (!$activeCrop) activeCrop: false, @endif
+            @if (!$activeCrop) :active-crop="false" @endif
         >{{ $note }}@if($multiple) </a17-slideshow> @else </a17-mediafield> @endif
     </a17-inputframe>
 

--- a/views/partials/form/_medias.blade.php
+++ b/views/partials/form/_medias.blade.php
@@ -13,6 +13,7 @@
     $widthMin = $widthMin ?? 0;
     $heightMin = $heightMin ?? 0;
     $buttonOnTop = $buttonOnTop ?? false;
+    $activeCrop = $activeCrop ?? true;
 @endphp
 
 @if (config('twill.media_library.translated_form_fields', $translated ?? false) && ($translated ?? true))
@@ -32,6 +33,7 @@
             @if (!$withVideoUrl) withVideoUrl: false, @endif
             @if (!$withCaption) withCaption: false, @endif
             @if ($buttonOnTop) buttonOnTop: true, @endif
+            @if (!$activeCrop) activeCrop: false, @endif
             @include('twill::partials.form.utils._field_name', ['asAttributes' => true])
         }"
     ></a17-locale>
@@ -61,6 +63,7 @@
             @if ($altTextMaxLength) :alt-text-max-length="{{ $altTextMaxLength }}" @endif
             @if ($captionMaxLength) :caption-max-length="{{ $captionMaxLength }}" @endif
             @if ($buttonOnTop) :button-on-top="true" @endif
+            @if (!$activeCrop) activeCrop: false, @endif
         >{{ $note }}@if($multiple) </a17-slideshow> @else </a17-mediafield> @endif
     </a17-inputframe>
 


### PR DESCRIPTION
## Description

_activeCrop_ was already available in vue-file but could not be set. Now _activeCrop_ can be set in medias form-field.

```
@formField('medias', [
    'name' => 'image', 
    'label' => 'Image',
    'activeCrop' => false
])
```

This also adds a missing _activeCrop_ condition (media-crop-link)

