### PR TITLE
Allow setting dev_assets_path from `.env`

### DIFF
--- a/config/frontend.php
+++ b/config/frontend.php
@@ -12,7 +12,7 @@ return [
     |
      */
     'rev_manifest_path' => public_path('dist/rev-manifest.json'),
-    'dev_assets_path' => '/dist', // you can use another path for dev to avoid having to recompile after a deploy that compiles assets locally
+    'dev_assets_path' => env('TWILL_DEV_ASSETS_PATH', '/dist'), // you can use another path for dev to avoid having to recompile after a deploy that compiles assets locally
     'dist_assets_path' => '/dist',
     'svg_sprites_path' => 'sprites.svg', // relative to dev/dist assets paths
     'svg_sprites_use_hash_only' => true,

--- a/vue.config.js
+++ b/vue.config.js
@@ -30,7 +30,7 @@ const WebpackAssetsManifest = require('webpack-assets-manifest')
 const WebpackNotifierPlugin = require('webpack-notifier')
 
 const srcDirectory = 'frontend'
-const outputDir = 'dist'
+const outputDir = isProd ? 'dist' : (process.env.TWILL_DEV_ASSETS_PATH || 'dist')
 const assetsDir = process.env.TWILL_ASSETS_DIR || 'assets/admin'
 
 const pages = {


### PR DESCRIPTION
## Description

Allow setting the dist path for the dev task in `.env`. This has two small advantages to me: it's possible to enable dev mode and set variables from `.env` only and also allow setting the dev path to a folder that is ignored by git, for example `public/dist`, leaving a clean git status.

```env
TWILL_DEV_MODE_URL=http://10.0.0.10:8080
TWILL_DEV_MODE=true
TWILL_DEV_ASSETS_PATH="/public/dist"
```

## Related Issues

—