### PR TITLE
fix qrcode requirement in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
     "nunomaduro/collision": "^3.0|^4.2|^5.0",
     "orchestra/testbench": "~3.3|~3.4|~3.5|~3.6|~3.7|~3.8|^4.0|^5.0|^6.0",
     "phpunit/phpunit": "~5.0|~6.0|~7.0|~8.0|~9.0",
-    "chillerlan/php-qrcode": "~1.0|~1.0|~3.0|~4.0"
+    "chillerlan/php-qrcode": "~2.0|~3.0|~4.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
## Description
A fix for the qrcode requirement: v1.x is PHP 5 only and unsupported.