### PR TITLE
Update model and repository behaviors docblocks

### DIFF
--- a/docs/.sections/media-library.md
+++ b/docs/.sections/media-library.md
@@ -42,87 +42,9 @@ Using the Person example, your `cover` image could have a `square` crop for mobi
 
 The only thing you have to do to make it work is to compose your model and repository with the appropriate traits, respectively `HasMedias` and `HandleMedias`, setup your `$mediasParams` configuration and use the `medias` form partial in your form view (more info in the CRUD section).
 
-When it comes to using those data model images in the frontend site, there are a few methods on the `HasMedias` trait that will help you to retrieve them for each of your layouts:
+When it comes to using those data model images in the frontend site, there are a few methods on the `HasMedias` trait that will help you to retrieve them for each of your layouts. You can find the full
+reference in the [HasMedias API documentation](https://twill.io/docs/api/2.x/A17/Twill/Models/Behaviors/HasMedias.html)
 
-```php
-<?php
-
-/**
- * Returns the url of the associated image for $roleName and $cropName.
- * Optionally add params compatible with the current image service in use like w or h.
- * Optionally indicate that you can provide a fallback so that this method will return null
- * instead of the fallback image.
- * Optionally indicate that you are displaying this image in the CMS views.
- * Optionally provide a $media object if you already retrieved one to prevent more SQL requests.
- */
-$model->image($roleName, $cropName[, array $params, $has_fallback, $cms, $media])
-
-/**
- * Returns an array of images URLs assiociated with $roleName and $cropName with appended $params.
- */
-$model->images($roleName, $cropName[, array $params])
-
-/**
- * Returns the image for $roleName and $cropName with default social image params and $params appended
- */
-$model->socialImage($roleName, $cropName[, array $params, $has_fallback])
-
-/**
- * Returns the lqip base64 encoded string from the database for $roleName and $cropName.
- * Use this in conjunction with the RefreshLQIP Artisan command.
- */
-$model->lowQualityImagePlaceholder($roleName, $cropName[, array $params, $has_fallback])
-
-/**
- * Returns the image for $roleName and $cropName with default CMS image params and $params appended.
- */
-$model->cmsImage($roleName, $cropName[, array $params, $has_fallback])
-
-/**
- * Returns the alt text of the image associated with $roleName.
- */
-$model->imageAltText($roleName[, $media])
-
-/**
- * Returns the caption of the image associated with $roleName.
- */
-$model->imageCaption($roleName[, $media])
-
-/**
- * Returns the image object associated with $roleName.
- */
-$model->imageObject($roleName[, $cropName])
-
-/**
- * Returns the image objects associated with $roleName.
- */
-$model->imageObjects($roleName[, $cropName])
-
-/**
- * Returns the image associated with $roleName as an array containing meta information.
- */
-$model->imageAsArray($roleName[, $cropName, array $params, $media])
-
-/**
- * Returns the images associated with $roleName as an array containing meta information.
- */
-$model->imagesAsArrays($roleName[, $cropName, array $params])
-
-/**
- * Returns an array of images URLs assiociated with $roleName with appended $params for each crop.
- */
-$model->imagesWithCrops($roleName[, array $params])
-
-/**
- * Returns the images associated with $roleName as an array containing meta information for each crop.
- */
-$model->imagesAsArraysWithCrops($roleName[, array $params])
-
-/**
- * Checks if an image has been attached for the provided role
- */
-$model->hasImage($roleName[, $cropName])
-```
 
 ### File library
 The file library is much simpler but also works with S3 and local storage. To associate files to your model, use the `HasFiles` and `HandleFiles` traits, the `$filesParams` configuration and the `files` form partial.

--- a/docs/.sections/media-library.md
+++ b/docs/.sections/media-library.md
@@ -49,28 +49,9 @@ reference in the [HasMedias API documentation](https://twill.io/docs/api/2.x/A17
 ### File library
 The file library is much simpler but also works with S3 and local storage. To associate files to your model, use the `HasFiles` and `HandleFiles` traits, the `$filesParams` configuration and the `files` form partial.
 
-When it comes to using those data model files in the frontend site, there are a few methods on the `HasFiles` trait that will help you to retrieve direct URLs:
+When it comes to using those data model files in the frontend site, there are a few methods on the `HasFiles` trait that will help you to retrieve direct URLs. You can find the full
+reference in the [HasFiles API documentation](https://twill.io/docs/api/2.x/A17/Twill/Models/Behaviors/HasFiles.html)
 
-```php
-<?php
-
-/**
- * Returns the url of the associated file for $roleName.
- * Optionally indicate which locale of the file if your site has multiple languages.
- * Optionally provide a $file object if you already retrieved one to prevent more SQL requests.
- */
-$model->file($roleName[, $locale, $file])
-
-/**
- * Returns an array of files URLs assiociated with $roleName.
- */
-$model->filesList($roleName[, $locale])
-
-/**
- * Returns the file object associated with $roleName.
- */
-$model->fileObject($roleName)
-```
 
 ### Imgix and S3 direct uploads
 

--- a/src/Models/Behaviors/HasBlocks.php
+++ b/src/Models/Behaviors/HasBlocks.php
@@ -6,11 +6,24 @@ use A17\Twill\Models\Block;
 
 trait HasBlocks
 {
+    /**
+     * Defines the one-to-many relationship for block objects.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\MorphMany
+     */
     public function blocks()
     {
         return $this->morphMany(Block::class, 'blockable')->orderBy(config('twill.blocks_table', 'twill_blocks') . '.position', 'asc');
     }
 
+    /**
+     * Returns the rendered Blade views for all attached blocks in their proper order.
+     *
+     * @param bool $renderChilds Include all child blocks in the rendered output.
+     * @param array $blockViewMappings Provide alternate Blade views for blocks. Format: `['block-type' => 'view.path']`.
+     * @param array $data Provide extra data to Blade views.
+     * @return string
+     */
     public function renderBlocks($renderChilds = true, $blockViewMappings = [], $data = [])
     {
         return $this->blocks->where('parent_id', null)->map(function ($block) use ($blockViewMappings, $renderChilds, $data) {

--- a/src/Models/Behaviors/HasFiles.php
+++ b/src/Models/Behaviors/HasFiles.php
@@ -61,7 +61,7 @@ trait HasFiles
     }
 
     /**
-     * Returns an array of files URLs assiociated with $roleName.
+     * Returns an array of URLs of all attached files for a role.
      *
      * @param string $role Role name.
      * @param string $locale Locale of the file if your site has multiple languages.
@@ -85,7 +85,7 @@ trait HasFiles
     }
 
     /**
-     * Returns the file object associated with $roleName.
+     * Returns the file object attached for a role.
      *
      * @param string $role Role name.
      * @param string $locale Locale of the file if your site has multiple languages.

--- a/src/Models/Behaviors/HasFiles.php
+++ b/src/Models/Behaviors/HasFiles.php
@@ -7,6 +7,11 @@ use A17\Twill\Services\FileLibrary\FileService;
 
 trait HasFiles
 {
+    /**
+     * Defines the many-to-many relationship for file objects.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\MorphToMany
+     */
     public function files()
     {
         return $this->morphToMany(
@@ -33,6 +38,14 @@ trait HasFiles
         return $file;
     }
 
+    /**
+     * Returns the URL of the attached file for a role.
+     *
+     * @param string $role Role name.
+     * @param string $locale Locale of the file if your site has multiple languages.
+     * @param File $file Provide a file object if you already retrieved one to prevent more SQL queries.
+     * @return string|null
+     */
     public function file($role, $locale = null, $file = null)
     {
 
@@ -47,6 +60,13 @@ trait HasFiles
         return null;
     }
 
+    /**
+     * Returns an array of files URLs assiociated with $roleName.
+     *
+     * @param string $role Role name.
+     * @param string $locale Locale of the file if your site has multiple languages.
+     * @return array
+     */
     public function filesList($role, $locale = null)
     {
         $locale = $locale ?? app()->getLocale();
@@ -64,6 +84,13 @@ trait HasFiles
         return $urls;
     }
 
+    /**
+     * Returns the file object associated with $roleName.
+     *
+     * @param string $role Role name.
+     * @param string $locale Locale of the file if your site has multiple languages.
+     * @return File
+     */
     public function fileObject($role, $locale = null)
     {
         return $this->findFile($role, $locale);

--- a/src/Models/Behaviors/HasFiles.php
+++ b/src/Models/Behaviors/HasFiles.php
@@ -42,8 +42,8 @@ trait HasFiles
      * Returns the URL of the attached file for a role.
      *
      * @param string $role Role name.
-     * @param string $locale Locale of the file if your site has multiple languages.
-     * @param File $file Provide a file object if you already retrieved one to prevent more SQL queries.
+     * @param string|null $locale Locale of the file if your site has multiple languages.
+     * @param File|null $file Provide a file object if you already retrieved one to prevent more SQL queries.
      * @return string|null
      */
     public function file($role, $locale = null, $file = null)
@@ -64,7 +64,7 @@ trait HasFiles
      * Returns an array of URLs of all attached files for a role.
      *
      * @param string $role Role name.
-     * @param string $locale Locale of the file if your site has multiple languages.
+     * @param string|null $locale Locale of the file if your site has multiple languages.
      * @return array
      */
     public function filesList($role, $locale = null)
@@ -88,8 +88,8 @@ trait HasFiles
      * Returns the file object attached for a role.
      *
      * @param string $role Role name.
-     * @param string $locale Locale of the file if your site has multiple languages.
-     * @return File
+     * @param string|null $locale Locale of the file if your site has multiple languages.
+     * @return File|null
      */
     public function fileObject($role, $locale = null)
     {

--- a/src/Models/Behaviors/HasMedias.php
+++ b/src/Models/Behaviors/HasMedias.php
@@ -16,7 +16,7 @@ trait HasMedias
     ];
 
     /**
-     * Defines the one-to-many relationship for media objects
+     * Defines the one-to-many relationship for media objects.
      *
      * @return \Illuminate\Database\Eloquent\Relations\MorphMany
      */
@@ -60,7 +60,7 @@ trait HasMedias
     }
 
     /**
-     * Checks if an image has been attached for a role and crop
+     * Checks if an image has been attached for a role and crop.
      *
      * @param string $role Role name
      * @param string $crop Crop name
@@ -74,14 +74,14 @@ trait HasMedias
     }
 
     /**
-     * Returns the URL of the attached image for a role and crop, with appended parameters
+     * Returns the URL of the attached image for a role and crop, with appended parameters.
      *
-     * @param string $role Role name
-     * @param string $crop Crop name
-     * @param array $params Parameters compatible with the current image service, like `w` or `h`
+     * @param string $role Role name.
+     * @param string $crop Crop name.
+     * @param array $params Parameters compatible with the current image service, like `w` or `h`.
      * @param bool $has_fallback Indicate that you can provide a fallback. Will return null instead of the default image fallback.
-     * @param bool $cms Indicate that you are displaying this image in the CMS views
-     * @param Media $media Provide a media object if you already retrieved one to prevent more SQL queries
+     * @param bool $cms Indicate that you are displaying this image in the CMS views.
+     * @param Media $media Provide a media object if you already retrieved one to prevent more SQL queries.
      * @return string|null
      */
     public function image($role, $crop = "default", $params = [], $has_fallback = false, $cms = false, $media = null)
@@ -111,11 +111,11 @@ trait HasMedias
     }
 
     /**
-     * Returns an array of all associated image URLs for a role and crop, with appended parameters
+     * Returns an array of all associated image URLs for a role and crop, with appended parameters.
      *
-     * @param string $role Role name
-     * @param string $crop Crop name
-     * @param array $params Parameters compatible with the current image service, like `w` or `h`
+     * @param string $role Role name.
+     * @param string $crop Crop name.
+     * @param array $params Parameters compatible with the current image service, like `w` or `h`.
      * @return array
      */
     public function images($role, $crop = "default", $params = [])
@@ -134,11 +134,11 @@ trait HasMedias
     }
 
     /**
-     * Returns an array of image URLs assiociated with a role with appended parameters for each crop
+     * Returns an array of image URLs assiociated with a role with appended parameters for each crop.
      *
-     * @param string $role Role name
-     * @param string $crop Crop name
-     * @param array $params Parameters compatible with the current image service, like `w` or `h`
+     * @param string $role Role name.
+     * @param string $crop Crop name.
+     * @param array $params Parameters compatible with the current image service, like `w` or `h`.
      * @return array
      */
     public function imagesWithCrops($role, $params = [])
@@ -158,12 +158,12 @@ trait HasMedias
     }
 
     /**
-     * Returns the image associated with $role as an array containing meta information
+     * Returns the image associated with $role as an array containing meta information.
      *
-     * @param string $role Role name
-     * @param string $crop Crop name
-     * @param array $params Parameters compatible with the current image service, like `w` or `h`
-     * @param Media|null $media
+     * @param string $role Role name.
+     * @param string $crop Crop name.
+     * @param array $params Parameters compatible with the current image service, like `w` or `h`.
+     * @param Media $media Provide a media object if you already retrieved one to prevent more SQL queries.
      * @return array
      */
     public function imageAsArray($role, $crop = "default", $params = [], $media = null)
@@ -187,11 +187,11 @@ trait HasMedias
     }
 
     /**
-     * Returns the images associated with $role as an array containing meta information
+     * Returns the images associated with $role as an array containing meta information.
      *
-     * @param string $role Role name
-     * @param string $crop Crop name
-     * @param array $params Parameters compatible with the current image service, like `w` or `h`
+     * @param string $role Role name.
+     * @param string $crop Crop name.
+     * @param array $params Parameters compatible with the current image service, like `w` or `h`.
      * @return array
      */
     public function imagesAsArrays($role, $crop = "default", $params = [])
@@ -210,10 +210,10 @@ trait HasMedias
     }
 
     /**
-     * Returns the images associated with $roleName as an array containing meta information for each crop
+     * Returns the images associated with $roleName as an array containing meta information for each crop.
      *
-     * @param string $role Role name
-     * @param array $params Parameters compatible with the current image service, like `w` or `h`
+     * @param string $role Role name.
+     * @param array $params Parameters compatible with the current image service, like `w` or `h`.
      * @return array
      */
     public function imagesAsArraysWithCrops($role, $params = [])
@@ -233,10 +233,10 @@ trait HasMedias
     }
 
     /**
-     * Returns the alt text of the image associated with a role
+     * Returns the alt text of the image associated with a role.
      *
-     * @param string $role Role name
-     * @param Media $media Provide a media object if you already retrieved one to prevent more SQL queries
+     * @param string $role Role name.
+     * @param Media $media Provide a media object if you already retrieved one to prevent more SQL queries.
      * @return string
      */
     public function imageAltText($role, $media = null)
@@ -259,10 +259,10 @@ trait HasMedias
     }
 
     /**
-     * Returns the caption of the image associated with a role
+     * Returns the caption of the image associated with a role.
      *
-     * @param string $role Role name
-     * @param Media $media Provide a media object if you already retrieved one to prevent more SQL queries
+     * @param string $role Role name.
+     * @param Media $media Provide a media object if you already retrieved one to prevent more SQL queries.
      * @return string
      */
     public function imageCaption($role, $media = null)
