### PR TITLE
Fixed Exception-Handler throwing errors when extending it

### DIFF
--- a/src/Exceptions/Handler.php
+++ b/src/Exceptions/Handler.php
@@ -3,67 +3,12 @@
 namespace A17\Twill\Exceptions;
 
 use Illuminate\Auth\AuthenticationException;
-use Illuminate\Config\Repository as Config;
-use Illuminate\Contracts\Container\Container;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
-use Illuminate\Routing\Redirector;
-use Illuminate\Routing\ResponseFactory;
-use Illuminate\Routing\UrlGenerator;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Validation\ValidationException;
-use Illuminate\View\Factory as ViewFactory;
 
 class Handler extends ExceptionHandler
 {
-
-    /**
-     * @var Redirector
-     */
-    protected $redirector;
-
-    /**
-     * @var UrlGenerator
-     */
-    protected $urlGenerator;
-
-    /**
-     * @var ViewFactory
-     */
-    protected $viewFactory;
-
-    /**
-     * @var ResponseFactory
-     */
-    protected $responseFactory;
-
-    /**
-     * @var Config
-     */
-    protected $config;
-
-    /**
-     * @param Container $container
-     * @param Redirector $redirector
-     * @param UrlGenerator $urlGenerator
-     * @param ResponseFactory $responseFactory
-     */
-    public function __construct(
-        Container $container,
-        Redirector $redirector,
-        UrlGenerator $urlGenerator,
-        ResponseFactory $responseFactory,
-        Config $config,
-        ViewFactory $viewFactory
-    ) {
-        parent::__construct($container);
-
-        $this->redirector = $redirector;
-        $this->urlGenerator = $urlGenerator;
-        $this->responseFactory = $responseFactory;
-        $this->viewFactory = $responseFactory;
-        $this->config = $config;
-    }
-
     /**
      * Convert an authentication exception into a response.
      *
@@ -74,8 +19,8 @@ class Handler extends ExceptionHandler
     protected function unauthenticated($request, AuthenticationException $exception)
     {
         return $request->expectsJson()
-        ? $this->responseFactory->json(['message' => $exception->getMessage()], 401)
-        : $this->redirector->guest($exception->redirectTo() ?? $this->urlGenerator->route('admin.login', Route::current()->parameters()));
+            ? response()->json(['message' => $exception->getMessage()], 401)
+            : redirect()->guest($exception->redirectTo() ?? route('admin.login', Route::current()->parameters()));
     }
 
     /**
@@ -87,10 +32,10 @@ class Handler extends ExceptionHandler
     protected function getTwillErrorView($statusCode, $frontend = false)
     {
         if ($frontend) {
-            return $this->config->get('twill.frontend.views_path') . ".errors.{$statusCode}";
+            return config('twill.frontend.views_path') . ".errors.$statusCode";
         }
 
-        return $this->viewFactory->exists("admin.errors.$statusCode") ? "admin.errors.$statusCode" : "twill::errors.$statusCode";
+        return view()->exists("admin.errors.$statusCode") ? "admin.errors.$statusCode" : "twill::errors.$statusCode";
     }
 
     protected function invalidJson($request, ValidationException $exception)


### PR DESCRIPTION
## Description

When extending the Twill-Handler and setting the `'bind_exception_handler'` in twill.php to `false`, there  appeared an Error while runnnig `composer dump-autload`:

`Script @php artisan package:discover --ansi handling the post-autoload-dump event returned with error code 255`

Also running PHPStan has thrown and Error:

```
Note: Using configuration file /var/www/phpstan.neon.
Illuminate\Contracts\Container\BindingResolutionException thrown in /var/www/vendor/laravel/framework/src/Illuminate/Container/Container.php on line 875 while loading bootstrap file /var/www/vendor/nunomaduro/larastan/bootstrap.php: Target class [cache] does not exist.
```

After debugging i came on it, that the constructor makes the problem. So i refactored the Handler to use the Laravel Helper instead of Dependency Injection.
