### PR TITLE
Feature/media references

### DIFF
--- a/config/media-library.php
+++ b/config/media-library.php
@@ -31,4 +31,5 @@ return [
     'prefix_uuid_with_local_path' => config('twill.file_library.prefix_uuid_with_local_path', false),
     'translated_form_fields' => false,
     'show_file_name' => false,
+    'show_media_references' => false,
 ];

--- a/config/twill.php
+++ b/config/twill.php
@@ -194,4 +194,14 @@ return [
         'zh-Hans',
         'ru',
     ],
+    /*
+    |--------------------------------------------------------------------------
+    | Admin Module route prefixes
+    |--------------------------------------------------------------------------
+    |
+    | Used to link modules referenced by medias and files and that have route prefixes
+    |
+     */
+    'module_route_prefixes' => [
+    ],
 ];

--- a/frontend/js/components/MediaField.vue
+++ b/frontend/js/components/MediaField.vue
@@ -30,6 +30,12 @@
           <li class="f--small">
             <a href="#" @click.prevent="metadatasInfos" v-if="withAddInfo" class="f--link-underlined--o">{{ metadatas.text }}</a>
           </li>
+          <li v-if="showMediaReferences && media.owners.length >= 1">
+            <ul class="media__references ">
+              <li class="media__name">{{ $trans('media-library.sidebar.references', 'References') }}</li>
+              <li class="f--small" :style="(index)" v-for="(item, index) in media.owners" :key="'mediaowner_' + item.id"><a :href="item.edit" target="_blank">{{ item.name }}</a></li>
+            </ul>
+          </li>
         </ul>
 
         <!--Actions-->
@@ -256,7 +262,8 @@
       },
       ...mapState({
         selectedMedias: state => state.mediaLibrary.selected,
-        allCrops: state => state.mediaLibrary.crops
+        allCrops: state => state.mediaLibrary.crops,
+        showMediaReferences: state => state.mediaLibrary.showMediaReferences
       })
     },
     watch: {
@@ -803,6 +810,10 @@
       margin-top:20px;
       margin-bottom:20px;
     }
+  }
+  /* Media References */
+  .media__references {
+    margin-top: 20px;
   }
 </style>
 

--- a/frontend/js/components/files/FileItem.vue
+++ b/frontend/js/components/files/FileItem.vue
@@ -1,26 +1,37 @@
 <template>
-  <tr class="fileItem">
-    <td v-if="draggable" class="fileItem__cell fileItem__cell--drag">
-      <div class="drag__handle--drag"></div>
-    </td>
-    <td class="fileItem__cell fileItem__cell--extension" v-if="currentItem.hasOwnProperty('extension')">
-      <a href="#" target="_blank"><span v-svg :symbol="getSvgIconName()"></span></a>
-    </td>
-    <td class="fileItem__cell fileItem__cell--name">
-      <span v-if="currentItem.hasOwnProperty('thumbnail')"><img :src="currentItem.thumbnail"/></span>
-      <a :href="currentItem.hasOwnProperty('original') ? currentItem.original : '#'" download><span class="f--link-underlined--o">{{ currentItem.name }}</span></a>
-      <input type="hidden" :name="name" :value="currentItem.id"/>
-    </td>
-    <td class=" fileItem__cell fileItem__cell--size" v-if="currentItem.hasOwnProperty('size')">{{ currentItem.size }}</td>
-    <td class="fileItem__cell">
-      <a17-button class="bucket__action" icon="close" @click="deleteItem()"><span v-svg symbol="close_icon"></span>
-      </a17-button>
-    </td>
-  </tr>
+  <div>
+    <tr class="fileItem">
+      <td v-if="draggable" class="fileItem__cell fileItem__cell--drag">
+        <div class="drag__handle--drag"></div>
+      </td>
+      <td class="fileItem__cell fileItem__cell--extension" v-if="currentItem.hasOwnProperty('extension')">
+        <a href="#" target="_blank"><span v-svg :symbol="getSvgIconName()"></span></a>
+      </td>
+      <td class="fileItem__cell fileItem__cell--name">
+        <span v-if="currentItem.hasOwnProperty('thumbnail')"><img :src="currentItem.thumbnail"/></span>
+        <a :href="currentItem.hasOwnProperty('original') ? currentItem.original : '#'" download><span class="f--link-underlined--o">{{ currentItem.name }}</span></a>
+        <input type="hidden" :name="name" :value="currentItem.id"/>
+      </td>
+      <td class=" fileItem__cell fileItem__cell--size" v-if="currentItem.hasOwnProperty('size')">{{ currentItem.size }}</td>
+      <td class="fileItem__cell">
+        <a17-button class="bucket__action" icon="close" @click="deleteItem()"><span v-svg symbol="close_icon"></span>
+        </a17-button>
+      </td>
+    </tr>
+    <tr v-if="showMediaReferences && currentItem.owners.length >= 1" class="fileItem fileReferences">
+      <td class="fileItem">
+        <ul class="fileItem_references">
+          <li class="media__name"><strong>{{ $trans('media-library.sidebar.references', 'References') }}</strong></li>
+          <li class="f--small" :style="(index)" v-for="(item, index) in currentItem.owners" :key="'fileowner_' + item.id"><a :href="item.edit" target="_blank">{{ item.name }}</a></li>
+        </ul>
+      </td>
+    </tr>
+  </div>
 </template>
 
 <script>
   import Extensions from './Extensions'
