### PR TITLE
Add table aliases

### DIFF
--- a/src/Models/Behaviors/HasPosition.php
+++ b/src/Models/Behaviors/HasPosition.php
@@ -19,7 +19,7 @@ trait HasPosition
 
     protected function getCurrentLastPosition()
     {
-        return ((int) static::max('position'));
+        return ((int) static::max("{$this->getTable()}.position"));
     }
 
     /**
@@ -28,7 +28,7 @@ trait HasPosition
      */
     public function scopeOrdered($query)
     {
-        return $query->orderBy('position');
+        return $query->orderBy("{$this->getTable()}.position");
     }
 
     /**

--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -26,13 +26,14 @@ abstract class Model extends BaseModel implements TaggableInterface
 
     public function scopePublished($query)
     {
-        return $query->wherePublished(true);
+        return $query->where("{$this->getTable()}.published", true);
     }
 
     public function scopePublishedInListings($query)
     {
         if ($this->isFillable('public')) {
-            $query->wherePublic(true);
+            $query->where("{$this->getTable()}.public", true);
+
         }
 
         return $query->published()->visible();
@@ -42,12 +43,12 @@ abstract class Model extends BaseModel implements TaggableInterface
     {
         if ($this->isFillable('publish_start_date')) {
             $query->where(function ($query) {
-                $query->whereNull('publish_start_date')->orWhere('publish_start_date', '<=', Carbon::now());
+                $query->whereNull("{$this->getTable()}.publish_start_date")->orWhere("{$this->getTable()}.publish_start_date", '<=', Carbon::now());
             });
 
             if ($this->isFillable('publish_end_date')) {
                 $query->where(function ($query) {
-                    $query->whereNull('publish_end_date')->orWhere('publish_end_date', '>=', Carbon::now());
+                    $query->whereNull("{$this->getTable()}.publish_end_date")->orWhere("{$this->getTable()}.publish_end_date", '>=', Carbon::now());
                 });
             }
         }
@@ -62,12 +63,12 @@ abstract class Model extends BaseModel implements TaggableInterface
 
     public function scopeDraft($query)
     {
-        return $query->wherePublished(false);
+        return $query->where("{$this->getTable()}.published", false);
     }
 
     public function scopeOnlyTrashed($query)
     {
-        return $query->whereNotNull('deleted_at');
+        return $query->whereNotNull("{$this->getTable()}.deleted_at");
     }
 
     public function getFillable()


### PR DESCRIPTION
## Description

When adding some joins I always get into the situation where the internal Twill scopes are not aliased and Laravel raises the exception saying that the `published` column is ambiguous. I believe this is a behaviour can be found on other classes (like the scopePublished on the User class) and probably needs a larger review by someone with more global knowledge of queries in Twill. But this one fixed query joins done directly between module models.
