### PR TITLE
feat(media-library): add option to return original media file

### DIFF
--- a/config/glide.php
+++ b/config/glide.php
@@ -41,4 +41,5 @@ return [
         'dpr' => '1',
     ],
     'presets' => [],
+    'original_media_for_extensions' => [],
 ];

--- a/docs/.sections/getting-started/configuration.md
+++ b/docs/.sections/getting-started/configuration.md
@@ -322,6 +322,8 @@ MEDIA_LIBRARY_ENDPOINT_TYPE=local
 MEDIA_LIBRARY_IMAGE_SERVICE=A17\Twill\Services\MediaLibrary\Glide
 ```
 
+If you want to add support for other image formats, which aren't covered by Glide, you can specify an array of extensions. For files matching the ending, the original media URL will be returned, instead of the modified one. For this, you can specify the following configuration key: `glide.original_media_for_extensions`
+
 #### Imgix
 
 As noted above, by default, Twill uses and recommends using [Imgix](https://imgix.com) to transform, optimize, and intelligently cache your uploaded images. 

--- a/src/Services/MediaLibrary/Glide.php
+++ b/src/Services/MediaLibrary/Glide.php
@@ -278,7 +278,7 @@ class Glide implements ImageServiceInterface
     {
         $libraryDisk = $this->config->get('twill.media_library.disk');
         $endpointType = $this->config->get('twill.media_library.endpoint_type');
-        $localMediaLibraryUrl = $this->config->get('filesystems.disks.twill_media_library.url');
+        $localMediaLibraryUrl = $this->config->get("filesystems.disks.$libraryDisk.url");
         $originalMediaForExtensions = $this->config->get('twill.glide.original_media_for_extensions');
         $addParamsToSvgs = $this->config->get('twill.glide.add_params_to_svgs', false);
 

--- a/src/Services/MediaLibrary/Glide.php
+++ b/src/Services/MediaLibrary/Glide.php
@@ -277,21 +277,28 @@ class Glide implements ImageServiceInterface
     private function getOriginalMediaUrl($id)
     {
         if (!Str::endsWith($id, $this->config->get('twill.glide.original_media_for_extensions'))) {
-            return false;
+            return null;
         }
 
         $libraryDisk = $this->config->get('twill.media_library.disk');
         $endpointType = $this->config->get('twill.media_library.endpoint_type');
-        $localPath = $this->config->get('twill.media_library.local_path');
-        $appUrl = $this->config->get('app.url');
+        $localMediaLibraryUrl = $this->config->get('filesystems.disks.twill_media_library.url');
+
+        /** @var string $endpoint */
+        $endpoint;
 
         switch ($endpointType) {
             case 'local':
-                return $appUrl . '/storage/' . $localPath;
+                $endpoint = $localMediaLibraryUrl;
+                break;
             case 's3':
-                return s3Endpoint($libraryDisk) . '/';
+                $endpoint = s3Endpoint($libraryDisk);
+                break;
             case 'azure':
-                return azureEndpoint($libraryDisk). '/';
+                $endpoint = azureEndpoint($libraryDisk);
+                break;
         }
+
+        return $endpoint . '/' . $id;
     }
 }

--- a/src/Services/MediaLibrary/Glide.php
+++ b/src/Services/MediaLibrary/Glide.php
@@ -106,7 +106,7 @@ class Glide implements ImageServiceInterface
         $addParamsToSvgs = config('twill.glide.add_params_to_svgs', false);
 
         if (!$addParamsToSvgs && Str::endsWith($id, '.svg')) {
-            return $this->urlBuilder->getUrl($id);
+            return $this->getMediaUrl() . $id;
         }
 
         return $this->urlBuilder->getUrl($id, array_replace($defaultParams, $params));
@@ -198,6 +198,10 @@ class Glide implements ImageServiceInterface
      */
     public function getRawUrl($id)
     {
+        if (Str::endsWith($id, '.svg')) {
+            return $this->getMediaUrl() . $id;
+        }
+            
         return $this->urlBuilder->getUrl($id);
     }
 
@@ -272,5 +276,13 @@ class Glide implements ImageServiceInterface
         }
 
         return [];
+    }
+
+    /**
+     * @return string
+     */
+    private function getMediaUrl()
+    {
+        return config('app.url') . '/storage/' . config('twill.media_library.local_path');
     }
 }

--- a/src/Services/MediaLibrary/Glide.php
+++ b/src/Services/MediaLibrary/Glide.php
@@ -106,7 +106,7 @@ class Glide implements ImageServiceInterface
         $addParamsToSvgs = config('twill.glide.add_params_to_svgs', false);
 
         if (!$addParamsToSvgs && Str::endsWith($id, '.svg')) {
-            return $this->getMediaUrl() . $id;
+            return $this->urlBuilder->getUrl($id);
         }
 
         return $this->urlBuilder->getUrl($id, array_replace($defaultParams, $params));
@@ -283,6 +283,18 @@ class Glide implements ImageServiceInterface
      */
     private function getMediaUrl()
     {
-        return config('app.url') . '/storage/' . config('twill.media_library.local_path');
+        $libraryDisk = $this->config->get('twill.media_library.disk');
+        $endpointType = $this->config->get('twill.media_library.endpoint_type');
+        $localPath = $this->config->get('twill.media_library.local_path');
+        $appUrl = $this->config->get('app.url');
+
+        switch ($endpointType) {
+            case 'local':
+                return $appUrl . '/storage/' . $localPath;
+            case 's3':
+                return s3Endpoint($libraryDisk) . '/';
+            case 'azure':
+                return azureEndpoint($libraryDisk). '/';
+        }
     }
 }

--- a/src/Services/MediaLibrary/Glide.php
+++ b/src/Services/MediaLibrary/Glide.php
@@ -276,13 +276,15 @@ class Glide implements ImageServiceInterface
      */
     private function getOriginalMediaUrl($id)
     {
-        if (!Str::endsWith($id, $this->config->get('twill.glide.original_media_for_extensions'))) {
-            return null;
-        }
-
         $libraryDisk = $this->config->get('twill.media_library.disk');
         $endpointType = $this->config->get('twill.media_library.endpoint_type');
         $localMediaLibraryUrl = $this->config->get('filesystems.disks.twill_media_library.url');
+        $originalMediaForExtensions = $this->config->get('twill.glide.original_media_for_extensions');
+        $addParamsToSvgs = $this->config->get('twill.glide.add_params_to_svgs', false);
+
+        if ((Str::endsWith($id, '.svg') && $addParamsToSvgs) || !Str::endsWith($id, $originalMediaForExtensions)) {
+            return null;
+        }
 
         /** @var string $endpoint */
         $endpoint;

--- a/src/Services/MediaLibrary/Glide.php
+++ b/src/Services/MediaLibrary/Glide.php
@@ -103,13 +103,9 @@ class Glide implements ImageServiceInterface
     public function getUrl($id, array $params = [])
     {
         $defaultParams = config('twill.glide.default_params');
-        $addParamsToSvgs = config('twill.glide.add_params_to_svgs', false);
 
-        if (!$addParamsToSvgs && Str::endsWith($id, '.svg')) {
-            return $this->urlBuilder->getUrl($id);
-        }
-
-        return $this->urlBuilder->getUrl($id, array_replace($defaultParams, $params));
+        return $this->getOriginalMediaUrl($id) ??
+            $this->urlBuilder->getUrl($id, array_replace($defaultParams, $params));
     }
 
     /**
@@ -198,11 +194,7 @@ class Glide implements ImageServiceInterface
      */
     public function getRawUrl($id)
     {
-        if (Str::endsWith($id, '.svg')) {
-            return $this->getMediaUrl() . $id;
-        }
-            
-        return $this->urlBuilder->getUrl($id);
+        return $this->getOriginalMediaUrl($id) ?? $this->urlBuilder->getUrl($id);
     }
 
     /**
@@ -279,10 +271,15 @@ class Glide implements ImageServiceInterface
     }
 
     /**
+     * @param string $id 
      * @return string
      */
-    private function getMediaUrl()
+    private function getOriginalMediaUrl($id)
     {
+        if (!Str::endsWith($id, $this->config->get('twill.glide.original_media_for_extensions'))) {
+            return false;
+        }
+
         $libraryDisk = $this->config->get('twill.media_library.disk');
         $endpointType = $this->config->get('twill.media_library.endpoint_type');
         $localPath = $this->config->get('twill.media_library.local_path');


### PR DESCRIPTION
<!--
  Thanks for opening a PR! Your contribution is much appreciated.
  Do you have any questions? Check out the contributing docs at https://github.com/area17/twill/blob/2.x/CONTRIBUTING.md, 
  or ask in this Pull Request and a Twill maintainer will be happy to help :)
-->

## Description

Currently, when using Glide as Media Library Image Service, I am unable to display uploaded SVGs, since Glide does not support SVGs.

There is a workaround to this problem, you can set the environment variable `GLIDE_DRIVER` to `imagick`. This “solves” the problem, meaning the SVG will be converted into a JPEG and thus loosing image quality and transparency.

The workaround, however, is not perfect, and I'd prefer getting my unmodified SVG back instead. This is what this PR solves.

--- 

This may result in a breaking change, and it might make more sense to add an option in the config that allows the original SVG to be returned, such as `twill.glide.use_original_svg` with its default value being set to `false`. 

Open to ideas and feedback