+  import { mapState } from 'vuex'
 
   export default {
     name: 'a17FileItem',
@@ -60,7 +71,10 @@
     computed: {
       currentItem: function () {
         return this.item
-      }
+      },
+      ...mapState({
+        showMediaReferences: state => state.mediaLibrary.showMediaReferences
+      })
     },
     methods: {
       deleteItem: function () {
@@ -184,5 +198,12 @@
     margin-right:auto;
     transition: background 250ms ease;
     @include dragGrid($color__drag, $color__drag_bg);
+  }
+
+  .fileItem_references {
+    padding: 5px 15px;
+    flex-grow: 1;
+    color: $color__text--light;
+    overflow: hidden;
   }
 </style>

--- a/frontend/js/components/media-library/MediaSidebar.vue
+++ b/frontend/js/components/media-library/MediaSidebar.vue
@@ -19,6 +19,13 @@
           </ul>
         </template>
 
+        <template v-if="showMediaReferences && hasSingleMedia && firstMedia.owners.length >= 1">
+          <p v-if="firstMedia.owners.length >= 1" class="mediasidebar__reference_label">{{ $trans('media-library.sidebar.references', 'References') }}</p>
+          <ul  class="mediasidebar__metadatas usage">
+            <li class="f--small" :style="(index)" v-for="(item, index) in firstMedia.owners" :key="'mediaowner_' + item.id"><a :href="item.edit" target="_blank">{{ item.name }}</a></li>
+          </ul>
+        </template>
+
         <a17-buttonbar class="mediasidebar__buttonbar" v-if="hasMedia">
           <!-- Actions -->
           <a v-if="hasSingleMedia" :href="firstMedia.original" download><span v-svg symbol="download"></span></a>
@@ -243,7 +250,8 @@
         return this.extraMetadatas.filter(m => !m.multiple || (m.multiple && this.translatableMetadatas.includes(m.name)))
       },
       ...mapState({
-        mediasLoading: state => state.mediaLibrary.loading
+        mediasLoading: state => state.mediaLibrary.loading,
+        showMediaReferences: state => state.mediaLibrary.showMediaReferences
       })
     },
     methods: {

--- a/frontend/js/store/modules/media-library.js
+++ b/frontend/js/store/modules/media-library.js
@@ -78,7 +78,12 @@ const state = {
    * An index used when mediaLibrary is open to replace a file
    * @type {number}
    */
-  indexToReplace: -1
+  indexToReplace: -1,
+  /**
+   * Displays where an image, file or record is being referenced
+   * @type {Boolean}
+   */
+  showMediaReferences: window[process.env.VUE_APP_NAME].STORE.medias.showMediaReferences || false
 }
 
 // getters

--- a/src/Helpers/routes_helpers.php
+++ b/src/Helpers/routes_helpers.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Support\Str;
 use Illuminate\Support\Facades\Request;
+use Illuminate\Support\Facades\Route;
 
 if (!function_exists('moduleRoute')) {
     /**

--- a/src/Helpers/routes_helpers.php
+++ b/src/Helpers/routes_helpers.php
@@ -80,3 +80,36 @@ if (!function_exists('isActiveNavigation')) {
         return $urlsAreMatching;
     }
 }
+
+if (!function_exists('moduleRouteExists')) {
+    /**
+     * @param string $moduleName
+     * @param string $prefix
+     * @param string $action
+     * @param array $parameters
+     * @param bool $absolute
+     * @return bool
+     */
+    function moduleRouteExists($moduleName, $prefix, $action)
+    {
+        // Fix module name case
+        $moduleName = Str::camel($moduleName);
+
+        // Create base route name
+        $routeName = 'admin.' . ($prefix ? $prefix . '.' : '');
+
+        // Prefix it with module name only if prefix doesn't contains it already
+        if (
+            config('twill.allow_duplicates_on_route_names', true) ||
+            ($prefix !== $moduleName &&
+                !Str::endsWith($prefix, '.' . $moduleName))
+        ) {
+            $routeName .= "{$moduleName}.";
+        }
+
+        //  Add the action name
+        $routeName .= $action;
+
+        return Route::has($routeName);
+    }
+}

--- a/src/Models/File.php
+++ b/src/Models/File.php
@@ -90,7 +90,7 @@ class File extends Model
                     'titleKey' => $model->titleKey,
                     'model'=>$model,
                     'module'=>$module,
-                    'edit' => moduleRoute($module, config('twill.block_editor.browser_route_prefixes.' . $module), 'edit', $model->id),
+                    'edit' => moduleRouteExists($module,config('twill.module_route_prefixes.' . $module),'edit', $model->id ) ? moduleRoute($module, config('twill.module_route_prefixes.' . $module), 'edit', $model->id) : null,
                 ] : [];
 
             }
