### PR TITLE
Display publishable languages labels using the currently set locale

### DIFF
--- a/src/Helpers/i18n_helpers.php
+++ b/src/Helpers/i18n_helpers.php
@@ -73,7 +73,7 @@ if (!function_exists('getLanguageLabelFromLocaleCode')) {
             if ($native) {
                 return ucfirst(Locale::getDisplayLanguage($code, $code));
             } else {
-                return ucfirst(Locale::getDisplayLanguage($code, 'en'));
+                return ucfirst(Locale::getDisplayLanguage($code, config('twill.locale', config('twill.fallback_locale', 'en'))));
             }
         }
 


### PR DESCRIPTION
<!--
  Thanks for opening a PR! Your contribution is much appreciated.
  Do you have any questions? Check out the contributing docs at https://github.com/area17/twill/blob/2.x/CONTRIBUTING.md, 
  or ask in this Pull Request and a Twill maintainer will be happy to help :)
-->

## Description

<!-- Write a description of the changes introduced by this PR -->
<!-- If this is introducing a new feature, it would be great if you can create a stub for documentation including bullet points for how to use the feature, code snippets, etc. -->

When setting the `twill.locale` to something else than `en`, the list of languages in the publisher was still displayed in English. This change uses the locale set in the configuration as well as the user's preferred locale if different than the configured one.

