### PR TITLE
Fix Exception Handler broken for Laravel 8

### DIFF
--- a/src/Exceptions/Handler.php
+++ b/src/Exceptions/Handler.php
@@ -5,7 +5,7 @@ namespace A17\Twill\Exceptions;
 use Illuminate\Auth\AuthenticationException;
 use Illuminate\Config\Repository as Config;
 use Illuminate\Contracts\Container\Container;
-use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
+use App\Exceptions\Handler as ExceptionHandler;
 use Illuminate\Routing\Redirector;
 use Illuminate\Routing\ResponseFactory;
 use Illuminate\Routing\UrlGenerator;

--- a/tests/integration/TestCase.php
+++ b/tests/integration/TestCase.php
@@ -769,9 +769,16 @@ abstract class TestCase extends OrchestraTestCase
     public function ensureAppExceptionHandlerExists()
     {
         $stubPath = __DIR__.'/../../tests/stubs/classes/AppExceptionHandler.php';
+
         $filePath = __DIR__.'/../../vendor/orchestra/testbench-core/laravel/app/Exceptions/Handler.php';
 
+        $dir = dirname($filePath);
+
         if (!file_exists($filePath)) {
+            if (!file_exists($dir)) {
+                mkdir($dir, 0755, true);
+            }
+
             file_put_contents($filePath, file_get_contents($stubPath));
         }
     }

--- a/tests/integration/TestCase.php
+++ b/tests/integration/TestCase.php
@@ -4,6 +4,7 @@ namespace A17\Twill\Tests\Integration;
 
 use A17\Twill\AuthServiceProvider;
 use A17\Twill\Models\User;
+use App\Exceptions\SnAppException;
 use A17\Twill\RouteServiceProvider;
 use A17\Twill\Tests\Integration\Behaviors\CopyBlocks;
 use A17\Twill\TwillServiceProvider;
@@ -17,6 +18,7 @@ use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Str;
 use Orchestra\Testbench\TestCase as OrchestraTestCase;
+use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
 
 abstract class TestCase extends OrchestraTestCase
 {
@@ -122,6 +124,8 @@ abstract class TestCase extends OrchestraTestCase
         $this->copyBlocks();
 
         $this->installTwill();
+
+        $this->ensureAppExceptionHandlerExists();
     }
 
     /**
@@ -760,5 +764,15 @@ abstract class TestCase extends OrchestraTestCase
 
     public function loadConfig()
     {
+    }
+
+    public function ensureAppExceptionHandlerExists()
+    {
+        $stubPath = __DIR__.'/../../tests/stubs/classes/AppExceptionHandler.php';
+        $filePath = __DIR__.'/../../vendor/orchestra/testbench-core/laravel/app/Exceptions/Handler.php';
+
+        if (!file_exists($filePath)) {
+            file_put_contents($filePath, file_get_contents($stubPath));
+        }
     }
 }

--- a/tests/stubs/classes/AppExceptionHandler.php
+++ b/tests/stubs/classes/AppExceptionHandler.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Exceptions;
+
+use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
+use Throwable;
+
+class Handler extends ExceptionHandler
+{
+    /**
+     * A list of the exception types that are not reported.
+     *
+     * @var array
+     */
+    protected $dontReport = [
+        //
+    ];
+
+    /**
+     * A list of the inputs that are never flashed for validation exceptions.
+     *
+     * @var array
+     */
+    protected $dontFlash = [
+        'current_password',
+        'password',
+        'password_confirmation',
+    ];
+
+    /**
+     * Register the exception handling callbacks for the application.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        $this->reportable(function (Throwable $e) {
+            //
+        });
+    }
+}


### PR DESCRIPTION
## Description

As Twill is replacing (by default) the Laravel Exception Handler, on Laravel 8 this has some bad outcomes. As the handler now uses the `App\Exceptions\Handler::register()` method to register new closure handlers, this method is never called by Twill and this would never work:

``` php
    /**
     * Register the exception handling callbacks for the application.
     *
     * @return void
     */
    public function register()
    {
        $this->renderable(function (MyException $e) {
            return response()->view('errors.exception', [], 500);
        });
    }
```

## Solution

Instead of extending `Illuminate\Foundation\Exceptions\Handler`, we can probably extend  `App\Exceptions\Handler` as this class will always exist on new Laravel applications and it also extends Laravel's Exception handler.

