### PR TITLE
 Fix: Ensure pasting content in quill do not make editor scroll to the top

### DIFF
--- a/frontend/js/components/Wysiwyg.vue
+++ b/frontend/js/components/Wysiwyg.vue
@@ -457,6 +457,14 @@
       text-decoration: underline $color__link;
     }
 
+    // Ensure pasting content do not make editor scroll to the top
+    .ql-clipboard {
+      position: fixed;
+      display: none;
+      left: 50%;
+      top: 50%;
+    }
+
     .ql-snow.ql-toolbar {
       padding: 13px 8px;
 


### PR DESCRIPTION
<!--
  Thanks for opening a PR! Your contribution is much appreciated.
  Do you have any questions? Check out the contributing docs at https://github.com/area17/twill/blob/2.x/CONTRIBUTING.md, 
  or ask in this Pull Request and a Twill maintainer will be happy to help :)
-->

## Description
 Ensure pasting content in quill do not make editor scroll to the top.

Currently, when data us pasted into the editor, it scrolls to the top. This PR fixes it
<!-- Write a description of the changes introduced by this PR -->
<!-- If this is introducing a new feature, it would be great if you can create a stub for documentation including bullet points for how to use the feature, code snippets, etc. -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