@@ -285,10 +285,10 @@ trait HasMedias
     }
 
     /**
-     * Returns the video URL of the image associated with a role
+     * Returns the video URL of the image associated with a role.
      *
-     * @param string $role Role name
-     * @param Media $media Provide a media object if you already retrieved one to prevent more SQL queries
+     * @param string $role Role name.
+     * @param Media $media Provide a media object if you already retrieved one to prevent more SQL queries.
      * @return string
      */
     public function imageVideo($role, $media = null)
@@ -313,10 +313,10 @@ trait HasMedias
     }
 
     /**
-     * Returns the image object associated with a role and crop
+     * Returns the image object associated with a role and crop.
      *
-     * @param string $role Role name
-     * @param string $crop Crop name
+     * @param string $role Role name.
+     * @param string $crop Crop name.
      * @return Media
      */
     public function imageObject($role, $crop = "default")
@@ -328,9 +328,9 @@ trait HasMedias
      * Returns the LQIP base64 encoded string from the database for a role.
      * Use this in conjunction with the RefreshLQIP Artisan command.
      *
-     * @param string $role Role name
-     * @param string $crop Crop name
-     * @param array $params Parameters compatible with the current image service, like `w` or `h`
+     * @param string $role Role name.
+     * @param string $crop Crop name.
+     * @param array $params Parameters compatible with the current image service, like `w` or `h`.
      * @param bool $has_fallback Indicate that you can provide a fallback. Will return null instead of the default image fallback.
      * @return string
      */
@@ -351,11 +351,11 @@ trait HasMedias
     }
 
     /**
-     * Returns the URL of the social image for a role
+     * Returns the URL of the social image for a role.
      *
-     * @param string $role Role name
-     * @param string $crop Crop name
-     * @param array $params Parameters compatible with the current image service, like `w` or `h`
+     * @param string $role Role name.
+     * @param string $crop Crop name.
+     * @param array $params Parameters compatible with the current image service, like `w` or `h`.
      * @param bool $has_fallback Indicate that you can provide a fallback. Will return null instead of the default image fallback.
      * @return string
      */
@@ -377,11 +377,11 @@ trait HasMedias
     }
 
     /**
-     * Returns the URL of the CMS image for a role
+     * Returns the URL of the CMS image for a role.
      *
-     * @param string $role Role name
-     * @param string $crop Crop name
-     * @param array $params Parameters compatible with the current image service, like `w` or `h`
+     * @param string $role Role name.
+     * @param string $crop Crop name.
+     * @param array $params Parameters compatible with the current image service, like `w` or `h`.
      * @return string
      */
     public function cmsImage($role, $crop = "default", $params = [])
@@ -390,9 +390,9 @@ trait HasMedias
     }
 
     /**
-     * Returns the URL of the default CMS image for this model
+     * Returns the URL of the default CMS image for this model.
      *
-     * @param array $params Parameters compatible with the current image service, like `w` or `h`
+     * @param array $params Parameters compatible with the current image service, like `w` or `h`.
      * @return string
      */
     public function defaultCmsImage($params = [])
@@ -407,10 +407,10 @@ trait HasMedias
     }
 
     /**
-     * Returns the image objects associated with a role and crop
+     * Returns the image objects associated with a role and crop.
      *
-     * @param string $role Role name
-     * @param string $crop Crop name
+     * @param string $role Role name.
+     * @param string $crop Crop name.
      * @return \Illuminate\Support\Enumerable
      */
     public function imageObjects($role, $crop = "default")

--- a/src/Models/Behaviors/HasMedias.php
+++ b/src/Models/Behaviors/HasMedias.php
@@ -81,7 +81,7 @@ trait HasMedias
      * @param array $params Parameters compatible with the current image service, like `w` or `h`.
      * @param bool $has_fallback Indicate that you can provide a fallback. Will return `null` instead of the default image fallback.
      * @param bool $cms Indicate that you are displaying this image in the CMS views.
-     * @param Media $media Provide a media object if you already retrieved one to prevent more SQL queries.
+     * @param Media|null $media Provide a media object if you already retrieved one to prevent more SQL queries.
      * @return string|null
      */
     public function image($role, $crop = "default", $params = [], $has_fallback = false, $cms = false, $media = null)
@@ -162,7 +162,7 @@ trait HasMedias
      * @param string $role Role name.
      * @param string $crop Crop name.
      * @param array $params Parameters compatible with the current image service, like `w` or `h`.
-     * @param Media $media Provide a media object if you already retrieved one to prevent more SQL queries.
+     * @param Media|null $media Provide a media object if you already retrieved one to prevent more SQL queries.
      * @return array
      */
     public function imageAsArray($role, $crop = "default", $params = [], $media = null)
@@ -235,7 +235,7 @@ trait HasMedias
      * Returns the alt text of the image attached for a role.
      *
      * @param string $role Role name.
-     * @param Media $media Provide a media object if you already retrieved one to prevent more SQL queries.
+     * @param Media|null $media Provide a media object if you already retrieved one to prevent more SQL queries.
      * @return string
      */
     public function imageAltText($role, $media = null)
