### PR TITLE
fix: Add AM/PM suffix in timepicker default format

### DIFF
--- a/views/partials/form/_time_picker.blade.php
+++ b/views/partials/form/_time_picker.blade.php
@@ -8,7 +8,7 @@
     'required' => $required ?? false,
     'inModal' => $fieldsInModal ?? false,
     'time24Hr' => $time24Hr ?? false,
-    'altFormat' => $altFormat ?? (($time24Hr ?? false) ? 'H:i' : 'h:i'),
+    'altFormat' => $altFormat ?? (($time24Hr ?? false) ? 'H:i' : 'h:i K'),
     'timeOnly' => true,
     'withTime' => true,
     'hourIncrement' => $hourncrement ?? null,


### PR DESCRIPTION
## Description

Small fix in timepicker's default format string to add AM/PM suffix for 12h clocks :

![timepicker](https://user-images.githubusercontent.com/7805679/128743824-ee98475e-014f-4b8a-8f9d-6b5b75df3973.png)
