### PR TITLE
Add Twill API documentation generator

### DIFF
--- a/docs-api/.gitignore
+++ b/docs-api/.gitignore
@@ -1,0 +1,4 @@
+cache/
+build/
+vendor/
+composer.lock

--- a/docs-api/README.md
+++ b/docs-api/README.md
@@ -1,0 +1,24 @@
+# Twill API docs
+
+Uses [Doctum](https://github.com/code-lts/doctum) to generate a static website to browse the Twill API.
+
+## Initial setup
+
+```
+cd docs-api
+composer install
+```
+
+## Generate the documentation
+
+```
+composer run build
+```
+
+## Access the documentation locally
+
+```
+composer run serve
+```
+
+Visit [localhost:8000/2.x](http://localhost:8000/2.x/index.html) in your Web browser.

--- a/docs-api/composer.json
+++ b/docs-api/composer.json
@@ -1,0 +1,9 @@
+{
+  "require": {
+    "code-lts/doctum": "^5.4"
+  },
+  "scripts": {
+    "build": "php vendor/bin/doctum.php update --ignore-parse-errors -- config.php",
+    "serve": "php -S 0.0.0.0:8000 -t build"
+  }
+}

--- a/docs-api/config.php
+++ b/docs-api/config.php
@@ -1,0 +1,29 @@
+<?php
+
+use Doctum\Doctum;
+use Doctum\RemoteRepository\GitHubRemoteRepository;
+use Doctum\Version\GitVersionCollection;
+use Symfony\Component\Finder\Finder;
+
+$dir = '../src';
+
+$iterator = Finder::create()
+    ->files()
+    ->name('*.php')
+    ->in($dir);
+
+$versions = GitVersionCollection::create($dir)
+    ->add('1.1', '1.1 branch')
+    ->add('1.2', '1.2 branch')
+    ->add('2.x', '2.x branch')
+    ->add('master', 'master branch');
+
+return new Doctum($iterator, [
+    'title' => 'Twill API',
+    'versions' => $versions,
+    'language' => 'en',
+    'build_dir' => __DIR__ . '/build/%version%',
+    'cache_dir' => __DIR__ . '/cache/%version%',
+    'remote_repository' => new GitHubRemoteRepository('area17/twill', dirname($dir)),
+    'default_opened_level' => 2,
+]);

--- a/docs/.sections/api-documentation.md
+++ b/docs/.sections/api-documentation.md
@@ -1,0 +1,8 @@
+## API Documentation
+
+[Doctum](https://github.com/code-lts/doctum) generated API documentation of the framework is available [here](twill.io/api/2.x) for `2.x` and previous versions.
+
+- [`2.x`](twill.io/api/2.x)
+- [`master`](twill.io/api/master)
+- [`1.2`](twill.io/api/1.2)
+- [`1.1`](twill.io/api/1.1)

--- a/docs/generate_readme.js
+++ b/docs/generate_readme.js
@@ -12,7 +12,8 @@ const sections = [
   'media-library',
   'artisan',
   'other-cms-features',
-  'resources'
+  'resources',
+  'api-documentation'
 ];
 
 const settings = `---


### PR DESCRIPTION
## Description

This adds a `docs-api/` directory with a [Doctum](https://github.com/code-lts/doctum) setup to generate static API docs for multiple versions of Twill.

The versions correspond to branches `1.1`, `1.2`, `2.x` and `master`. This can be adjusted more granularly (e.g. tags instead of branches). See `config.php`.

Doctum generates independent sites/bundles for each versions, without a main level `index.html`. I was hesitant to add one. A server-side redirect (e.g. from `twill.io/api` to `twill.io/api/2.x`) could be a simple solution but may require some maintenance over time.

## TODO

- Add a link from the main docs to the API docs
- Rework the default CSS theme to be more in tune with the main docs

## Related Issues

Related to https://github.com/area17/twill/discussions/921
