### PR TITLE
Add HandleRelatedBrowsers to ModuleRepository 

### DIFF
--- a/src/Repositories/ModuleRepository.php
+++ b/src/Repositories/ModuleRepository.php
@@ -7,6 +7,7 @@ use A17\Twill\Models\Model;
 use A17\Twill\Repositories\Behaviors\HandleBrowsers;
 use A17\Twill\Repositories\Behaviors\HandleDates;
 use A17\Twill\Repositories\Behaviors\HandleFieldsGroups;
+use A17\Twill\Repositories\Behaviors\HandleRelatedBrowsers;
 use A17\Twill\Repositories\Behaviors\HandleRepeaters;
 use A17\Twill\Services\Capsules\HasCapsules;
 use Illuminate\Database\Eloquent\Relations\Relation;
@@ -21,7 +22,7 @@ use PDO;
 
 abstract class ModuleRepository
 {
-    use HandleDates, HandleBrowsers, HandleRepeaters, HandleFieldsGroups, HasCapsules;
+    use HandleDates, HandleBrowsers, HandleRelatedBrowsers, HandleRepeaters, HandleFieldsGroups, HasCapsules;
 
     /**
      * @var \A17\Twill\Models\Model


### PR DESCRIPTION
## Description

This adds `HandleRelatedBrowsers` to the list of default `ModuleRepository` traits.

Because of a limitation with PHP traits, a property coming from a trait can't be immediately redefined on the consuming class. However, this doesn't apply to child classes. Effectively, this update would allow this:

```
class ArticleRepository extends ModuleRepository
{
    protected $relatedBrowsers = ['authors'];
}
```

instead of:

```
class ArticleRepository extends ModuleRepository
{
    use HandleRelatedBrowsers;
    
    /* ... */

    public function __construct(Article $model)
    {
        $this->relatedBrowsers = ['authors'];
        $this->model = $model;
    }
}
```

## Related Issues

Related to https://github.com/area17/twill/pull/1035
