### PR TITLE
Allow Google2FA-QRCode 2.0 to add support for chillerlan php-qrcode

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
     "league/glide-laravel": "^1.0",
     "matthewbdaly/laravel-azure-storage": "^1.3",
     "myclabs/php-enum": "^1.5",
-    "pragmarx/google2fa-qrcode": "^1.0",
+    "pragmarx/google2fa-qrcode": "^1.0|^2.0",
     "spatie/laravel-activitylog": "^2.5|^3.2",
     "spatie/laravel-analytics": "^3.6",
     "spatie/once": "^2.0"

--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,8 @@
     "kalnoy/nestedset": "^5.0",
     "nunomaduro/collision": "^3.0|^4.2|^5.0",
     "orchestra/testbench": "~3.3|~3.4|~3.5|~3.6|~3.7|~3.8|^4.0|^5.0|^6.0",
-    "phpunit/phpunit": "~5.0|~6.0|~7.0|~8.0|~9.0"
+    "phpunit/phpunit": "~5.0|~6.0|~7.0|~8.0|~9.0",
+    "chillerlan/php-qrcode": "~4.0"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
     "nunomaduro/collision": "^3.0|^4.2|^5.0",
     "orchestra/testbench": "~3.3|~3.4|~3.5|~3.6|~3.7|~3.8|^4.0|^5.0|^6.0",
     "phpunit/phpunit": "~5.0|~6.0|~7.0|~8.0|~9.0",
-    "chillerlan/php-qrcode": "~4.0"
+    "chillerlan/php-qrcode": "~1.0|~1.0|~3.0|~4.0"
   },
   "autoload": {
     "psr-4": {

--- a/src/TwillServiceProvider.php
+++ b/src/TwillServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace A17\Twill;
 
+use Exception;
 use A17\Twill\Commands\BlockMake;
 use A17\Twill\Commands\Build;
 use A17\Twill\Commands\CapsuleInstall;
@@ -86,6 +87,8 @@ class TwillServiceProvider extends ServiceProvider
 
         $this->extendBlade();
         $this->addViewComposers();
+
+        $this->check2FA();
     }
 
     /**
@@ -477,5 +480,24 @@ class TwillServiceProvider extends ServiceProvider
     public function version()
     {
         return static::VERSION;
+    }
+
+    /**
+     * In case 2FA is enabled, we need to check if a QRCode compatible package is
+     * installed.
+     */
+    public function check2FA()
+    {
+        if (!config('twill.enabled.users-2fa')) {
+            return;
+        }
+
+        try {
+            (new User())->get2faQrCode();
+        } catch (Exception $e) {
+            throw new Exception(
+                "Twill ERROR: As you have 2FA enabled, you also need to install a QRCode service package, please check https://github.com/antonioribeiro/google2fa-qrcode#built-in-qrcode-rendering-services"
+            );
+        }
     }
 }

--- a/src/TwillServiceProvider.php
+++ b/src/TwillServiceProvider.php
@@ -38,6 +38,7 @@ use Illuminate\Support\Facades\View;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Str;
 use Spatie\Activitylog\ActivitylogServiceProvider;
+use PragmaRX\Google2FAQRCode\Google2FA as Google2FAQRCode;
 
 class TwillServiceProvider extends ServiceProvider
 {
@@ -492,9 +493,8 @@ class TwillServiceProvider extends ServiceProvider
             return;
         }
 
-        try {
-            (new User())->get2faQrCode();
-        } catch (Exception $e) {
+        if (blank((new Google2FAQRCode())->getQrCodeService()))
+        {
             throw new Exception(
                 "Twill ERROR: As you have 2FA enabled, you also need to install a QRCode service package, please check https://github.com/antonioribeiro/google2fa-qrcode#built-in-qrcode-rendering-services"
             );

--- a/src/TwillServiceProvider.php
+++ b/src/TwillServiceProvider.php
@@ -489,7 +489,7 @@ class TwillServiceProvider extends ServiceProvider
      */
     public function check2FA()
     {
-        if (!config('twill.enabled.users-2fa')) {
+        if (!$this->app->runningInConsole() || !config('twill.enabled.users-2fa')) {
             return;
         }
 

--- a/views/users/form.blade.php
+++ b/views/users/form.blade.php
@@ -69,7 +69,7 @@
                 'fieldName' => 'google_2fa_enabled',
                 'fieldValues' => true,
             ])
-                <img style="display: block; margin-left: auto; margin-right: auto;" src="{{ $qrCode }}">
+                <img style="display: block; margin-left: auto; margin-right: auto; max-height: 300px;" src="{{ $qrCode }}">
                 <div class="f--regular f--note" style="margin: 20px 0;">{!! twillTrans('twill::lang.user-management.2fa-description', ['link' => 'https://github.com/antonioribeiro/google2fa#google-authenticator-apps']) !!}</div>
                 @formField('input', [
                     'name' => 'verify-code',


### PR DESCRIPTION
## Description

BaconQR code requires (required?) the Imagick extension, which poses some problems on certain environments. This PR allows Composer to install Google2FA-QRCode 2.x, if possible, which support both BaconQRCode and [Chillerlan PHP QRCode](https://github.com/chillerlan/php-qrcode).

This is probably a breaking change, because people will have to choose and explicitly install one of those: 

``` sh
composer require chillerlan/php-qrcode
```

``` sh
composer require bacon/bacon-qr-code
```

This is the endresult on Twill with Chillerlan:

<img width="998" alt="Screenshot 2021-07-07 at 19 09 04" src="https://user-images.githubusercontent.com/3182864/124801149-cf1e8f00-df56-11eb-9e8a-1cce5e847379.png">