@@ -102,7 +102,7 @@ class File extends Model
                 'titleKey' => $item->titleKey,
                 'model'=>$item,
                 'module'=>$module,
-                'edit' => moduleRoute($module, config('twill.block_editor.browser_route_prefixes.' . $module), 'edit', $item->id),
+                'edit' => moduleRouteExists($module,config('twill.module_route_prefixes.' . $module),'edit', $item->id ) ? moduleRoute($module, config('twill.module_route_prefixes.' . $module), 'edit', $item->id) : null,
             ];
 
         })->filter()->values()->toArray();

--- a/src/Models/File.php
+++ b/src/Models/File.php
@@ -4,6 +4,9 @@ namespace A17\Twill\Models;
 
 use FileService;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use A17\Twill\Models\Behaviors\HasSlug;
 
 class File extends Model
 {
@@ -40,11 +43,69 @@ class File extends Model
             'original' => FileService::getUrl($this->uuid),
             'size' => $this->size,
             'filesizeInMb' => number_format($this->attributes['size'] / 1048576, 2),
+            'owners' => $this->getOwnerDetails(),
         ];
     }
 
     public function getTable()
     {
         return config('twill.files_table', 'twill_files');
+    }
+
+    public function getOwners()
+    {
+        $morphMap = Relation::morphMap();
+
+        $owners = collect(
+            DB::table(config('twill.fileables_table', 'twill_fileables'))
+                ->where('file_id', $this->id)->get()
+            );
+
+        return $owners->map(function ($owner) use ($morphMap){
+            $resolvedClass =  array_key_exists($owner->fileable_type, $morphMap) ? $morphMap[ $owner->fileable_type ] : $owner->fileable_type;
+
+            return resolve($resolvedClass)::find($owner->fileable_id);
+
+        });
+    }
+
+    public function getOwnerDetails()
+    {
+        $owners =  $this->getOwners();
+
+        return collect(($owners))->filter(function ($value){
+            return is_object($value);
+        })->map(function ($item){
+            $module = Str::plural(lcfirst((new \ReflectionClass($item))->getShortName()));
+
+            if ($item instanceof Block){
+                $model=$item->blockable;
+
+                $module = $model ? Str::plural(lcfirst((new \ReflectionClass($model))->getShortName())): null;
+
+                return ($model && $module) ? [
+                    'id' => $model->id,
+                    'slug' => classHasTrait($model, HasSlug::class) ? $model->slug : null,
+                    'name' => $model->{$model->titleKey},
+                    'titleKey' => $model->titleKey,
+                    'model'=>$model,
+                    'module'=>$module,
+                    'edit' => moduleRoute($module, config('twill.block_editor.browser_route_prefixes.' . $module), 'edit', $model->id),
+                ] : [];
+
+            }
+
+            return [
+                'id' => $item->id,
+                'slug' => classHasTrait($item, HasSlug::class) ? $item->slug : null,
+                'name' => $item->{$item->titleKey},
+                'titleKey' => $item->titleKey,
+                'model'=>$item,
+                'module'=>$module,
+                'edit' => moduleRoute($module, config('twill.block_editor.browser_route_prefixes.' . $module), 'edit', $item->id),
+            ];
+
+        })->filter()->values()->toArray();
+
     }
 }

