### PR TITLE
Add suport for custom titleKeys to related browsers

### DIFF
--- a/src/Repositories/Behaviors/HandleBrowsers.php
+++ b/src/Repositories/Behaviors/HandleBrowsers.php
@@ -127,12 +127,12 @@ trait HandleBrowsers
      * @param string $relation
      * @return array
      */
-    public function getFormFieldsForRelatedBrowser($object, $relation)
+    public function getFormFieldsForRelatedBrowser($object, $relation, $titleKey = 'title')
     {
-        return $object->getRelated($relation)->map(function ($relatedElement) {
+        return $object->getRelated($relation)->map(function ($relatedElement) use ($titleKey) {
             return ($relatedElement != null) ? [
                 'id' => $relatedElement->id,
-                'name' => $relatedElement->titleInBrowser ?? $relatedElement->title,
+                'name' => $relatedElement->titleInBrowser ?? $relatedElement->$titleKey,
                 'endpointType' => $relatedElement->getMorphClass(),
             ] + (empty($relatedElement->adminEditUrl) ? [] : [
                 'edit' => $relatedElement->adminEditUrl,


### PR DESCRIPTION
This PR brings support to have something different from `title` as main column name on `related browsers`:

``` php
$fields['browsers']['cars'] = $this->getFormFieldsForRelatedBrowser($object, 'cars', 'name');
```