### PR TITLE
Fix 'undefined' and 'null' being returned by the frontend

### DIFF
--- a/src/Http/Controllers/Admin/FileLibraryController.php
+++ b/src/Http/Controllers/Admin/FileLibraryController.php
@@ -315,6 +315,6 @@ class FileLibraryController extends ModuleController implements SignUploadListen
      */
     private function shouldReplaceFile($id)
     {
-        return isset($id) ? $this->repository->whereId($id)->exists() : false;
+        return is_numeric($id) ? $this->repository->whereId($id)->exists() : false;
     }
 }

--- a/src/Http/Controllers/Admin/MediaLibraryController.php
+++ b/src/Http/Controllers/Admin/MediaLibraryController.php
@@ -339,6 +339,6 @@ class MediaLibraryController extends ModuleController implements SignUploadListe
      */
     private function shouldReplaceMedia($id)
     {
-        return isset($id) ? $this->repository->whereId($id)->exists() : false;
+        return is_numeric($id) ? $this->repository->whereId($id)->exists() : false;
     }
 }


### PR DESCRIPTION
We bumped into this bug today, with @luislavena, so this is a hot fix. 

Locally it all was working fine but when when we deployed to a staging server the frontend was able to upload the file to S3 but when POSTing to our backend it it was alternately sending `null` and `undefined` in the property `media_to_replace_id`, generating the error seen on [this issue](https://github.com/area17/twill/issues/957).

I believe `is_numeric` [covers all possibilities](https://3v4l.org/LI3dq), unless users are using UUIDs as Twill database keys, which seems like very edge cases.

Closes https://github.com/area17/twill/issues/957.