@@ -261,7 +261,7 @@ trait HasMedias
      * Returns the caption of the image attached for a role.
      *
      * @param string $role Role name.
-     * @param Media $media Provide a media object if you already retrieved one to prevent more SQL queries.
+     * @param Media|null $media Provide a media object if you already retrieved one to prevent more SQL queries.
      * @return string
      */
     public function imageCaption($role, $media = null)
@@ -287,7 +287,7 @@ trait HasMedias
      * Returns the video URL of the image attached for a role.
      *
      * @param string $role Role name.
-     * @param Media $media Provide a media object if you already retrieved one to prevent more SQL queries.
+     * @param Media|null $media Provide a media object if you already retrieved one to prevent more SQL queries.
      * @return string
      */
     public function imageVideo($role, $media = null)
@@ -316,7 +316,7 @@ trait HasMedias
      *
      * @param string $role Role name.
      * @param string $crop Crop name.
-     * @return Media
+     * @return Media|null
      */
     public function imageObject($role, $crop = "default")
     {
@@ -411,7 +411,7 @@ trait HasMedias
      *
      * @param string $role Role name.
      * @param string $crop Crop name.
-     * @return \Illuminate\Support\Enumerable
+     * @return \Illuminate\Database\Eloquent\Collection
      */
     public function imageObjects($role, $crop = "default")
     {

--- a/src/Models/Behaviors/HasMedias.php
+++ b/src/Models/Behaviors/HasMedias.php
@@ -16,9 +16,9 @@ trait HasMedias
     ];
 
     /**
-     * Defines the one-to-many relationship for media objects.
+     * Defines the many-to-many relationship for media objects.
      *
-     * @return \Illuminate\Database\Eloquent\Relations\MorphMany
+     * @return \Illuminate\Database\Eloquent\Relations\MorphToMany
      */
     public function medias()
     {
@@ -62,8 +62,8 @@ trait HasMedias
     /**
      * Checks if an image has been attached for a role and crop.
      *
-     * @param string $role Role name
-     * @param string $crop Crop name
+     * @param string $role Role name.
+     * @param string $crop Crop name.
      * @return bool
      */
     public function hasImage($role, $crop = "default")
@@ -79,7 +79,7 @@ trait HasMedias
      * @param string $role Role name.
      * @param string $crop Crop name.
      * @param array $params Parameters compatible with the current image service, like `w` or `h`.
-     * @param bool $has_fallback Indicate that you can provide a fallback. Will return null instead of the default image fallback.
+     * @param bool $has_fallback Indicate that you can provide a fallback. Will return `null` instead of the default image fallback.
      * @param bool $cms Indicate that you are displaying this image in the CMS views.
      * @param Media $media Provide a media object if you already retrieved one to prevent more SQL queries.
      * @return string|null
@@ -325,13 +325,13 @@ trait HasMedias
 
     /**
      * Returns the LQIP base64 encoded string for a role.
-     * Use this in conjunction with the RefreshLQIP Artisan command.
+     * Use this in conjunction with the `RefreshLQIP` Artisan command.
      *
      * @param string $role Role name.
      * @param string $crop Crop name.
      * @param array $params Parameters compatible with the current image service, like `w` or `h`.
-     * @param bool $has_fallback Indicate that you can provide a fallback. Will return null instead of the default image fallback.
-     * @return string
+     * @param bool $has_fallback Indicate that you can provide a fallback. Will return `null` instead of the default image fallback.
+     * @return string|null
      * @see \A17\Twill\Commands\RefreshLQIP
      */
     public function lowQualityImagePlaceholder($role, $crop = "default", $params = [], $has_fallback = false)
@@ -356,8 +356,8 @@ trait HasMedias
      * @param string $role Role name.
      * @param string $crop Crop name.
      * @param array $params Parameters compatible with the current image service, like `w` or `h`.
-     * @param bool $has_fallback Indicate that you can provide a fallback. Will return null instead of the default image fallback.
-     * @return string
+     * @param bool $has_fallback Indicate that you can provide a fallback. Will return `null` instead of the default image fallback.
+     * @return string|null
      */
     public function socialImage($role, $crop = "default", $params = [], $has_fallback = false)
     {

--- a/src/Models/Behaviors/HasMedias.php
+++ b/src/Models/Behaviors/HasMedias.php
@@ -15,6 +15,11 @@ trait HasMedias
         'crop_h',
     ];
 
+    /**
+     * Defines the one-to-many relationship for media objects
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\MorphMany
+     */
     public function medias()
     {
         return $this->morphToMany(
@@ -54,6 +59,13 @@ trait HasMedias
         return $media;
     }
 
+    /**
+     * Checks if an image has been attached for a role and crop
+     *
+     * @param string $role Role name
+     * @param string $crop Crop name
+     * @return bool
+     */
     public function hasImage($role, $crop = "default")
     {
         $media = $this->findMedia($role, $crop);
@@ -61,6 +73,17 @@ trait HasMedias
         return !empty($media);
     }
 
+    /**
+     * Returns the URL of the attached image for a role and crop, with appended parameters
+     *
+     * @param string $role Role name
+     * @param string $crop Crop name
+     * @param array $params Parameters compatible with the current image service, like `w` or `h`
+     * @param bool $has_fallback Indicate that you can provide a fallback. Will return null instead of the default image fallback.
+     * @param bool $cms Indicate that you are displaying this image in the CMS views
+     * @param Media $media Provide a media object if you already retrieved one to prevent more SQL queries
+     * @return string|null
+     */
     public function image($role, $crop = "default", $params = [], $has_fallback = false, $cms = false, $media = null)
     {
 
@@ -87,6 +110,14 @@ trait HasMedias
         return ImageService::getTransparentFallbackUrl();
     }
 
+    /**
+     * Returns an array of all associated image URLs for a role and crop, with appended parameters
+     *
+     * @param string $role Role name
+     * @param string $crop Crop name
+     * @param array $params Parameters compatible with the current image service, like `w` or `h`
+     * @return array
+     */
     public function images($role, $crop = "default", $params = [])
     {
         $medias = $this->medias->filter(function ($media) use ($role, $crop) {
@@ -102,6 +133,14 @@ trait HasMedias
         return $urls;
     }
 
+    /**
+     * Returns an array of image URLs assiociated with a role with appended parameters for each crop
+     *
+     * @param string $role Role name
+     * @param string $crop Crop name
+     * @param array $params Parameters compatible with the current image service, like `w` or `h`
+     * @return array
+     */
     public function imagesWithCrops($role, $params = [])
     {
         $medias = $this->medias->filter(function ($media) use ($role) {
@@ -118,6 +157,15 @@ trait HasMedias
         return $urls;
     }
 
+    /**
+     * Returns the image associated with $role as an array containing meta information
+     *
+     * @param string $role Role name
+     * @param string $crop Crop name
+     * @param array $params Parameters compatible with the current image service, like `w` or `h`
+     * @param Media|null $media
+     * @return array
+     */
     public function imageAsArray($role, $crop = "default", $params = [], $media = null)
     {
         if (!$media) {
@@ -138,6 +186,14 @@ trait HasMedias
         return [];
     }
 
+    /**
+     * Returns the images associated with $role as an array containing meta information
+     *
+     * @param string $role Role name
+     * @param string $crop Crop name
+     * @param array $params Parameters compatible with the current image service, like `w` or `h`
+     * @return array
+     */
     public function imagesAsArrays($role, $crop = "default", $params = [])
     {
         $medias = $this->medias->filter(function ($media) use ($role, $crop) {
@@ -153,6 +209,13 @@ trait HasMedias
         return $arrays;
     }
 
+    /**
+     * Returns the images associated with $roleName as an array containing meta information for each crop
+     *
+     * @param string $role Role name
+     * @param array $params Parameters compatible with the current image service, like `w` or `h`
+     * @return array
+     */
     public function imagesAsArraysWithCrops($role, $params = [])
     {
         $medias = $this->medias->filter(function ($media) use ($role) {
@@ -169,6 +232,13 @@ trait HasMedias
         return $arrays;
     }
 
+    /**
+     * Returns the alt text of the image associated with a role
+     *
+     * @param string $role Role name
+     * @param Media $media Provide a media object if you already retrieved one to prevent more SQL queries
+     * @return string
+     */
     public function imageAltText($role, $media = null)
     {
         if (!$media) {
@@ -188,6 +258,13 @@ trait HasMedias
         return '';
     }
 
+    /**
+     * Returns the caption of the image associated with a role
+     *
+     * @param string $role Role name
+     * @param Media $media Provide a media object if you already retrieved one to prevent more SQL queries
+     * @return string
+     */
     public function imageCaption($role, $media = null)
     {
         if (!$media) {
@@ -207,6 +284,13 @@ trait HasMedias
         return '';
     }
 
+    /**
+     * Returns the video URL of the image associated with a role
+     *
+     * @param string $role Role name
+     * @param Media $media Provide a media object if you already retrieved one to prevent more SQL queries
+     * @return string
+     */
     public function imageVideo($role, $media = null)
     {
         if (!$media) {
@@ -228,11 +312,28 @@ trait HasMedias
         return '';
     }
 
+    /**
+     * Returns the image object associated with a role and crop
+     *
+     * @param string $role Role name
+     * @param string $crop Crop name
+     * @return Media
+     */
     public function imageObject($role, $crop = "default")
     {
         return $this->findMedia($role, $crop);
     }
 
+    /**
+     * Returns the LQIP base64 encoded string from the database for a role.
+     * Use this in conjunction with the RefreshLQIP Artisan command.
+     *
+     * @param string $role Role name
+     * @param string $crop Crop name
+     * @param array $params Parameters compatible with the current image service, like `w` or `h`
+     * @param bool $has_fallback Indicate that you can provide a fallback. Will return null instead of the default image fallback.
+     * @return string
+     */
     public function lowQualityImagePlaceholder($role, $crop = "default", $params = [], $has_fallback = false)
     {
         $media = $this->findMedia($role, $crop);
@@ -249,6 +350,15 @@ trait HasMedias
 
     }
 
+    /**
+     * Returns the URL of the social image for a role
+     *
+     * @param string $role Role name
+     * @param string $crop Crop name
+     * @param array $params Parameters compatible with the current image service, like `w` or `h`
+     * @param bool $has_fallback Indicate that you can provide a fallback. Will return null instead of the default image fallback.
+     * @return string
+     */
     public function socialImage($role, $crop = "default", $params = [], $has_fallback = false)
     {
         $media = $this->findMedia($role, $crop);
@@ -266,11 +376,25 @@ trait HasMedias
         return ImageService::getSocialFallbackUrl();
     }
 
+    /**
+     * Returns the URL of the CMS image for a role
+     *
+     * @param string $role Role name
+     * @param string $crop Crop name
+     * @param array $params Parameters compatible with the current image service, like `w` or `h`
+     * @return string
+     */
     public function cmsImage($role, $crop = "default", $params = [])
     {
         return $this->image($role, $crop, $params, false, true, false) ?? ImageService::getTransparentFallbackUrl($params);
     }
 
+    /**
+     * Returns the URL of the default CMS image for this model
+     *
+     * @param array $params Parameters compatible with the current image service, like `w` or `h`
+     * @return string
+     */
     public function defaultCmsImage($params = [])
     {
         $media = $this->medias->first();
@@ -282,6 +406,13 @@ trait HasMedias
         return ImageService::getTransparentFallbackUrl($params);
     }
 
+    /**
+     * Returns the image objects associated with a role and crop
+     *
+     * @param string $role Role name
+     * @param string $crop Crop name
+     * @return \Illuminate\Support\Enumerable
+     */
     public function imageObjects($role, $crop = "default")
     {
         return $this->medias->filter(function ($media) use ($role, $crop) {

--- a/src/Models/Behaviors/HasMedias.php
+++ b/src/Models/Behaviors/HasMedias.php
@@ -74,7 +74,7 @@ trait HasMedias
     }
 
     /**
-     * Returns the URL of the attached image for a role and crop, with appended parameters.
+     * Returns the URL of the attached image for a role and crop.
      *
      * @param string $role Role name.
      * @param string $crop Crop name.
@@ -111,7 +111,7 @@ trait HasMedias
     }
 
     /**
-     * Returns an array of all associated image URLs for a role and crop, with appended parameters.
+     * Returns an array of URLs of all attached images for a role and crop.
      *
      * @param string $role Role name.
      * @param string $crop Crop name.
@@ -134,10 +134,9 @@ trait HasMedias
     }
 
     /**
-     * Returns an array of image URLs assiociated with a role with appended parameters for each crop.
+     * Returns an array of URLs of all attached images for a role, including all crops.
      *
      * @param string $role Role name.
-     * @param string $crop Crop name.
      * @param array $params Parameters compatible with the current image service, like `w` or `h`.
      * @return array
      */
@@ -158,7 +157,7 @@ trait HasMedias
     }
 
     /**
-     * Returns the image associated with $role as an array containing meta information.
+     * Returns an array of meta information for the image attached for a role and crop.
      *
      * @param string $role Role name.
      * @param string $crop Crop name.
@@ -187,7 +186,7 @@ trait HasMedias
     }
 
     /**
-     * Returns the images associated with $role as an array containing meta information.
+     * Returns an array of meta information for all images attached for a role and crop.
      *
      * @param string $role Role name.
      * @param string $crop Crop name.
@@ -210,7 +209,7 @@ trait HasMedias
     }
 
     /**
-     * Returns the images associated with $roleName as an array containing meta information for each crop.
+     * Returns an array of meta information for all images attached for a role, including all crops.
      *
      * @param string $role Role name.
      * @param array $params Parameters compatible with the current image service, like `w` or `h`.
@@ -233,7 +232,7 @@ trait HasMedias
     }
 
     /**
-     * Returns the alt text of the image associated with a role.
+     * Returns the alt text of the image attached for a role.
      *
      * @param string $role Role name.
      * @param Media $media Provide a media object if you already retrieved one to prevent more SQL queries.
@@ -259,7 +258,7 @@ trait HasMedias
     }
 
     /**
-     * Returns the caption of the image associated with a role.
+     * Returns the caption of the image attached for a role.
      *
      * @param string $role Role name.
      * @param Media $media Provide a media object if you already retrieved one to prevent more SQL queries.
@@ -285,7 +284,7 @@ trait HasMedias
     }
 
     /**
-     * Returns the video URL of the image associated with a role.
+     * Returns the video URL of the image attached for a role.
      *
      * @param string $role Role name.
      * @param Media $media Provide a media object if you already retrieved one to prevent more SQL queries.
@@ -313,7 +312,7 @@ trait HasMedias
     }
 
     /**
-     * Returns the image object associated with a role and crop.
+     * Returns the media object attached for a role and crop.
      *
      * @param string $role Role name.
      * @param string $crop Crop name.
@@ -325,7 +324,7 @@ trait HasMedias
     }
 
     /**
-     * Returns the LQIP base64 encoded string from the database for a role.
+     * Returns the LQIP base64 encoded string for a role.
      * Use this in conjunction with the RefreshLQIP Artisan command.
      *
      * @param string $role Role name.
@@ -333,6 +332,7 @@ trait HasMedias
      * @param array $params Parameters compatible with the current image service, like `w` or `h`.
      * @param bool $has_fallback Indicate that you can provide a fallback. Will return null instead of the default image fallback.
      * @return string
+     * @see \A17\Twill\Commands\RefreshLQIP
      */
     public function lowQualityImagePlaceholder($role, $crop = "default", $params = [], $has_fallback = false)
     {
@@ -351,7 +351,7 @@ trait HasMedias
     }
 
     /**
-     * Returns the URL of the social image for a role.
+     * Returns the URL of the social image for a role and crop.
      *
      * @param string $role Role name.
      * @param string $crop Crop name.
@@ -377,7 +377,7 @@ trait HasMedias
     }
 
     /**
-     * Returns the URL of the CMS image for a role.
+     * Returns the URL of the CMS image for a role and crop.
      *
      * @param string $role Role name.
      * @param string $crop Crop name.
@@ -407,7 +407,7 @@ trait HasMedias
     }
 
     /**
-     * Returns the image objects associated with a role and crop.
+     * Returns the media objects associated with a role and crop.
      *
      * @param string $role Role name.
      * @param string $crop Crop name.

--- a/src/Models/Behaviors/HasOauth.php
+++ b/src/Models/Behaviors/HasOauth.php
@@ -7,6 +7,9 @@ use A17\Twill\Models\UserOauth;
 trait HasOauth
 {
 
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     */
     public function providers()
     {
 
@@ -14,6 +17,11 @@ trait HasOauth
 
     }
 
+    /**
+     * @param \Laravel\Socialite\Contracts\User $oauthUser
+     * @param string $provider Socialite provider
+     * @return \Illuminate\Database\Eloquent\Model|false
+     */
     public function linkProvider($oauthUser, $provider)
     {
 

--- a/src/Models/Behaviors/HasPosition.php
+++ b/src/Models/Behaviors/HasPosition.php
@@ -22,11 +22,20 @@ trait HasPosition
         return ((int) static::max('position'));
     }
 
+    /**
+     * @param \Illuminate\Database\Eloquent\Builder $query
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
     public function scopeOrdered($query)
     {
         return $query->orderBy('position');
     }
 
+    /**
+     * @param array $ids
+     * @param int $startOrder
+     * @return void
+     */
     public static function setNewOrder($ids, $startOrder = 1)
     {
         if (!is_array($ids)) {

--- a/src/Models/Behaviors/HasPresenter.php
+++ b/src/Models/Behaviors/HasPresenter.php
@@ -6,6 +6,10 @@ trait HasPresenter
 {
     protected $presenterInstance;
 
+    /**
+     * @param string $presenter
+     * @return object
+     */
     public function present($presenter = 'presenter')
     {
         if (!$this->$presenter or !class_exists($this->$presenter)) {
@@ -19,11 +23,19 @@ trait HasPresenter
         return $this->presenterInstance;
     }
 
+    /**
+     * @return object
+     */
     public function presentAdmin()
     {
         return $this->present('presenterAdmin');
     }
 
+    /**
+     * @param string $presenter
+     * @param string $presenterProperty
+     * @return $this
+     */
     public function setPresenter($presenter, $presenterProperty = 'presenter')
     {
         if (!$this->$presenterProperty) {
@@ -32,6 +44,10 @@ trait HasPresenter
         return $this;
     }
 
+    /**
+     * @param string $presenter
+     * @return $this
+     */
     public function setPresenterAdmin($presenter)
     {
         return $this->setPresenter($presenter, 'presenterAdmin');

--- a/src/Models/Behaviors/HasRelated.php
+++ b/src/Models/Behaviors/HasRelated.php
@@ -11,11 +11,22 @@ trait HasRelated
 {
     protected $relatedCache;
 
+    /**
+     * Defines the one-to-many relationship for related items.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\MorphMany
+     */
     public function relatedItems()
     {
         return $this->morphMany(RelatedItem::class, 'subject')->orderBy('position');
     }
 
+    /**
+     * Returns the related items for a browser field.
+     *
+     * @param string $browser_name
+     * @return \Illuminate\Database\Eloquent\Collection
+     */
     public function getRelated($browser_name)
     {
         if (!isset($this->relatedCache[$browser_name]) || $this->relatedCache[$browser_name] === null) {
@@ -25,6 +36,12 @@ trait HasRelated
         return $this->relatedCache[$browser_name];
     }
 
+    /**
+     * Eager load related items for a browser field.
+     *
+     * @param string $browser_name
+     * @return \Illuminate\Database\Eloquent\Collection
+     */
     public function loadRelated($browser_name)
     {
         if (!isset($this->relatedItems)) {
@@ -38,6 +55,13 @@ trait HasRelated
             });
     }
 
+    /**
+     * Attach items to the model for a browser field.
+     *
+     * @param array $items
+     * @param string $browser_name
+     * @return void
+     */
     public function saveRelated($items, $browser_name)
     {
         RelatedItem::where([

--- a/src/Models/Behaviors/HasRevisions.php
+++ b/src/Models/Behaviors/HasRevisions.php
@@ -4,11 +4,22 @@ namespace A17\Twill\Models\Behaviors;
 
 trait HasRevisions
 {
+    /**
+     * Defines the one-to-many relationship for revisions.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     */
     public function revisions()
     {
         return $this->hasMany($this->getRevisionModel())->orderBy('created_at', 'desc');
     }
 
+    /**
+     * Scope a query to only include the current user's revisions.
+     *
+     * @param \Illuminate\Database\Eloquent\Builder $query
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
     public function scopeMine($query)
     {
         return $query->whereHas('revisions', function ($query) {
@@ -16,6 +27,11 @@ trait HasRevisions
         });
     }
 
+    /**
+     * Returns an array of revisions for the CMS views.
+     *
+     * @return array
+     */
     public function revisionsArray()
     {
         return $this->revisions->map(function ($revision) {

--- a/src/Models/Behaviors/HasSlug.php
+++ b/src/Models/Behaviors/HasSlug.php
@@ -24,16 +24,31 @@ trait HasSlug
         });
     }
 
+    /**
+     * Defines the one-to-many relationship for slug objects.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     */
     public function slugs()
     {
         return $this->hasMany($this->getSlugModelClass());
     }
 
+    /**
+     * Returns an instance of the slug class for this model.
+     *
+     * @return object
+     */
     public function getSlugClass()
     {
         return new $this->getSlugModelClass();
     }
 
+    /**
+     * Returns the fully qualified slug class name for this model.
+     *
+     * @return string
+     */
     public function getSlugModelClass()
     {
         $slug = $this->getNamespace() . "\Slugs\\" . $this->getSlugClassName();
@@ -50,6 +65,11 @@ trait HasSlug
         return class_basename($this) . "Slug";
     }
 
+    /**
+     * @param \Illuminate\Database\Eloquent\Builder $query
+     * @param string $slug
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
     public function scopeForSlug($query, $slug)
     {
         return $query->whereHas('slugs', function ($query) use ($slug) {
@@ -59,6 +79,11 @@ trait HasSlug
         })->with(['slugs']);
     }
 
+    /**
+     * @param \Illuminate\Database\Eloquent\Builder $query
+     * @param string $slug
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
     public function scopeForInactiveSlug($query, $slug)
     {
         return $query->whereHas('slugs', function ($query) use ($slug) {
@@ -67,6 +92,11 @@ trait HasSlug
         })->with(['slugs']);
     }
 
+    /**
+     * @param \Illuminate\Database\Eloquent\Builder $query
+     * @param string $slug
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
     public function scopeForFallbackLocaleSlug($query, $slug)
     {
         return $query->whereHas('slugs', function ($query) use ($slug) {
@@ -76,6 +106,10 @@ trait HasSlug
         })->with(['slugs']);
     }
 
+    /**
+     * @param bool $restoring
+     * @return void
+     */
     public function setSlugs($restoring = false)
     {
         foreach ($this->getSlugParams() as $slugParams) {
@@ -83,6 +117,11 @@ trait HasSlug
         }
     }
 
+    /**
+     * @param array $slugParams
+     * @param bool $restoring
+     * @return void
+     */
     public function updateOrNewSlug($slugParams, $restoring = false)
     {
         if (in_array($slugParams['locale'], config('twill.slug_utf8_languages', []))) {
@@ -104,6 +143,10 @@ trait HasSlug
         }
     }
 
+    /**
+     * @param array $slugParams
+     * @return object|null
+     */
     public function getExistingSlug($slugParams)
     {
         $query = DB::table($this->getSlugsTable())->where($this->getForeignKey(), $this->id);
@@ -143,6 +186,11 @@ trait HasSlug
         $this->disableLocaleSlugs($slugParams['locale'], $id);
     }
 
+    /**
+     * @param string $locale
+     * @param int $except_slug_id
+     * @return void
+     */
     public function disableLocaleSlugs($locale, $except_slug_id = 0)
     {
         DB::table($this->getSlugsTable())
@@ -179,6 +227,12 @@ trait HasSlug
         return $slugParams['slug'];
     }
 
+    /**
+     * Returns the active slug object for this model.
+     *
+     * @param string $locale Locale of the slug if your site has multiple languages.
+     * @return object|null
+     */
     public function getActiveSlug($locale = null)
     {
         return $this->slugs->first(function ($slug) use ($locale) {
@@ -186,6 +240,11 @@ trait HasSlug
         }) ?? null;
     }
 
+    /**
+     * Returns the fallback active slug object for this model.
+     *
+     * @return object|null
+     */
     public function getFallbackActiveSlug()
     {
         return $this->slugs->first(function ($slug) {
@@ -193,6 +252,12 @@ trait HasSlug
         }) ?? null;
     }
 
+    /**
+     * Returns the active slug string for this model.
+     *
+     * @param string $locale Locale of the slug if your site has multiple languages.
+     * @return string
+     */
     public function getSlug($locale = null)
     {
         if (($slug = $this->getActiveSlug($locale)) != null) {
@@ -206,11 +271,18 @@ trait HasSlug
         return "";
     }
 
+    /**
+     * @return string
+     */
     public function getSlugAttribute()
     {
         return $this->getSlug();
     }
 
+    /**
+     * @param string $locale
+     * @return array|null
+     */
     public function getSlugParams($locale = null)
     {
         if (count(getLocales()) === 1 || !isset($this->translations)) {
@@ -257,6 +329,10 @@ trait HasSlug
         return $locale == null ? $slugParams : null;
     }
 
+    /**
+     * @param string $locale
+     * @return array|null
+     */
     public function getSingleSlugParams($locale = null)
     {
         $slugParams = [];
@@ -294,11 +370,21 @@ trait HasSlug
         return $locale == null ? $slugParams : null;
     }
 
+    /**
+     * Returns the database table name for this model's slugs.
+     *
+     * @return string
+     */
     public function getSlugsTable()
     {
         return $this->slugs()->getRelated()->getTable();
     }
 
+    /**
+     * Returns the database foreign key column name for this model.
+     *
+     * @return string
+     */
     public function getForeignKey()
     {
         return Str::snake(class_basename(get_class($this))) . "_id";
@@ -309,6 +395,13 @@ trait HasSlug
         return $this->id;
     }
 
+    /**
+     * Generate a URL friendly slug from a UTF-8 string.
+     *
+     * @param string $str
+     * @param array $options
+     * @return string
+     */
     public function getUtf8Slug($str, $options = [])
     {
         // Make sure string is in UTF-8 and strip invalid UTF-8 characters
@@ -423,11 +516,35 @@ trait HasSlug
         return $options['lowercase'] ? mb_strtolower($str, 'UTF-8') : $str;
     }
 
+    /**
+     * Generate a URL friendly slug from a given string.
+     *
+     * @param string $string
+     * @return string
+     */
     public function urlSlugShorter($string)
     {
-        return strtolower(trim(preg_replace('~[^0-9a-z]+~i', '-', html_entity_decode(preg_replace('~&([a-z]{1,2})(?:acute|cedil|circ|grave|lig|orn|ring|slash|th|tilde|uml);~i', '$1', htmlentities($string, ENT_QUOTES, 'UTF-8')), ENT_QUOTES, 'UTF-8')), '-'));
+        return strtolower(
+                trim(
+                    preg_replace('~[^0-9a-z]+~i', '-',
+                        html_entity_decode(
+                            preg_replace('~&([a-z]{1,2})(?:acute|cedil|circ|grave|lig|orn|ring|slash|th|tilde|uml);~i', '$1',
+                                         htmlentities($string, ENT_QUOTES, 'UTF-8')
+                            ),
+                            ENT_QUOTES,
+                            'UTF-8'
+                        )
+                    ),
+                    '-'
+                )
+            );
     }
 
+    /**
+     * Returns the fully qualified namespace for this model.
+     *
+     * @return string
+     */
     public function getNamespace()
     {
         $pos = mb_strrpos(self::class, '\\');

--- a/src/Models/Behaviors/HasSlug.php
+++ b/src/Models/Behaviors/HasSlug.php
@@ -47,7 +47,7 @@ trait HasSlug
     /**
      * Returns the fully qualified slug class name for this model.
      *
-     * @return string
+     * @return string|null
      */
     public function getSlugModelClass()
     {
@@ -230,7 +230,7 @@ trait HasSlug
     /**
      * Returns the active slug object for this model.
      *
-     * @param string $locale Locale of the slug if your site has multiple languages.
+     * @param string|null $locale Locale of the slug if your site has multiple languages.
      * @return object|null
      */
     public function getActiveSlug($locale = null)
@@ -255,7 +255,7 @@ trait HasSlug
     /**
      * Returns the active slug string for this model.
      *
-     * @param string $locale Locale of the slug if your site has multiple languages.
+     * @param string|null $locale Locale of the slug if your site has multiple languages.
      * @return string
      */
     public function getSlug($locale = null)
@@ -280,7 +280,7 @@ trait HasSlug
     }
 
     /**
-     * @param string $locale
+     * @param string|null $locale
      * @return array|null
      */
     public function getSlugParams($locale = null)
@@ -330,7 +330,7 @@ trait HasSlug
     }
 
     /**
-     * @param string $locale
+     * @param string|null $locale
      * @return array|null
      */
     public function getSingleSlugParams($locale = null)

--- a/src/Models/Behaviors/HasSlug.php
+++ b/src/Models/Behaviors/HasSlug.php
@@ -524,20 +524,7 @@ trait HasSlug
      */
     public function urlSlugShorter($string)
     {
-        return strtolower(
-                trim(
-                    preg_replace('~[^0-9a-z]+~i', '-',
-                        html_entity_decode(
-                            preg_replace('~&([a-z]{1,2})(?:acute|cedil|circ|grave|lig|orn|ring|slash|th|tilde|uml);~i', '$1',
-                                         htmlentities($string, ENT_QUOTES, 'UTF-8')
-                            ),
-                            ENT_QUOTES,
-                            'UTF-8'
-                        )
-                    ),
-                    '-'
-                )
-            );
+        return strtolower(trim(preg_replace('~[^0-9a-z]+~i', '-', html_entity_decode(preg_replace('~&([a-z]{1,2})(?:acute|cedil|circ|grave|lig|orn|ring|slash|th|tilde|uml);~i', '$1', htmlentities($string, ENT_QUOTES, 'UTF-8')), ENT_QUOTES, 'UTF-8')), '-'));
     }
 
     /**

--- a/src/Models/Behaviors/HasTranslation.php
+++ b/src/Models/Behaviors/HasTranslation.php
@@ -9,6 +9,11 @@ trait HasTranslation
 {
     use Translatable;
 
+    /**
+     * Returns the fully qualified translation class name for this model.
+     *
+     * @return string|null
+     */
     public function getTranslationModelNameDefault()
     {
         $repository = config('twill.namespace') . "\Models\Translations\\" . class_basename($this) . 'Translation';
@@ -20,6 +25,11 @@ trait HasTranslation
         return $this->getCapsuleTranslationClass(class_basename($this));
     }
 
+    /**
+     * @param \Illuminate\Database\Eloquent\Builder $query
+     * @param string|null $locale
+     * @return \Illuminate\Database\Eloquent\Builder|null
+     */
     public function scopeWithActiveTranslations($query, $locale = null)
     {
         if (method_exists($query->getModel(), 'translations')) {
@@ -45,6 +55,13 @@ trait HasTranslation
         }
     }
 
+    /**
+     * @param \Illuminate\Database\Eloquent\Builder $query
+     * @param string $orderField
+     * @param string $orderType
+     * @param string|null $locale
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
     public function scopeOrderByTranslation($query, $orderField, $orderType = 'ASC', $locale = null)
     {
         $translationTable = $this->getTranslationsTable();
@@ -65,6 +82,13 @@ trait HasTranslation
             ->with('translations');
     }
 
+    /**
+     * @param \Illuminate\Database\Eloquent\Builder $query
+     * @param string $orderRawString
+     * @param string $groupByField
+     * @param string|null $locale
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
     public function scopeOrderByRawByTranslation($query, $orderRawString, $groupByField, $locale = null)
     {
         $translationTable = $this->getTranslationsTable();
@@ -80,6 +104,12 @@ trait HasTranslation
             ->with('translations');
     }
 
+    /**
+     * Checks if this model has active translations.
+     *
+     * @param string|null $locale
+     * @return bool
+     */
     public function hasActiveTranslation($locale = null)
     {
         $locale = $locale ?: $this->locale();
@@ -95,6 +125,9 @@ trait HasTranslation
         return false;
     }
 
+    /**
+     * @return Illuminate\Support\Collection
+     */
     public function getActiveLanguages()
     {
         return $this->translations->map(function ($translation) {
@@ -110,6 +143,12 @@ trait HasTranslation
         })->values();
     }
 
+    /**
+     * Returns all translations for a given attribute.
+     *
+     * @param string $key
+     * @return Illuminate\Support\Collection
+     */
     public function translatedAttribute($key)
     {
         return $this->translations->mapWithKeys(function ($translation) use ($key) {

--- a/src/Models/Behaviors/IsTranslatable.php
+++ b/src/Models/Behaviors/IsTranslatable.php
@@ -4,6 +4,12 @@ namespace A17\Twill\Models\Behaviors;
 
 trait IsTranslatable
 {
+    /**
+     * Checks if this model is translatable.
+     *
+     * @param array|string|null $columns Optionally limit the check to a set of columns.
+     * @return bool
+     */
     public function isTranslatable($columns = null)
     {
         // Model must have the trait

--- a/src/Models/Behaviors/Sortable.php
+++ b/src/Models/Behaviors/Sortable.php
@@ -4,7 +4,16 @@ namespace A17\Twill\Models\Behaviors;
 
 interface Sortable
 {
+    /**
+     * @param \Illuminate\Database\Eloquent\Builder $query
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
     public function scopeOrdered($query);
 
+    /**
+     * @param array $ids
+     * @param int $startOrder
+     * @return void
+     */
     public static function setNewOrder($ids, $startOrder = 1);
 }

--- a/src/Repositories/Behaviors/HandleBlocks.php
+++ b/src/Repositories/Behaviors/HandleBlocks.php
@@ -15,7 +15,12 @@ trait HandleBlocks
     /**
      * @param \A17\Twill\Models\Model $object
      * @param array $fields
-     * @return \A17\Twill\Models\Model|void
+     * @param int $fakeBlockId
+     * @param int|null $parentId
+     * @param \Illuminate\Support\Collection|null $blocksFromFields
+     * @param \Illuminate\Support\Collection|null $mainCollection
+     * @param int|null $mainCollection|void
+     * @return \A17\Twill\Models\Model
      */
     public function hydrateHandleBlocks($object, $fields, &$fakeBlockId = 0, $parentId = null, $blocksFromFields = null, $mainCollection = null)
     {
@@ -86,7 +91,6 @@ trait HandleBlocks
      *
      * @param  \A17\Twill\Repositories\BlockRepository $blockRepository
      * @param  array $blockFields
-     *
      * @return \A17\Twill\Models\Block $blockCreated
      */
     private function createBlock(BlockRepository $blockRepository, $blockFields)
@@ -128,7 +132,6 @@ trait HandleBlocks
      *
      * @param  \A17\Twill\Models\Model $object
      * @param  array $parentBlockFields
-     *
      * @return \Illuminate\Support\Collection
      */
     private function getChildBlocks($object, $parentBlockFields)

--- a/src/Repositories/Behaviors/HandleBrowsers.php
+++ b/src/Repositories/Behaviors/HandleBrowsers.php
@@ -12,18 +12,18 @@ trait HandleBrowsers
     /**
      * All browsers used in the model, as an array of browser names:
      * [
-     *  'books',
-     *  'publications'
-     * ].
+     *     'books',
+     *     'publications'
+     * ]
      *
-     * When only the browser name is given here, its rest information will be inferred from the name.
-     * Each browser's detail can also be override with an array
+     * When only the browser name is given, the rest of the parameters are inferred from the name.
+     * The parameters can also be overridden with an array:
      * [
-     *  'books',
-     *  'publication' => [
-     *      'routePrefix' => 'collections',
-     *      'titleKey' => 'name'
-     *  ]
+     *     'books',
+     *     'publication' => [
+     *         'routePrefix' => 'collections',
+     *         'titleKey' => 'name'
+     *     ]
      * ]
      *
      * @var array

--- a/src/Repositories/Behaviors/HandleBrowsers.php
+++ b/src/Repositories/Behaviors/HandleBrowsers.php
@@ -26,7 +26,7 @@ trait HandleBrowsers
      *  ]
      * ]
      *
-     * @var string|array(array)|array(mix(string|array))
+     * @var array
      */
     protected $browsers = [];
 
@@ -103,7 +103,7 @@ trait HandleBrowsers
     }
 
     /**
-     * @param mixed $object
+     * @param \A17\Twill\Models\Model $object
      * @param array $fields
      * @param string $browserName
      * @return void
@@ -166,7 +166,7 @@ trait HandleBrowsers
      * Get all browser' detail info from the $browsers attribute.
      * The missing information will be inferred by convention of Twill.
      *
-     * @return Illuminate\Support\Collection
+     * @return \Illuminate\Support\Collection
      */
     protected function getBrowsers()
     {
@@ -187,10 +187,9 @@ trait HandleBrowsers
     }
 
     /**
-     * The relation name shoud be lower camel case, ex. userGroup, contactOffice
+     * Guess the browser's relation name (shoud be lower camel case, ex. userGroup, contactOffice).
      *
-     * @param  string $browserName
-     *
+     * @param string $browserName
      * @return string
      */
     protected function inferRelationFromBrowserName(string $browserName): string
@@ -199,10 +198,9 @@ trait HandleBrowsers
     }
 
     /**
-     * The model name should be singular upper camel case, ex. User, ArticleType
+     * Guess the module's model name (should be singular upper camel case, ex. User, ArticleType).
      *
-     * @param  string $moduleName
-     *
+     * @param string $moduleName
      * @return string
      */
     protected function inferModelFromModuleName(string $moduleName): string
@@ -211,11 +209,9 @@ trait HandleBrowsers
     }
 
     /**
-     * The module name should be plural lower camel case
+     * Guess the browser's module name (should be plural lower camel case, ex. userGroups, contactOffices).
      *
-     * @param  mixed $string
-     * @param  mixed $browserName
-     *
+     * @param string $browserName
      * @return string
      */
     protected function inferModuleNameFromBrowserName(string $browserName): string

--- a/src/Repositories/Behaviors/HandleFieldsGroups.php
+++ b/src/Repositories/Behaviors/HandleFieldsGroups.php
@@ -9,7 +9,7 @@ trait HandleFieldsGroups
 
     /**
      * @param \A17\Twill\Models\Model $object
-     * @param array $fields
+     * @param array|null $fields
      * @return \A17\Twill\Models\Model
      */
     public function hydrateHandleFieldsGroups($object, $fields)
@@ -22,7 +22,7 @@ trait HandleFieldsGroups
 
         return $object;
     }
-    
+
     /**
      * @param \A17\Twill\Models\Model|null $object
      * @param array $fields
@@ -34,7 +34,6 @@ trait HandleFieldsGroups
     }
 
     /**
-     * @param \A17\Twill\Models\Model|null $object
      * @param array $fields
      * @return array
      */
@@ -69,11 +68,11 @@ trait HandleFieldsGroups
             $fields[$group] = Arr::where(Arr::only($fields, $groupFields), function ($value, $key) {
                 return !empty($value);
             });
-            
+
             if (empty($fields[$group])) {
                 $fields[$group] = null;
             }
-            
+
             Arr::forget($fields, $groupFields);
         }
 

--- a/src/Repositories/Behaviors/HandleFiles.php
+++ b/src/Repositories/Behaviors/HandleFiles.php
@@ -36,7 +36,7 @@ trait HandleFiles
     }
 
     /**
-     * @param \A17\Twill\Models\Behaviors\HasFiles $object
+     * @param \A17\Twill\Models\Model $object
      * @param array $fields
      * @return void
      */
@@ -54,7 +54,7 @@ trait HandleFiles
     }
 
     /**
-     * @param $fields
+     * @param array $fields
      * @return \Illuminate\Support\Collection
      */
     private function getFiles($fields)

--- a/src/Repositories/Behaviors/HandleJsonRepeaters.php
+++ b/src/Repositories/Behaviors/HandleJsonRepeaters.php
@@ -60,6 +60,12 @@ trait HandleJsonRepeaters
         return $fields;
     }
 
+    /**
+     * @param array $fields
+     * @param string $repeaterName
+     * @param array $serializedData
+     * @return array
+     */
     public function getJsonRepeater($fields, $repeaterName, $serializedData)
     {
         $repeatersFields = [];

--- a/src/Repositories/Behaviors/HandleJsonRepeaters.php
+++ b/src/Repositories/Behaviors/HandleJsonRepeaters.php
@@ -7,7 +7,6 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 
 /**
- *
  * Save repeaters in a json column instead of a new model.
  *
  * This trait is not intended to replace main repeaters but to give a quick
@@ -21,16 +20,15 @@ use Illuminate\Support\Str;
  *
  * Supported: Input, WYSIWYG, textarea, browsers.
  * Not supported: Medias, Files, repeaters.
- *
  */
 
 trait HandleJsonRepeaters
 {
 
     /**
-     * @param \A17\Twill\Models\Model $object
+     * @param \A17\Twill\Models\Model|null $object
      * @param array $fields
-     * @return string[]
+     * @return array
      */
     public function prepareFieldsBeforeSaveHandleJsonRepeaters($object, $fields)
     {
@@ -44,9 +42,9 @@ trait HandleJsonRepeaters
     }
 
     /**
-     * @param \A17\Twill\Models\Model $object
+     * @param \A17\Twill\Models\Model|null $object
      * @param array $fields
-     * @return string[]
+     * @return array
      */
     public function getFormFieldsHandleJsonRepeaters($object, $fields)
     {

--- a/src/Repositories/Behaviors/HandleOauth.php
+++ b/src/Repositories/Behaviors/HandleOauth.php
@@ -6,8 +6,8 @@ trait HandleOauth
 {
 
     /**
-     * @param $oauthUser
-     * @return A17\Twill\Models\User
+     * @param \Laravel\Socialite\Contracts\User $oauthUser
+     * @return \A17\Twill\Models\User
      */
     public function oauthUser($oauthUser)
     {
@@ -15,8 +15,8 @@ trait HandleOauth
     }
 
     /**
-     * @param $oauthUser
-     * @param $provider
+     * @param \Laravel\Socialite\Contracts\User $oauthUser
+     * @param string $provider
      * @return boolean
      */
     public function oauthIsUserLinked($oauthUser, $provider)
@@ -29,9 +29,9 @@ trait HandleOauth
     }
 
     /**
-     * @param $oauthUser
-     * @param $provider
-     * @return A17\Twill\Models\User
+     * @param \Laravel\Socialite\Contracts\User $oauthUser
+     * @param string $provider
+     * @return \A17\Twill\Models\User
      */
     public function oauthUpdateProvider($oauthUser, $provider)
     {
@@ -48,8 +48,8 @@ trait HandleOauth
     }
 
     /**
-     * @param $oauthUser
-     * @return A17\Twill\Models\User
+     * @param \Laravel\Socialite\Contracts\User $oauthUser
+     * @return \A17\Twill\Models\User
      */
     public function oauthCreateUser($oauthUser)
     {

--- a/src/Repositories/Behaviors/HandleRepeaters.php
+++ b/src/Repositories/Behaviors/HandleRepeaters.php
@@ -27,7 +27,7 @@ trait HandleRepeaters
      *  ]
      * ]
      *
-     * @var string|array(array)|array(mix(string|array))
+     * @var array
      */
     protected $repeaters = [];
 
@@ -148,12 +148,11 @@ trait HandleRepeaters
     /**
      * Given relation, model and repeaterName, retrieve the repeater data from request and update the database record.
      *
-     * @param  object $object
-     * @param  array $fields
-     * @param  string $relation
-     * @param  string $model
-     * @param  string $repeaterName
-     *
+     * @param \A17\Twill\Models\Model $object
+     * @param array $fields
+     * @param string $relation
+     * @param \A17\Twill\Models\Model|\A17\Twill\Repositories\ModuleRepository|null $modelOrRepository
+     * @param string|null $repeaterName
      * @return void
      */
     public function updateRepeater($object, $fields, $relation, $modelOrRepository = null, $repeaterName = null)
@@ -208,12 +207,11 @@ trait HandleRepeaters
     /**
      * Given relation, model and repeaterName, get the necessary fields for rendering a repeater
      *
-     * @param  object $object
-     * @param  array $fields
-     * @param  string $relation
-     * @param  string $modelOrRepository
-     * @param  string $repeaterName
-     *
+     * @param \A17\Twill\Models\Model $object
+     * @param array $fields
+     * @param string $relation
+     * @param \A17\Twill\Models\Model|\A17\Twill\Repositories\ModuleRepository|null $modelOrRepository
+     * @param string|null $repeaterName
      * @return array
      */
     public function getFormFieldsForRepeater($object, $fields, $relation, $modelOrRepository = null, $repeaterName = null)
@@ -324,7 +322,7 @@ trait HandleRepeaters
      * Get all repeaters' model and relation from the $repeaters attribute.
      * The missing information will be inferred by convention of Twill.
      *
-     * @return Illuminate\Support\Collection
+     * @return \Illuminate\Support\Collection
      */
     protected function getRepeaters()
     {
@@ -339,10 +337,9 @@ trait HandleRepeaters
     }
 
     /**
-     * The relation name shoud be lower camel case, ex. userGroup, contactOffice
+     * Get the relation name (shoud be lower camel case, ex. userGroup, contactOffice).
      *
-     * @param  string $repeaterName
-     *
+     * @param string $repeaterName
      * @return string
      */
     protected function inferRelationFromRepeaterName(string $repeaterName): string
@@ -351,10 +348,9 @@ trait HandleRepeaters
     }
 
     /**
-     * The model name should be singular upper camel case, ex. User, ArticleType
+     * Get the model name (should be singular upper camel case, ex. User, ArticleType).
      *
-     * @param  string $repeaterName
-     *
+     * @param string $repeaterName
      * @return string
      */
     protected function inferModelFromRepeaterName(string $repeaterName): string

--- a/src/Repositories/Behaviors/HandleRepeaters.php
+++ b/src/Repositories/Behaviors/HandleRepeaters.php
@@ -57,6 +57,14 @@ trait HandleRepeaters
         return $fields;
     }
 
+    /**
+     * @param \A17\Twill\Models\Model $object
+     * @param array $fields
+     * @param string $relation
+     * @param bool $keepExisting
+     * @param \A17\Twill\Models\Model|null $model
+     * @return void
+     */
     public function updateRepeaterMany($object, $fields, $relation, $keepExisting = true, $model = null)
     {
         $relationFields = $fields['repeaters'][$relation] ?? [];
@@ -74,6 +82,15 @@ trait HandleRepeaters
         }
     }
 
+    /**
+     * @param \A17\Twill\Models\Model $object
+     * @param array $fields
+     * @param string $relation
+     * @param string|null $morph
+     * @param \A17\Twill\Models\Model|null $model
+     * @param string|null $repeaterName
+     * @return void
+     */
     public function updateRepeaterMorphMany($object, $fields, $relation, $morph = null, $model = null, $repeaterName = null)
     {
         if (!$repeaterName) {

--- a/src/Repositories/Behaviors/HandleRepeaters.php
+++ b/src/Repositories/Behaviors/HandleRepeaters.php
@@ -337,7 +337,7 @@ trait HandleRepeaters
     }
 
     /**
-     * Get the relation name (shoud be lower camel case, ex. userGroup, contactOffice).
+     * Guess the relation name (shoud be lower camel case, ex. userGroup, contactOffice).
      *
      * @param string $repeaterName
      * @return string
@@ -348,7 +348,7 @@ trait HandleRepeaters
     }
 
     /**
-     * Get the model name (should be singular upper camel case, ex. User, ArticleType).
+     * Guess the model name (should be singular upper camel case, ex. User, ArticleType).
      *
      * @param string $repeaterName
      * @return string

--- a/src/Repositories/Behaviors/HandleRepeaters.php
+++ b/src/Repositories/Behaviors/HandleRepeaters.php
@@ -13,18 +13,18 @@ trait HandleRepeaters
     /**
      * All repeaters used in the model, as an array of repeater names:
      * [
-     *  'article_repeater',
-     *  'page_repeater'
+     *     'article_repeater',
+     *     'page_repeater'
      * ].
      *
-     * When only the repeater name is given here, its model and relation will be inferred from the name.
-     * Each repeater's detail can also be override with an array
+     * When only the repeater name is given, the model and relation are inferred from the name.
+     * The parameters can also be overridden with an array:
      * [
-     *  'article_repeater',
-     *  'page_repeater' => [
-     *      'model' => 'Page',
-     *      'relation' => 'pages'
-     *  ]
+     *     'article_repeater',
+     *     'page_repeater' => [
+     *         'model' => 'Page',
+     *         'relation' => 'pages'
+     *     ]
      * ]
      *
      * @var array

--- a/src/Repositories/Behaviors/HandleRevisions.php
+++ b/src/Repositories/Behaviors/HandleRevisions.php
@@ -8,6 +8,11 @@ use Illuminate\Support\Facades\Auth;
 
 trait HandleRevisions
 {
+    /**
+     * @param \A17\Twill\Models\Model $object
+     * @param array $fields
+     * @return \A17\Twill\Models\Model
+     */
     public function hydrateHandleRevisions($object, $fields)
     {
         // HandleRepeaters trait => getRepeaters
@@ -23,6 +28,11 @@ trait HandleRevisions
         return $object;
     }
 
+    /**
+     * @param \A17\Twill\Models\Model $object
+     * @param array $fields
+     * @return array
+     */
     public function beforeSaveHandleRevisions($object, $fields)
     {
         $lastRevisionPayload = json_decode($object->revisions->first()->payload ?? "{}", true);
@@ -37,6 +47,11 @@ trait HandleRevisions
         return $fields;
     }
 
+    /**
+     * @param int $id
+     * @param array $fields
+     * @return \A17\Twill\Models\Model
+     */
     public function preview($id, $fields)
     {
         $object = $this->model->findOrFail($id);
@@ -44,6 +59,11 @@ trait HandleRevisions
         return $this->hydrateObject($object, $fields);
     }
 
+    /**
+     * @param \A17\Twill\Models\Model $object
+     * @param array $fields
+     * @return \A17\Twill\Models\Model
+     */
     protected function hydrateObject($object, $fields)
     {
         $fields = $this->prepareFieldsBeforeSave($object, $fields);
@@ -55,6 +75,11 @@ trait HandleRevisions
         return $object;
     }
 
+    /**
+     * @param int $id
+     * @param int $revisionId
+     * @return \A17\Twill\Models\Model
+     */
     public function previewForRevision($id, $revisionId)
     {
         $object = $this->model->findOrFail($id);
@@ -67,6 +92,14 @@ trait HandleRevisions
         return $hydratedObject;
     }
 
+    /**
+     * @param \A17\Twill\Models\Model $object
+     * @param array $fields
+     * @param string $relationship
+     * @param \A17\Twill\Models\Model|null $model
+     * @param string|null $customHydratedRelationship
+     * @return void
+     */
     public function hydrateMultiSelect($object, $fields, $relationship, $model = null, $customHydratedRelationship = null)
     {
         $fieldsHasElements = isset($fields[$relationship]) && !empty($fields[$relationship]);
@@ -83,11 +116,27 @@ trait HandleRevisions
         $object->setRelation($customHydratedRelationship ?? $relationship, $relatedElementsCollection);
     }
 
+    /**
+     * @param \A17\Twill\Models\Model $object
+     * @param array $fields
+     * @param string $relationship
+     * @param string $positionAttribute
+     * @param \A17\Twill\Models\Model|null $model
+     * @return null
+     */
     public function hydrateBrowser($object, $fields, $relationship, $positionAttribute = 'position', $model = null)
     {
         return $this->hydrateOrderedBelongsTomany($object, $fields, $relationship, $positionAttribute, $model);
     }
 
+    /**
+     * @param \A17\Twill\Models\Model $object
+     * @param array $fields
+     * @param string $relationship
+     * @param string $positionAttribute
+     * @param \A17\Twill\Models\Model|null $model
+     * @return void
+     */
     public function hydrateOrderedBelongsTomany($object, $fields, $relationship, $positionAttribute = 'position', $model = null)
     {
         $fieldsHasElements = isset($fields['browsers'][$relationship]) && !empty($fields['browsers'][$relationship]);
@@ -107,6 +156,14 @@ trait HandleRevisions
         $object->setRelation($relationship, $relatedElementsCollection);
     }
 
+    /**
+     * @param \A17\Twill\Models\Model $object
+     * @param array $fields
+     * @param string $relationship
+     * @param \A17\Twill\Models\Model $model
+     * @param string|null $repeaterName
+     * @return void
+     */
     public function hydrateRepeater($object, $fields, $relationship, $model, $repeaterName = null)
     {
         if (!$repeaterName) {
@@ -132,12 +189,19 @@ trait HandleRevisions
         $object->setRelation($relationship, $repeaterCollection);
     }
 
+    /**
+     * @return int
+     */
     public function getCountForMine()
     {
         $query = $this->model->newQuery();
         return $this->filter($query, $this->countScope)->mine()->count();
     }
 
+    /**
+     * @param string $slug
+     * @return int|bool
+     */
     public function getCountByStatusSlugHandleRevisions($slug)
     {
         if ($slug === 'mine') {

--- a/src/Repositories/Behaviors/HandleSlugs.php
+++ b/src/Repositories/Behaviors/HandleSlugs.php
@@ -4,6 +4,11 @@ namespace A17\Twill\Repositories\Behaviors;
 
 trait HandleSlugs
 {
+    /**
+     * @param \A17\Twill\Models\Model $object
+     * @param array $fields
+     * @return void
+     */
     public function afterSaveHandleSlugs($object, $fields)
     {
         if (property_exists($this->model, 'slugAttributes')) {
@@ -21,16 +26,29 @@ trait HandleSlugs
         }
     }
 
+    /**
+     * @param \A17\Twill\Models\Model $object
+     * @return void
+     */
     public function afterDeleteHandleSlugs($object)
     {
         $object->slugs()->delete();
     }
 
+    /**
+     * @param \A17\Twill\Models\Model $object
+     * @return void
+     */
     public function afterRestoreHandleSlugs($object)
     {
         $object->slugs()->restore();
     }
 
+    /**
+     * @param \A17\Twill\Models\Model $object
+     * @param array $fields
+     * @return array
+     */
     public function getFormFieldsHandleSlugs($object, $fields)
     {
         unset($fields['slugs']);
@@ -46,6 +64,12 @@ trait HandleSlugs
         return $fields;
     }
 
+    /**
+     * @param \A17\Twill\Models\Model $object
+     * @param array $fields
+     * @param array $slug
+     * @return array
+     */
     public function getSlugParameters($object, $fields, $slug)
     {
         $slugParams = $object->getSlugParams($slug['locale']);
@@ -61,6 +85,13 @@ trait HandleSlugs
         return $slug;
     }
 
+    /**
+     * @param array $slug
+     * @param array $with
+     * @param array $withCount
+     * @param array $scopes
+     * @return \A17\Twill\Models\Model
+     */
     public function forSlug($slug, $with = [], $withCount = [], $scopes = [])
     {
         $query = $this->model->where($scopes)->scopes(['published', 'visible']);
@@ -91,6 +122,12 @@ trait HandleSlugs
         return $item;
     }
 
+    /**
+     * @param array $slug
+     * @param array $with
+     * @param array $withCount
+     * @return \A17\Twill\Models\Model
+     */
     public function forSlugPreview($slug, $with = [], $withCount = [])
     {
         return $this->model->forInactiveSlug($slug)->with($with)->withCount($withCount)->first();

--- a/src/Repositories/Behaviors/HandleTags.php
+++ b/src/Repositories/Behaviors/HandleTags.php
@@ -4,6 +4,11 @@ namespace A17\Twill\Repositories\Behaviors;
 
 trait HandleTags
 {
+    /**
+     * @param \A17\Twill\Models\Model $object
+     * @param array $fields
+     * @return void
+     */
     public function afterSaveHandleTags($object, $fields)
     {
         if (!isset($fields['bulk_tags']) && !isset($fields['previous_common_tags'])) {
@@ -36,6 +41,11 @@ trait HandleTags
         return $this->model->allTags()->orderBy('count', 'desc');
     }
 
+    /**
+     * @param string $query
+     * @param array $ids
+     * @return \Illuminate\Database\Eloquent\Collection
+     */
     public function getTags($query = '', $ids = [])
     {
         $tagQuery = $this->getTagsQuery();
@@ -55,6 +65,9 @@ trait HandleTags
         return $tagQuery->get();
     }
 
+    /**
+     * @return \Illuminate\Support\Collection
+     */
     public function getTagsList()
     {
         return $this->getTagsQuery()->where('count', '>', 0)->select('name', 'id')->get()->map(function ($tag) {

--- a/src/Repositories/Behaviors/HandleTranslations.php
+++ b/src/Repositories/Behaviors/HandleTranslations.php
@@ -9,11 +9,20 @@ trait HandleTranslations
 {
     protected $nullableFields = [];
 
+    /**
+     * @param array $fields
+     * @return array
+     */
     public function prepareFieldsBeforeCreateHandleTranslations($fields)
     {
         return $this->prepareFieldsBeforeSaveHandleTranslations(null, $fields);
     }
 
+    /**
+     * @param \A17\Twill\Models\Model|null $object
+     * @param array $fields
+     * @return array
+     */
     public function prepareFieldsBeforeSaveHandleTranslations($object, $fields)
     {
         if ($this->model->isTranslatable()) {
@@ -59,6 +68,11 @@ trait HandleTranslations
         return $fields;
     }
 
+    /**
+     * @param \A17\Twill\Models\Model $object
+     * @param array $fields
+     * @return array
+     */
     public function getFormFieldsHandleTranslations($object, $fields)
     {
         unset($fields['translations']);
@@ -95,6 +109,11 @@ trait HandleTranslations
         }
     }
 
+    /**
+     * @param \Illuminate\Database\Eloquent\Builder $query
+     * @param array $orders
+     * @return void
+     */
     public function orderHandleTranslations($query, &$orders)
     {
         if ($this->model->isTranslatable()) {
@@ -123,6 +142,9 @@ trait HandleTranslations
         }
     }
 
+    /**
+     * @return array
+     */
     public function getPublishedScopesHandleTranslations()
     {
         return ['withActiveTranslations'];


### PR DESCRIPTION
## Description

This is a draft PR to get some feedback on PHP code docblocks. Specifically, I want to discuss the potential value to be added to the API documentation. I understand that code comments can be a bit controversial as a topic and I'm genuinely interested to hear all personal opinions :)

The change presented here is to move the descriptions for HasMedias public methods, from the main docs to the code. This has the effect of enriching the API docs with descriptions and type information. For comparison :


**Trait overview — current vs. updated**

![overview](https://user-images.githubusercontent.com/7805679/120796937-6aac8200-c509-11eb-9675-234d0fdda5fa.png)



**Method details — current vs. updated** 

![method-details](https://user-images.githubusercontent.com/7805679/120796970-7304bd00-c509-11eb-8a4f-4801434fadfd.png)



Also, the annotated methods are removed from the main docs and replaced with a link to the API docs. From my perspective, this makes the methods a bit less visible in the context of the whole documentation. On the other hand, it makes the actual documentation more inline with the code and perhaps easier to maintain in the long term.

I'll admit that backfilling the docblocks is boring... I think that a good place to start would be the model and repository behaviors (traits). The annotations would trickle down to all of the consuming entities in the API documentation.

Curious to know what you think!


## Related

https://github.com/area17/twill/pull/929