### PR TITLE
Reflect user-selected file order in files field

### DIFF
--- a/src/Models/Behaviors/HasFiles.php
+++ b/src/Models/Behaviors/HasFiles.php
@@ -18,7 +18,8 @@ trait HasFiles
             File::class,
             'fileable',
             config('twill.fileables_table', 'twill_fileables')
-        )->withPivot(['role', 'locale'])->withTimestamps();
+        )->withPivot(['role', 'locale'])
+            ->withTimestamps()->orderBy(config('twill.fileables_table', 'twill_fileables') . '.id', 'asc');
     }
 
     private function findFile($role, $locale)


### PR DESCRIPTION
## Description

This updates the `HasFiles` behavior to order files by `fileable.id`. The `fileable.id` sequence already corresponds to the user-selected file order in the CMS. 

## Related Issues

Fixes https://github.com/area17/twill/issues/1020
