### PR TITLE
WIP: Remove main-free.css which is not actually shipped in dist

### DIFF
--- a/views/layouts/free.blade.php
+++ b/views/layouts/free.blade.php
@@ -2,15 +2,6 @@
 
 @section('appTypeClass', 'body--custom-page')
 
-@push('extra_css')
-    @if(app()->isProduction())
-        <link href="{{ twillAsset('main-free.css')}}" rel="preload" as="style" crossorigin/>
-    @endif
-    @unless(config('twill.dev_mode', false))
-        <link href="{{ twillAsset('main-free.css') }}" rel="stylesheet" crossorigin/>
-    @endunless
-@endpush
-
 @push('extra_js_head')
     @if(app()->isProduction())
         <link href="{{ twillAsset('main-free.js')}}" rel="preload" as="script" crossorigin/>


### PR DESCRIPTION
remove non packed main.css from throwing errors when using custom admin pages.

<!--
  Thanks for opening a PR! Your contribution is much appreciated.
  Do you have any questions? Check out the contributing docs at https://github.com/area17/twill/blob/2.x/CONTRIBUTING.md, 
  or ask in this Pull Request and a Twill maintainer will be happy to help :)
-->

## Description
When writing custom admin pages you get a 404 not found on the auto-queried/included main-free.css, when you check though this does not exist and is not shipped and is a placeholder. 
<!-- Write a description of the changes introduced by this PR -->
<!-- If this is introducing a new feature, it would be great if you can create a stub for documentation including bullet points for how to use the feature, code snippets, etc. -->

## Related Issues
None, its obviously not a massive issue to get the odd 404 on a page, but should be avoided as it lacks quality finish. 
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
