### PR TITLE
Fix for multi-country locales supported by Translatable

### DIFF
--- a/src/Helpers/helpers.php
+++ b/src/Helpers/helpers.php
@@ -245,7 +245,6 @@ if (!function_exists('capsule_namespace')) {
     }
 }
 
-
 if (!function_exists('capsule_namespace_to_path')) {
     function capsule_namespace_to_path($namespace, $capsuleNamespace, $rootPath) {
         return capsules()->capsuleNamespaceToPath($namespace, $capsuleNamespace, $rootPath);
@@ -261,5 +260,17 @@ if (!function_exists('capsules')) {
         }
 
         return $manager;
+    }
+}
+
+if (!function_exists('twill_locales')) {
+    function twill_locales() {
+        return $allLanguages = collect(config('translatable.locales'))->map(function ($locale, $index) {
+            return collect($locale)->map(function ($country) use ($locale, $index) {
+                return is_numeric($index)
+                    ? $locale
+                    : "$index-$country";
+            });
+        })->flatten()->toArray();
     }
 }

--- a/src/Helpers/helpers.php
+++ b/src/Helpers/helpers.php
@@ -262,15 +262,3 @@ if (!function_exists('capsules')) {
         return $manager;
     }
 }
-
-if (!function_exists('twill_locales')) {
-    function twill_locales() {
-        return $allLanguages = collect(config('translatable.locales'))->map(function ($locale, $index) {
-            return collect($locale)->map(function ($country) use ($locale, $index) {
-                return is_numeric($index)
-                    ? $locale
-                    : "$index-$country";
-            });
-        })->flatten()->toArray();
-    }
-}

--- a/src/Helpers/i18n_helpers.php
+++ b/src/Helpers/i18n_helpers.php
@@ -16,7 +16,7 @@ if (!function_exists('getLocales')) {
      */
     function getLocales()
     {
-        return config('translatable.locales') ?? [config('app.locale')];
+        return twill_locales() ?? [config('app.locale')];
     }
 }
 
@@ -30,7 +30,7 @@ if (!function_exists('getLanguagesForVueStore')) {
     {
         $manageMultipleLanguages = count(getLocales()) > 1;
         if ($manageMultipleLanguages && $translate) {
-            $allLanguages = Collection::make(config('translatable.locales'))->map(function ($locale, $index) use ($form_fields) {
+            $allLanguages = Collection::make(twill_locales())->map(function ($locale, $index) use ($form_fields) {
                 return [
                     'shortlabel' => strtoupper($locale),
                     'label' => getLanguageLabelFromLocaleCode($locale),

--- a/src/Helpers/i18n_helpers.php
+++ b/src/Helpers/i18n_helpers.php
@@ -16,7 +16,19 @@ if (!function_exists('getLocales')) {
      */
     function getLocales()
     {
-        return twill_locales() ?? [config('app.locale')];
+        $locales = collect(config('translatable.locales'))->map(function ($locale, $index) {
+            return collect($locale)->map(function ($country) use ($locale, $index) {
+                return is_numeric($index)
+                    ? $locale
+                    : "$index-$country";
+            });
+        })->flatten()->toArray();
+
+        if (blank($locales)) {
+            $locales = [config('app.locale')];
+        }
+
+        return $locales;
     }
 }
 
@@ -30,7 +42,7 @@ if (!function_exists('getLanguagesForVueStore')) {
     {
         $manageMultipleLanguages = count(getLocales()) > 1;
         if ($manageMultipleLanguages && $translate) {
-            $allLanguages = Collection::make(twill_locales())->map(function ($locale, $index) use ($form_fields) {
+            $allLanguages = Collection::make(getLocales())->map(function ($locale, $index) use ($form_fields) {
                 return [
                     'shortlabel' => strtoupper($locale),
                     'label' => getLanguageLabelFromLocaleCode($locale),

--- a/src/Http/Controllers/Admin/ModuleController.php
+++ b/src/Http/Controllers/Admin/ModuleController.php
@@ -1159,7 +1159,7 @@ abstract class ModuleController extends Controller
                 'html' => $column['html'] ?? false,
             ]);
         }
-        if ($this->moduleHas('translations') && count(twill_locales()) > 1) {
+        if ($this->moduleHas('translations') && count(getLocales()) > 1) {
             array_push($tableColumns, [
                 'name' => 'languages',
                 'label' => twillTrans('twill::lang.listing.languages'),

--- a/src/Http/Controllers/Admin/ModuleController.php
+++ b/src/Http/Controllers/Admin/ModuleController.php
@@ -1159,7 +1159,7 @@ abstract class ModuleController extends Controller
                 'html' => $column['html'] ?? false,
             ]);
         }
-        if ($this->moduleHas('translations') && count(config('translatable.locales')) > 1) {
+        if ($this->moduleHas('translations') && count(twill_locales()) > 1) {
             array_push($tableColumns, [
                 'name' => 'languages',
                 'label' => twillTrans('twill::lang.listing.languages'),

--- a/src/Models/Behaviors/HasTranslation.php
+++ b/src/Models/Behaviors/HasTranslation.php
@@ -138,7 +138,7 @@ trait HasTranslation
                 'published' => $translation->active ?? false,
             ];
         })->sortBy(function ($translation) {
-            $localesOrdered = twill_locales();
+            $localesOrdered = getLocales();
             return array_search($translation['value'], $localesOrdered);
         })->values();
     }

--- a/src/Models/Behaviors/HasTranslation.php
+++ b/src/Models/Behaviors/HasTranslation.php
@@ -138,7 +138,7 @@ trait HasTranslation
                 'published' => $translation->active ?? false,
             ];
         })->sortBy(function ($translation) {
-            $localesOrdered = config('translatable.locales');
+            $localesOrdered = twill_locales();
             return array_search($translation['value'], $localesOrdered);
         })->values();
     }


### PR DESCRIPTION
## Description

If we install Laravel and Twill and don't configure Translatable right away, [this error will happen](https://flareapp.io/share/oPRbJ8kP):

<img width="1239" alt="Screenshot 2021-05-23 at 00 20 59" src="https://user-images.githubusercontent.com/3182864/119242259-c3206e80-bb5c-11eb-9edd-c5a86ab7ad0e.png">

Because Twill doesn't support [multi-countries locales present on Translatable](https://github.com/Astrotomic/laravel-translatable/blame/master/src/config/translatable.php#L16):

``` php
'locales' => [
    'en',
    'fr',
    'es' => [
        'MX', // mexican spanish
         'CO', // colombian spanish
    ],
],
```

This PR basically fix this by changing the `i18_helpers->getLocales()` to support them and return:

``` php
[
    "en",
    "fr",
    "es-MX",
    "es-CO",
]
```

It also replaces some instances of `config('translatable.locales')` by the helper.

