### PR TITLE
Add support for browsers using HasRelated behavior

### DIFF
--- a/src/Repositories/Behaviors/HandleRelatedBrowsers.php
+++ b/src/Repositories/Behaviors/HandleRelatedBrowsers.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace A17\Twill\Repositories\Behaviors;
+
+/**
+ * Mimic HandleBrowsers, but when the relation uses
+ * HasRelated instead of being a proper model relation.
+ *
+ * @see A17\Twill\Repositories\Behaviors\HandleBrowsers
+ * @see https://github.com/area17/twill/discussions/940
+ */
+trait HandleRelatedBrowsers
+{
+    /**
+     * All related browsers used in the model, as an array of browser names:
+     * [
+     *  'books',
+     *  'publications'
+     * ].
+     *
+     * When only the browser name is given here, its rest information will be inferred from the name.
+     * Each browser's detail can also be overriden with an array
+     * [
+     *  'books',
+     *  'publication' => [
+     *      'relation' => 'magazine',
+     *      'model' => 'Magazine'
+     *  ]
+     * ]
+     *
+     * @var string|array(array)|array(mix(string|array))
+     */
+    protected $relatedBrowsers = [];
+
+    /**
+     * @param \A17\Twill\Models\Model $object
+     * @param array $fields
+     * @return void
+     */
+    public function afterSaveHandleRelatedBrowsers($object, $fields)
+    {
+        foreach ($this->getRelatedBrowsers() as $browser) {
+            $this->updateRelatedBrowser($object, $fields, $browser['browserName']);
+        }
+    }
+
+    /**
+     * @param \A17\Twill\Models\Model $object
+     * @param array $fields
+     * @return array
+     */
+    public function getFormFieldsHandleRelatedBrowsers($object, $fields)
+    {
+        foreach ($this->getRelatedBrowsers() as $browser) {
+            $fields['browsers'][$browser['browserName']] = $this->getFormFieldsForRelatedBrowser($object, $browser['relation']);
+        }
+
+        return $fields;
+    }
+
+    /**
+     * Get all related browser' detail info from the $relatedBrowsers attribute.
+     * The missing information will be inferred by convention of Twill.
+     *
+     * @return Illuminate\Support\Collection
+     */
+    protected function getRelatedBrowsers()
+    {
+        return collect($this->relatedBrowsers)->map(function ($browser, $key) {
+            $browserName = is_string($browser) ? $browser : $key;
+            $moduleName = !empty($browser['moduleName']) ? $browser['moduleName'] : $this->inferModuleNameFromBrowserName($browserName);
+
+            return [
+                'relation' => !empty($browser['relation']) ? $browser['relation'] : $this->inferRelationFromBrowserName($browserName),
+                'model' => !empty($browser['model']) ? $browser['model'] : $this->inferModelFromModuleName($moduleName),
+                'browserName' => $browserName,
+            ];
+        })->values();
+    }
+}


### PR DESCRIPTION
## Description

One thing we found when cleaning up our repositories to use Twill's new generalized browser functionality is that this functionality only works when the model uses a proper relation, e.g., the `updateBrowser` method looks for a model method that uses an Eloquent relationship that it can run a `sync()` on. For some of our model relationships, we use the `HasRelated` behavior so we don't have to build out DB tables for something minor. 

This PR adds support for these types of browsers by adding a behavior that mimics `HandleBrowsers`. It adds a Repository attribute to your classes, so you can reference these types of browsers in a similar way:

```
protected $relatedBrowsers = [
    'relatedVideos'
];
```

And similarly, each browser can pass an array to define non-default values for your browser:

```
protected $relatedBrowsers = [
    'related_videos' => [
        'relation' => 'related_videos'
    ],
];
```

## Related Issues

Related to discussion being had here: https://github.com/area17/twill/discussions/940
