### PR TITLE
Add a configuration system for capsules

### DIFF
--- a/config/capsules.php
+++ b/config/capsules.php
@@ -21,6 +21,8 @@ return [
         // ['name' => 'Artists', 'enabled' => true],
         // ['name' => 'Posts', 'enabled' => true],
     ],
+
+    'capsule_config_prefix' => 'twill.capsule'
 ];
 
 /// To fully override this config:


### PR DESCRIPTION
## Description

This PR creates a configuration system for Capsules. 

We can create config in two different places:

1. Create a `config.php` file on the capsule base directory (`app/Twill/Capsules/Homepages/config.php`):

``` php
<?php

return [
    'seo' => ['enabled' => false],
];
```

But this configuration can be overloaded by:

2. A `config/twill.php` configuration on the Capsule config entry:

``` php
<?php

return [
    'capsules' => [
        'list' => [
            [
                'name' => 'Homepages',
                
                'enabled' => true,

                'config' => [
                    'seo' => ['enabled' => false],
                ],
            ],
       ...
       ],
];
```

## Usage 

Using Laravel `config()` helper:

``` php
$seoEnabled = config('twill.capsule.homepages.seo.enabled')
```

But the config array is also hydrated into the capsule structure, so you can use the `capsules()` helper (coming on another PR):

``` php
$seoEnabled = capsules('homepages')['config]['seo']['enabled'];
```

## Rationale

By creating a set of community Capsules, we may need to allow people to enable/disable/configure some Capsules aspects, like SEO, which is good to have usually, but not everyone wants to have SEO being supported everywhere. On homepages, usually we do, but if we are creating a module (countries) that's not directly exposed to users as pages, we possibly wouldn't need them to have SEO fields, but, if we are creating Destinations pages for those countries, we probably will.

