### PR TITLE
Update Media Library Controller replace for postgres

### DIFF
--- a/src/Http/Controllers/Admin/FileLibraryController.php
+++ b/src/Http/Controllers/Admin/FileLibraryController.php
@@ -39,7 +39,7 @@ class FileLibraryController extends ModuleController implements SignUploadListen
     protected $defaultFilters = [
         'search' => 'search',
         'tag' => 'tag_id',
-        'unused' => 'unused'
+        'unused' => 'unused',
     ];
 
     /**
@@ -315,6 +315,6 @@ class FileLibraryController extends ModuleController implements SignUploadListen
      */
     private function shouldReplaceFile($id)
     {
-        return $this->repository->whereId($id)->exists();
+        return isset($id) ? $this->repository->whereId($id)->exists() : false;
     }
 }

--- a/src/Http/Controllers/Admin/MediaLibraryController.php
+++ b/src/Http/Controllers/Admin/MediaLibraryController.php
@@ -339,6 +339,6 @@ class MediaLibraryController extends ModuleController implements SignUploadListe
      */
     private function shouldReplaceMedia($id)
     {
-        return $id == 'null' ? false : $this->repository->whereId($id)->exists();
+        return isset($id) ? $this->repository->whereId($id)->exists() : false;
     }
 }

--- a/src/Http/Controllers/Admin/MediaLibraryController.php
+++ b/src/Http/Controllers/Admin/MediaLibraryController.php
@@ -339,6 +339,6 @@ class MediaLibraryController extends ModuleController implements SignUploadListe
      */
     private function shouldReplaceMedia($id)
     {
-        return $this->repository->whereId($id)->exists();
+        return $id == 'null' ? false : $this->repository->whereId($id)->exists();
     }
 }


### PR DESCRIPTION
Fix an issue with the media replacement functionality to support postgres databases.

## Description

Just a ternary to check if the id is 'null' and return false in that case.

## Related Issues
	Fixes #938

