### PR TITLE
Feature/i18n permalinks

### DIFF
--- a/frontend/js/components/TitleEditor.vue
+++ b/frontend/js/components/TitleEditor.vue
@@ -120,7 +120,7 @@
       },
       permalink: function () {
         const localizedPermalinkbase = this.localizedPermalinkbase.length > 0 ? JSON.parse(this.localizedPermalinkbase) : {}
-        return Object.keys(localizedPermalinkbase).length > 0 ? ((this.currentLocale.value in localizedPermalinkbase) ? localizedPermalinkbase[this.currentLocale.value].concat('/',this.fieldValueByName('slug')[this.currentLocale.value]) : this.fieldValueByName('slug')[this.currentLocale.value] ): this.fieldValueByName('slug')[this.currentLocale.value]
+        return Object.keys(localizedPermalinkbase).length > 0 ? ((this.currentLocale.value in localizedPermalinkbase) ? localizedPermalinkbase[this.currentLocale.value].concat('/', this.fieldValueByName('slug')[this.currentLocale.value]) : this.fieldValueByName('slug')[this.currentLocale.value]) : this.fieldValueByName('slug')[this.currentLocale.value]
       },
       ...mapState({
         baseUrl: state => state.form.baseUrl,

--- a/frontend/js/components/TitleEditor.vue
+++ b/frontend/js/components/TitleEditor.vue
@@ -71,7 +71,7 @@
         type: String,
         default: ''
       },
-      customLocalizedPermalinkbase: {
+      localizedPermalinkbase: {
         type: String,
         default: ''
       },
@@ -119,8 +119,8 @@
         return Object.keys(localizedCustomPermalink).length > 0 ? localizedCustomPermalink[this.currentLocale.value] : (this.customPermalink ? this.customPermalink : false)
       },
       permalink: function () {
-        const customLocalizedPermalinkbase = this.customLocalizedPermalinkbase.length > 0 ? JSON.parse(this.customLocalizedPermalinkbase) : {}
-        return Object.keys(customLocalizedPermalinkbase).length > 0 ? customLocalizedPermalinkbase[this.currentLocale.value].concat(this.fieldValueByName('slug')[this.currentLocale.value]) : this.fieldValueByName('slug')[this.currentLocale.value]
+        const localizedPermalinkbase = this.localizedPermalinkbase.length > 0 ? JSON.parse(this.localizedPermalinkbase) : {}
+        return Object.keys(localizedPermalinkbase).length > 0 ? ((this.currentLocale.value in localizedPermalinkbase) ? localizedPermalinkbase[this.currentLocale.value].concat('/',this.fieldValueByName('slug')[this.currentLocale.value]) : this.fieldValueByName('slug')[this.currentLocale.value] ): this.fieldValueByName('slug')[this.currentLocale.value]
       },
       ...mapState({
         baseUrl: state => state.form.baseUrl,

--- a/frontend/js/components/TitleEditor.vue
+++ b/frontend/js/components/TitleEditor.vue
@@ -74,6 +74,10 @@
       customLocalizedPermalinkbase: {
         type: String,
         default: ''
+      },
+      localizedCustomPermalink: {
+        type: String,
+        default: ''
       }
     },
     data: function () {
@@ -95,12 +99,12 @@
         return this.title.length > 0 ? 'update' : 'create'
       },
       fullUrl: function () {
-        return this.customPermalink || this.baseUrl
+        return this.customlink || this.baseUrl
           .replace('{language}', this.currentLocale.value)
           .replace('{preview}/', this.published ? '' : 'admin-preview/') + this.permalink
       },
       visibleUrl: function () {
-        return this.customPermalink || this.baseUrl
+        return this.customlink || this.baseUrl
           .replace('{language}', this.currentLocale.value)
           .replace('{preview}/', '') + this.permalink
       },
@@ -109,6 +113,10 @@
         const title = this.fieldValueByName(this.name) ? this.fieldValueByName(this.name) : ''
         const titleValue = typeof title === 'string' ? title : title[this.currentLocale.value]
         return titleValue || this.warningMessage
+      },
+      customlink: function () {
+        const localizedCustomPermalink = this.localizedCustomPermalink.length > 0 ? JSON.parse(this.localizedCustomPermalink) : {}
+        return Object.keys(localizedCustomPermalink).length > 0 ? localizedCustomPermalink[this.currentLocale.value] : (this.customPermalink ? this.customPermalink : false)
       },
       permalink: function () {
         const customLocalizedPermalinkbase = this.customLocalizedPermalinkbase.length > 0 ? JSON.parse(this.customLocalizedPermalinkbase) : {}

--- a/frontend/js/components/TitleEditor.vue
+++ b/frontend/js/components/TitleEditor.vue
@@ -70,6 +70,10 @@
       customPermalink: {
         type: String,
         default: ''
+      },
+      customLocalizedPermalinkbase: {
+        type: String,
+        default: ''
       }
     },
     data: function () {
@@ -107,7 +111,8 @@
         return titleValue || this.warningMessage
       },
       permalink: function () {
-        return this.fieldValueByName('slug')[this.currentLocale.value]
+        const customLocalizedPermalinkbase = this.customLocalizedPermalinkbase.length > 0 ? JSON.parse(this.customLocalizedPermalinkbase) : {}
+        return Object.keys(customLocalizedPermalinkbase).length > 0 ? customLocalizedPermalinkbase[this.currentLocale.value].concat(this.fieldValueByName('slug')[this.currentLocale.value]) : this.fieldValueByName('slug')[this.currentLocale.value]
       },
       ...mapState({
         baseUrl: state => state.form.baseUrl,

--- a/src/Http/Controllers/Admin/ModuleController.php
+++ b/src/Http/Controllers/Admin/ModuleController.php
@@ -1472,6 +1472,7 @@ abstract class ModuleController extends Controller
         $restoreRouteName = $fullRoutePrefix . 'restoreRevision';
 
         $baseUrl = $item->urlWithoutSlug ?? $this->getPermalinkBaseUrl();
+        $localizedPermalinkBase = $this->getLocalizedPermalinkBase();
 
         $data = [
             'item' => $item,
@@ -1488,6 +1489,7 @@ abstract class ModuleController extends Controller
             'createWithoutModal' => !$item[$this->identifierColumnKey] && $this->getIndexOption('skipCreateModal'),
             'form_fields' => $this->repository->getFormFields($item),
             'baseUrl' => $baseUrl,
+            'localizedPermalinkBase'=>$localizedPermalinkBase,
             'permalinkPrefix' => $this->getPermalinkPrefix($baseUrl),
             'saveUrl' => $item[$this->identifierColumnKey] ? $this->getModuleRoute($item[$this->identifierColumnKey], 'update') : moduleRoute($this->moduleName, $this->routePrefix, 'store', [$this->submoduleParentId]),
             'editor' => Config::get('twill.enabled.block-editor') && $this->moduleHas('blocks') && !$this->disableEditor,
@@ -1698,8 +1700,16 @@ abstract class ModuleController extends Controller
         return $appUrl . '/'
             . ($this->moduleHas('translations') ? '{language}/' : '')
             . ($this->moduleHas('revisions') ? '{preview}/' : '')
-            . ($this->permalinkBase ?? $this->getModulePermalinkBase())
-            . (isset($this->permalinkBase) && empty($this->permalinkBase) ? '' : '/');
+            . (empty($this->getLocalizedPermalinkBase()) ? ($this->permalinkBase ?? $this->getModulePermalinkBase()) : '')
+            . (((isset($this->permalinkBase) && empty($this->permalinkBase)) || !empty($this->getLocalizedPermalinkBase())) ? '' : '/');
+    }
+
+    /**
+     * @return array
+     */
+    protected function getLocalizedPermalinkBase()
+    {
+        return [];
     }
 
     /**

--- a/views/layouts/form.blade.php
+++ b/views/layouts/form.blade.php
@@ -47,8 +47,8 @@
                     :editable-title="{{ json_encode($editableTitle ?? true) }}"
                     custom-title="{{ $customTitle ?? '' }}"
                     custom-permalink="{{ $customPermalink ?? '' }}"
-                    custom-localized-permalinkbase="{{ $localizedPermalinkBase ?? '' }}"
-                    localized-custom-permalink="{{ $localizedCustomPermalink ?? '' }}"
+                    custom-localized-permalinkbase="{{ json_encode($localizedPermalinkBase ?? '') }}"
+                    localized-custom-permalink="{{ json_encode($localizedCustomPermalink ?? '') }}"
                     slot="title"
                     @if($createWithoutModal ?? false) :show-modal="true" @endif
                     @if(isset($editModalTitle)) modal-title="{{ $editModalTitle }}" @endif

--- a/views/layouts/form.blade.php
+++ b/views/layouts/form.blade.php
@@ -48,6 +48,7 @@
                     custom-title="{{ $customTitle ?? '' }}"
                     custom-permalink="{{ $customPermalink ?? '' }}"
                     custom-localized-permalinkbase="{{ $localizedPermalinkBase ?? '' }}"
+                    localized-custom-permalink="{{ $localizedCustomPermalink ?? '' }}"
                     slot="title"
                     @if($createWithoutModal ?? false) :show-modal="true" @endif
                     @if(isset($editModalTitle)) modal-title="{{ $editModalTitle }}" @endif

--- a/views/layouts/form.blade.php
+++ b/views/layouts/form.blade.php
@@ -47,7 +47,7 @@
                     :editable-title="{{ json_encode($editableTitle ?? true) }}"
                     custom-title="{{ $customTitle ?? '' }}"
                     custom-permalink="{{ $customPermalink ?? '' }}"
-                    custom-localized-permalinkbase="{{ json_encode($localizedPermalinkBase ?? '') }}"
+                    localized-permalinkbase="{{ json_encode($localizedPermalinkBase ?? '') }}"
                     localized-custom-permalink="{{ json_encode($localizedCustomPermalink ?? '') }}"
                     slot="title"
                     @if($createWithoutModal ?? false) :show-modal="true" @endif

--- a/views/layouts/form.blade.php
+++ b/views/layouts/form.blade.php
@@ -47,6 +47,7 @@
                     :editable-title="{{ json_encode($editableTitle ?? true) }}"
                     custom-title="{{ $customTitle ?? '' }}"
                     custom-permalink="{{ $customPermalink ?? '' }}"
+                    custom-localized-permalinkbase="{{ $localizedPermalinkBase ?? '' }}"
                     slot="title"
                     @if($createWithoutModal ?? false) :show-modal="true" @endif
                     @if(isset($editModalTitle)) modal-title="{{ $editModalTitle }}" @endif


### PR DESCRIPTION
<!--
  Thanks for opening a PR! Your contribution is much appreciated.
  Do you have any questions? Check out the contributing docs at https://github.com/area17/twill/blob/2.x/CONTRIBUTING.md, 
  or ask in this Pull Request and a Twill maintainer will be happy to help :)
-->

## Description
This PR enables the translation of permalinks.
Useful when frontend URL's are also translated based on the locale.

## Usage

1. Allows localization of the permalinkBase property of the ModuleController
```
//return an array from the getLocalizedPermalinkBase controller method with the keys being locales
//the slug attribute will be appended to the value

/**
* @return array
*/
protected function getLocalizedPermalinkBase()
{
    return [
        'en' => 'collection/artists',
        'fr' => 'collection/artistes',
    ];
}
```

2. Allow localization of the customPermalink property by use of localizedCustomPermalink property instead

```
//pass localizedCustomPermalink to the form data which is an array with the keys being locales and values being the translated urls
protected function formData($request)
{
    return [
        'localizedCustomPermalink' => [
            'en' =>'https://website.com/en/news',
            'fr' =>'https://website.com/fr/nouvelles',
        ],
    ];
}
```


