### PR TITLE
Allow `dev_mode` to be set in `.env`

### DIFF
--- a/config/twill.php
+++ b/config/twill.php
@@ -165,7 +165,7 @@ return [
     |
      */
     'js_namespace' => 'TWILL',
-    'dev_mode' => false,
+    'dev_mode' => env('TWILL_DEV_MODE', false),
     'dev_mode_url' => env('TWILL_DEV_MODE_URL', 'http://localhost:8080'),
     'public_directory' => env('TWILL_ASSETS_DIR', 'assets/admin'),
     'manifest_file' => 'twill-manifest.json',


### PR DESCRIPTION
## Description

Suggesting to look at `TWILL_DEV_MODE` in the `.env` to allow setting both `dev_mode` and `dev_mode_url` from `.env`.

```
TWILL_DEV_MODE_URL=http://10.0.0.10:8080
TWILL_DEV_MODE=true
```

I could update the related section in the doc too.

## Related Issues

—