### PR TITLE
Update model stub default crops

### DIFF
--- a/src/Commands/stubs/model.stub
+++ b/src/Commands/stubs/model.stub
@@ -28,7 +28,7 @@ class {{modelClassName}} extends Model {{modelImplements}}
     {{/hasSlug}}{{hasMedias}}
     public $mediasParams = [
         'cover' => [
-            'desktop' => [
+            'default' => [
                 [
                     'name' => 'desktop',
                     'ratio' => 16 / 9,

--- a/src/Commands/stubs/model.stub
+++ b/src/Commands/stubs/model.stub
@@ -30,7 +30,7 @@ class {{modelClassName}} extends Model {{modelImplements}}
         'cover' => [
             'default' => [
                 [
-                    'name' => 'desktop',
+                    'name' => 'default',
                     'ratio' => 16 / 9,
                 ],
             ],


### PR DESCRIPTION
## Description

Small update to `model.stub` to use `default` instead of `desktop` as first crop name. This makes generated models compatible out of the box with the various methods from `HasMedias` that use `default` as implicit crop name.

## Related Issues

Fixes https://github.com/area17/twill/issues/604
