### PR TITLE
Load translations files from capsules

### DIFF
--- a/src/CapsulesServiceProvider.php
+++ b/src/CapsulesServiceProvider.php
@@ -49,6 +49,7 @@ class CapsulesServiceProvider extends RouteServiceProvider
     protected function registerCapsule($capsule)
     {
         $this->loadMigrationsFrom($capsule['migrations_dir']);
+        $this->loadTranslationsFrom($capsule['lang_dir'], 'twill:capsules:' . $capsule['module']);
     }
 
     public function registerViewPaths()

--- a/src/Services/Capsules/HasCapsules.php
+++ b/src/Services/Capsules/HasCapsules.php
@@ -122,6 +122,8 @@ trait HasCapsules
             'migrations_dir'
         ] = "{$capsule['root_path']}/database/migrations";
 
+        $capsule['lang_dir'] = "{$capsule['root_path']}/resources/lang";
+
         $capsule['views_dir'] = "{$capsule['root_path']}/resources/views";
 
         $capsule['view_prefix'] = "{$name}.resources.views.admin";


### PR DESCRIPTION
<!--
  Thanks for opening a PR! Your contribution is much appreciated.
  Do you have any questions? Check out the contributing docs at https://github.com/area17/twill/blob/2.x/CONTRIBUTING.md, 
  or ask in this Pull Request and a Twill maintainer will be happy to help :)
-->

## Description

<!-- Write a description of the changes introduced by this PR -->
<!-- If this is introducing a new feature, it would be great if you can create a stub for documentation including bullet points for how to use the feature, code snippets, etc. -->
This allows Laravel `.php` translations file to be set up and used in a capsule.


To access translations, the internal Twill helper `twillTrans` can be used, for example:

`twillTrans('twill:capsules:events::lang.event-type')`. 

`lang` is the name of a file in the capsule's `resources/lang/<locale>/` directory and `events` is the name of the module that is set up in the capsule.
