### PR TITLE
[2x-null-replace_media_id] Due to null ID which cause error

### DIFF
--- a/src/Http/Controllers/Admin/MediaLibraryController.php
+++ b/src/Http/Controllers/Admin/MediaLibraryController.php
@@ -339,6 +339,9 @@ class MediaLibraryController extends ModuleController implements SignUploadListe
      */
     private function shouldReplaceMedia($id)
     {
+        if (is_null($id) || strval($id) === 'null') {
+            return false;
+        }
         return $this->repository->whereId($id)->exists();
     }
 }


### PR DESCRIPTION
## Description

I use PostgreSQL and got this error when uploading a media file

```
[2021-06-04 02:44:56] production.ERROR: SQLSTATE[22P02]: Invalid text representation: 7 ERROR:  invalid input syntax for integer: "null" (SQL: select exists(select * from "medias" where "id" = null and "medias"."deleted_at" is null) as "exists") {"userId":1,"exception":"[object] (Illuminate\\Database\\QueryException(code: 22P02): SQLSTATE[22P02]: Invalid text representation: 7 ERROR:  invalid input syntax for integer: \"null\" (SQL: select exists(select * from \"medias\" where \"id\" = null and \"medias\".\"deleted_at\" is null) as \"exists\") at /workspace/vendor/laravel/framework/src/Illuminate/Database/Connection.php:685)
[stacktrace]
#0 /workspace/vendor/laravel/framework/src/Illuminate/Database/Connection.php(645): Illuminate\\Database\\Connection->runQueryCallback()
#1 /workspace/vendor/laravel/framework/src/Illuminate/Database/Connection.php(353): Illuminate\\Database\\Connection->run()
#2 /workspace/vendor/laravel/framework/src/Illuminate/Database/Query/Builder.php(2705): Illuminate\\Database\\Connection->select()
#3 /workspace/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Builder.php(1648): Illuminate\\Database\\Query\\Builder->exists()
#4 /workspace/vendor/area17/twill/src/Http/Controllers/Admin/MediaLibraryController.php(342): Illuminate\\Database\\Eloquent\\Builder->__call()
#5 /workspace/vendor/area17/twill/src/Http/Controllers/Admin/MediaLibraryController.php(214): A17\\Twill\\Http\\Controllers\\Admin\\MediaLibraryController->shouldReplaceMedia()
#6 /workspace/vendor/
```
## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
