### PR TITLE
Add some capsule finder methods and helpers

### DIFF
--- a/src/Helpers/helpers.php
+++ b/src/Helpers/helpers.php
@@ -241,13 +241,25 @@ if (!function_exists('generate_list_of_allowed_blocks')) {
 
 if (!function_exists('capsule_namespace')) {
     function capsule_namespace($capsuleName, $type = null) {
-        return app('twill.capsules.manager')->capsuleNamespace($capsuleName, $type);
+        return capsules()->capsuleNamespace($capsuleName, $type);
     }
 }
 
 
 if (!function_exists('capsule_namespace_to_path')) {
     function capsule_namespace_to_path($namespace, $capsuleNamespace, $rootPath) {
-        return app('twill.capsules.manager')->capsuleNamespaceToPath($namespace, $capsuleNamespace, $rootPath);
+        return capsules()->capsuleNamespaceToPath($namespace, $capsuleNamespace, $rootPath);
+    }
+}
+
+if (!function_exists('capsules')) {
+    function capsules($capsule = null) {
+        $manager = app('twill.capsules.manager');
+
+        if (filled($capsule)) {
+            return $manager->capsule($capsule);
+        }
+
+        return $manager;
     }
 }


### PR DESCRIPTION
## Description

This PR add a set of new helpers to allow us to find capsules in different ways, we could already find Capsules by the module name or model name, now we also can find them by a file path name inside the capsule directory and by any Capsule class name. It also introduces a new `capsules()` helper, which can return the Capsules Manager, giving you access to all of the Capsules methods, or find a Capsule by any of those properties.

## Usage

Before we could get the Capsules Manager using the IoC Container directly:

``` php
$capsule = app('twill.capsules.manager')->getCapsuleByModel(Homepage::class);
``` 

Now we can use the helper:

``` php
$capsule = capsules()->getCapsuleByModel(Homepage::class);

$capsule = capsules()->getCapsuleByClass(HomepageRepository::class);

$capsule = capsules()->getCapsuleByPath('/myapp/app/Twill/Capsules/Homepages/config.php');

$capsule = capsules()->getCapsuleByPath('/myapp/app/Twill/Capsules/Homepages');

$capsule = capsules()->getCapsuleByModule('homepages');
```

But all of this can now be done using the helper directly:

``` php
$capsule = capsules(Homepage::class);

$capsule = capsules(HomepageRepository::class);

$capsule = capsules('/myapp/app/Twill/Capsules/Homepages/config.php');

$capsule = capsules('/myapp/app/Twill/Capsules/Homepages');

$capsule = capsules('homepages');
```