### PR TITLE
Register capsules routes before Twill internal routes

### DIFF
--- a/src/RouteServiceProvider.php
+++ b/src/RouteServiceProvider.php
@@ -48,6 +48,8 @@ class RouteServiceProvider extends ServiceProvider
             $this->getRouteMiddleware(),
             $this->supportSubdomainRouting()
         );
+        
+        $this->registerCapsulesRoutes($router);
 
         $this->mapInternalRoutes(
             $router,
@@ -55,8 +57,6 @@ class RouteServiceProvider extends ServiceProvider
             $this->getRouteMiddleware(),
             $this->supportSubdomainRouting()
         );
-
-        $this->registerCapsulesRoutes($router);
     }
 
     private function mapHostRoutes(


### PR DESCRIPTION
<!--
  Thanks for opening a PR! Your contribution is much appreciated.
  Do you have any questions? Check out the contributing docs at https://github.com/area17/twill/blob/2.x/CONTRIBUTING.md, 
  or ask in this Pull Request and a Twill maintainer will be happy to help :)
-->

## Description

<!-- Write a description of the changes introduced by this PR -->
<!-- If this is introducing a new feature, it would be great if you can create a stub for documentation including bullet points for how to use the feature, code snippets, etc. -->

While trying to set up a capsule under the `settings` navigation namespace, I wasn't able to register the module's routes under a group with the `settings` prefix. The index route was redirecting to the CMS index because Twill did not find a settings Blade file for that route. Registering the capsules routes before Twill's internal routes is making that possible.

