### PR TITLE
Ensures app/Twill/Capsules exists during install

### DIFF
--- a/src/Commands/CapsuleInstall.php
+++ b/src/Commands/CapsuleInstall.php
@@ -309,6 +309,8 @@ class CapsuleInstall extends Command
 
     protected function getTempFileName()
     {
+        $this->makeDir($this->capsule['base_path']);
+
         return $this->capsule['base_path'] . '/install.zip';
     }
 
@@ -402,5 +404,12 @@ class CapsuleInstall extends Command
         rename($this->getUnzippedPath(), $destination);
 
         return file_exists($destination);
+    }
+
+    public function makeDir($path)
+    {
+        if (!file_exists($path)) {
+            mkdir($path, 0775, true);
+        }
     }
 }


### PR DESCRIPTION
## Description

If try to install a Capsule without creating one or creating app/Twill/Capsules, the install command will not work. This PR fix this.
