### PR TITLE
Prefix admin dashboard (ex: blog/admin Route name => 'blog.admin')

### DIFF
--- a/config/twill.php
+++ b/config/twill.php
@@ -25,6 +25,16 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Application Admin Route Name
+    |--------------------------------------------------------------------------
+    |
+    | This value is added to the admin route names of your Admin application.
+    |
+     */
+    'admin_route_name_prefix' => env('ADMIN_ROUTE_NAME_PREFIX', 'admin.'),
+
+    /*
+    |--------------------------------------------------------------------------
     | Application Admin Title Suffix
     |--------------------------------------------------------------------------
     |

--- a/src/Services/Routing/HasRoutes.php
+++ b/src/Services/Routing/HasRoutes.php
@@ -71,7 +71,7 @@ trait HasRoutes
     protected function getRouteGroupOptions(): array
     {
         $groupOptions = [
-            'as' => 'admin.',
+            'as' => config('twill.admin_route_name_prefix', 'admin.'),
             'middleware' => [config('twill.admin_middleware_group', 'web')],
             'prefix' => rtrim(ltrim(config('twill.admin_app_path'), '/'), '/'),
         ];


### PR DESCRIPTION

## Description

Incorrect Admin route names when using a prefix with admin dashboard.

When I change the `ADMIN_APP_PATH` to be `blog/admin` all route URLs were created successfully but the route names are incorrect the route name became `admin.blog.admin` which is incorrect, the route name should be `blog.admin` so I need to configuration to change the `admin.` prefix before the admin route names.

## Related Issues