--- a/src/Models/Media.php
+++ b/src/Models/Media.php
@@ -175,7 +175,7 @@ class Media extends Model
                     'titleKey' => $model->titleKey,
                     'model'=>$model,
                     'module'=>$module,
-                    'edit' => moduleRoute($module, config('twill.block_editor.browser_route_prefixes.' . $module), 'edit', $model->id),
+                    'edit' => moduleRouteExists($module,config('twill.module_route_prefixes.' . $module),'edit', $model->id ) ? moduleRoute($module, config('twill.module_route_prefixes.' . $module), 'edit', $model->id) : null,
                 ] : [];
 
             }
@@ -187,7 +187,7 @@ class Media extends Model
                 'titleKey' => $item->titleKey,
                 'model'=>$item,
                 'module'=>$module,
-                'edit' => moduleRoute($module, config('twill.block_editor.browser_route_prefixes.' . $module), 'edit', $item->id),
+                'edit' =>  moduleRouteExists($module,config('twill.module_route_prefixes.' . $module),'edit', $item->id ) ? moduleRoute($module, config('twill.module_route_prefixes.' . $module), 'edit', $item->id) : null,
             ];
 
         })->filter()->values()->toArray();

--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -17,6 +17,13 @@ abstract class Model extends BaseModel implements TaggableInterface
 
     public $timestamps = true;
 
+    /**
+     * Key of the index column to use as title column.
+     *
+     * @var string
+     */
+    public $titleKey = 'title';
+
     public function scopePublished($query)
     {
         return $query->wherePublished(true);

--- a/views/layouts/main.blade.php
+++ b/views/layouts/main.blade.php
@@ -97,6 +97,7 @@
                     uploaderConfig: {!! json_encode($mediasUploaderConfig) !!}
                 });
                 window['{{ config('twill.js_namespace') }}'].STORE.medias.showFileName = !!'{{ config('twill.media_library.show_file_name') }}';
+                window['{{ config('twill.js_namespace') }}'].STORE.medias.showMediaReferences = !!'{{ config('twill.media_library.show_media_references') }}';
             @endif
 
             @if (config('twill.enabled.file-library'))


### PR DESCRIPTION
## Description

This PR allows users to know where images and files have been linked or referenced from either the media library or a media/file form field.

The PR introduces two additional configurations.

`twill.media-library.show_media_references => false`

and

`twill.module_route_prefixes=>[]` . Used as a fallback when modules have route prefixes .

## Screenshots

![media_library](https://user-images.githubusercontent.com/9251915/123712340-cf45cd00-d87a-11eb-8370-eaa7b043bc40.jpg)


![media_form_field](https://user-images.githubusercontent.com/9251915/123712370-e1277000-d87a-11eb-8920-e24d47f5a268.jpg)

