### PR TITLE
Add an autoloading system to to Capsules

### DIFF
--- a/src/Services/Capsules/HasCapsules.php
+++ b/src/Services/Capsules/HasCapsules.php
@@ -162,6 +162,8 @@ trait HasCapsules
 
         $this->registerPsr4Autoloader($capsule);
 
+        $this->autoloadConfigFiles($capsule);
+
         return $capsule;
     }
 
@@ -353,5 +355,20 @@ trait HasCapsules
         ]);
 
         return $config;
+    }
+
+    public function autoloadConfigFiles($capsule)
+    {
+        $files = $capsule['config']['autoload']['files'] ?? null;
+
+        if (blank($files)) {
+            return;
+        }
+
+        collect($files)->each(function ($file) {
+           if (file_exists($file)) {
+               require_once $file;
+           }
+        });
     }
 }


### PR DESCRIPTION
## Description

This PR adds that ability for Capsules to autoload files, like a `helpers.php`:

``` php
<?php

return [
    'seo' => ['enabled' => true],

    'autoload' => [
        'files' => [__DIR__ . '/../Base/helpers.php'],
    ],
];
```

In the future, maybe, this could be done by using Composer itself, but I have the impression it would drag everyone feet if we have to always go back to Composer.json to add stuff.

What this doesn't solve is a possible Capsule need to override a Laravel helper (or any other package), as files are being loaded too late on the application lifecycle.

This is, of course, a very rudimentary autoloading system. 😆