### PR TITLE
Update browser field documentation

### DIFF
--- a/docs/.sections/form-fields.md
+++ b/docs/.sections/form-fields.md
@@ -951,19 +951,9 @@ You can use the same approach to handle polymorphic relationships through Twill'
 - Update `ArticleRepository`:
 
 ```php
-use A17\Twill\Repositories\Behaviors\HandleRelatedBrowsers;
-
 class ArticleRepository extends ModuleRepository
 {
-    use HandleRelatedBrowsers;
-    
-    /* ... */
-
-    public function __construct(Article $model)
-    {
-        $this->relatedBrowsers = ['collaborators'];
-        $this->model = $model;
-    }
+    protected $relatedBrowsers = ['collaborators'];
 }
 ```
 
@@ -1018,11 +1008,11 @@ class ArticleRepository extends ModuleRepository
 To retrieve the items in the frontend, you can use the `getRelated` method on models and blocks. It will return of collection of related models in the correct order:
 
 ```php
-    $item->getRelated('related_content');
+    $item->getRelated('collaborators');
 
     // or, in a block:
 
-    $block->getRelated('related_content');
+    $block->getRelated('collaborators');
 ```
 
 #### Using browser fields and custom pivot tables

--- a/docs/.sections/form-fields.md
+++ b/docs/.sections/form-fields.md
@@ -918,22 +918,12 @@ class Article extends Model
 }
 ```
 
-- Update `ArticleRepository` to add the `HandleRelatedBrowsers` trait. Then, define the browser field in the `$relatedBrowsers` property:
+- Update `ArticleRepository` to add the browser field to the `$relatedBrowsers` property:
 
 ```php
-use A17\Twill\Repositories\Behaviors\HandleRelatedBrowsers;
-
 class ArticleRepository extends ModuleRepository
 {
-    use HandleRelatedBrowsers;
-    
-    /* ... */
-
-    public function __construct(Article $model)
-    {
-        $this->relatedBrowsers = ['authors'];
-        $this->model = $model;
-    }
+    protected $relatedBrowsers = ['authors'];
 }
 ```
 

--- a/docs/.sections/form-fields.md
+++ b/docs/.sections/form-fields.md
@@ -987,14 +987,40 @@ class ArticleRepository extends ModuleRepository
 
     @formField('browser', [
         'modules' => [
-            ['name' => 'authors', 'label' => 'Authors'],
-            ['name' => 'editors', 'label' => 'Editors'],
+            [
+              'label' => 'Authors',
+              'name' => 'authors',
+            ],
+            [
+              'label' => 'Editors',
+              'name' => 'editors',
+            ],
         ],
         'name' => 'collaborators',
         'label' => 'Collaborators',
         'max' => 4,
     ])
 @stop
+```
+
+- Alternatively, you can use manual endpoints instead of module names:
+
+```php
+    @formField('browser', [
+        'endpoints' => [
+            [
+              'label' => 'Authors',
+              'value' => '/authors/browser',
+            ],
+            [
+              'label' => 'Editors',
+              'value' => '/editors/browser',
+            ],
+        ],
+        'name' => 'collaborators',
+        'label' => 'Collaborators',
+        'max' => 4,
+    ])
 ```
 
 #### Working with related items

--- a/docs/.sections/form-fields.md
+++ b/docs/.sections/form-fields.md
@@ -895,14 +895,66 @@ See [Block editor](https://twill.io/docs/#block-editor-3)
 
 <br/>
 
-Browser fields can be used to save a `belongsToMany` relationship outside of the block editor.
+Browser fields can be used inside as well as outside the block editor.
 
-Checkout this [Spectrum tutorial](https://spectrum.chat/twill/tips-and-tricks/step-by-step-ii-creating-a-twill-app~37c36601-1198-4c53-857a-a2b47c6d11aa) until we update this section to get more info on setting things up.
+Inside the block editor, no migration is needed when using browsers. Refer to the section titled [Adding browser fields to a block](#adding-browser-fields-to-a-block) for a detailed explanation.
 
-When using inside of the block editor, no migration is needed. Refer to the section titled [Adding browser fields to a block](#adding-browser-fields-to-a-block) for a detailed explanation.
+Outside the block editor, browser fields are used to save `belongsToMany` relationships. The relationships can be stored in Twill's own `related` table or in a custom pivot table.
 
+#### Using browser fields as related items
 
-### Browser with multiple modules
+The following example demonstrates how to use a browser field to attach `Authors` to `Articles`. 
+
+- Update the `Article` model to add the `HasRelated` trait:
+
+```php
+use A17\Twill\Models\Behaviors\HasRelated;
+
+class Article extends Model
+{
+    use HasRelated;
+
+    /* ... */
+}
+```
+
+- Update `ArticleRepository` to add the `HandleRelatedBrowsers` trait. Then, define the browser field in the `$relatedBrowsers` property:
+
+```php
+use A17\Twill\Repositories\Behaviors\HandleRelatedBrowsers;
+
+class ArticleRepository extends ModuleRepository
+{
+    use HandleRelatedBrowsers;
+    
+    /* ... */
+
+    public function __construct(Article $model)
+    {
+        $this->relatedBrowsers = ['authors'];
+        $this->model = $model;
+    }
+}
+```
+
+- Add the browser field to `resources/views/admin/articles/form.blade.php`:
+
+```php
+@extends('twill::layouts.form')
+
+@section('contentFields')
+    ...
+
+    @formField('browser', [
+        'moduleName' => 'authors',
+        'name' => 'authors',
+        'label' => 'Authors',
+        'max' => 4,
+    ])
+@stop
+```
+
+#### Browser with multiple modules
 
 With module names:
 ```php


### PR DESCRIPTION
## Description

This is an update of the browser field section to focus on the new `HasRelatedBrowsers` trait. It covers mostly the same areas as before: single module, multiple modules, manual endpoints and frontend usage. The link to the extensive Spectrum tutorial is kept as a reference on how to work with custom pivot tables.

## Related Issues

Fixes https://github.com/area17/twill/issues/968
Related to https://github.com/area17/twill/pull/967