### PR TITLE
Add dependency resolver to twill:capsule:install

### DIFF
--- a/src/Commands/CapsuleInstall.php
+++ b/src/Commands/CapsuleInstall.php
@@ -119,7 +119,7 @@ class CapsuleInstall extends Command
             'module' => $this->argument('capsule'),
             'branch' => $this->option('branch'),
             'service' => $this->option('service'),
-            'prefix' => $this->option('service'),
+            'prefix' => $this->option('prefix'),
         ];
 
         $this->loadCapsule($capsule);


### PR DESCRIPTION
## Description

This PR brings a simple dependency resolver to Capsules installer. It's already possible to test it by running:

``` bash
php artisan twill:capsule:install --copy cities
```

It will install, along with the main Capsule ([Cities](https://github.com/area17/twill-capsule-cities)), also the [Base](https://github.com/area17/twill-capsule-base) and [Countries](https://github.com/area17/twill-capsule-countries) Capsules.

It gets information from a `twill.json` file (not sure if this the best name/format for it) which should be present in the root of a Capsule that has dependencies:

``` json
{
    "dependencies": {
        "capsules": [
            {
                "capsule": "Base"
            },
            {
                "capsule": "Countries",
                "branch": "stable"
            }
        ]
    }
}
```

