### PR TITLE
Get All Images with All Crops

### DIFF
--- a/src/Models/Behaviors/HasMedias.php
+++ b/src/Models/Behaviors/HasMedias.php
@@ -102,6 +102,22 @@ trait HasMedias
         return $urls;
     }
 
+    public function imagesWithCrops($role, $params = [])
+    {
+        $medias = $this->medias->filter(function ($media) use ($role) {
+            return $media->pivot->role === $role;
+        });
+
+        $urls = [];
+
+        foreach ($medias as $media) {
+            $paramsforcrop = $params[$media->pivot->crop] ?? [];
+            $urls[$media->id][$media->pivot->crop] = $this->image($role, $media->pivot->crop, $paramsforcrop, false, false, $media);
+        }
+
+        return $urls;
+    }
+
     public function imageAsArray($role, $crop = "default", $params = [], $media = null)
     {
         if (!$media) {
@@ -132,6 +148,22 @@ trait HasMedias
 
         foreach ($medias as $media) {
             $arrays[] = $this->imageAsArray($role, $crop, $params, $media);
+        }
+
+        return $arrays;
+    }
+
+    public function imagesAsArraysWithCrops($role, $params = [])
+    {
+        $medias = $this->medias->filter(function ($media) use ($role) {
+            return $media->pivot->role === $role;
+        });
+
+        $arrays = [];
+
+        foreach ($medias as $media) {
+            $paramsforcrop = $params[$media->pivot->crop] ?? [];
+            $arrays[$media->id][$media->pivot->crop] = $this->imageAsArray($role, $media->pivot->crop, $paramsforcrop, $media);
         }
 
         return $arrays;


### PR DESCRIPTION
## Description
get crops for all images and in params we can set for each crop

sample for $params: 
```
[
 'desktop'=>['w'=>'1400'],
 'mobile'=>['w'=>'450']
]
```
 
- imagesWithCrops($role, $params = [])
![235a1c1cf7fe3a6d93084ac0b351952c](https://user-images.githubusercontent.com/669491/119259219-e0ddea00-bbd5-11eb-92d5-522e3da3837e.jpg)

- imagesAsArraysWithCrops($role, $params = [])
![34252345](https://user-images.githubusercontent.com/669491/119259251-066af380-bbd6-11eb-9db0-3415ccfa6502.png)


