### PR TITLE
fix: Preserve natural text cursor position after paste

### DIFF
--- a/frontend/js/components/Wysiwyg.vue
+++ b/frontend/js/components/Wysiwyg.vue
@@ -313,6 +313,10 @@
       this.options.formats = QuillConfiguration.getFormats(this.options.modules.toolbar) // Formats are based on current toolbar configuration
       this.options.bounds = this.$refs.editor
 
+      // Ensure pasting content do not make editor scroll to the top
+      // @see https://github.com/quilljs/quill/issues/1374#issuecomment-545112021
+      this.options.scrollingContainer = 'html'
+
       // register custom handlers
       // register anchor toolbar handler
       if (toolbar.container.includes('anchor')) {
@@ -559,11 +563,9 @@
     }
 
     // Ensure pasting content do not make editor scroll to the top
+    // @see https://github.com/quilljs/quill/issues/1374#issuecomment-545112021
     .ql-clipboard {
       position: fixed;
-      display: none;
-      left: 50%;
-      top: 50%;
     }
 
     .ql-snow.ql-toolbar {


### PR DESCRIPTION
## Description

This fixes a small regression with the Quill WYSIWYG that causes the text cursor to jump back to the start of the pasted content:

![Peek 2021-08-31 13-12](https://user-images.githubusercontent.com/7805679/131547992-3d3c95db-6bee-49cf-8299-b64aeba31d7e.gif)

<br>

With this fix, the text cursor position is preserved:

![Peek 2021-08-31 13-16](https://user-images.githubusercontent.com/7805679/131548081-f4aad4fd-4524-4d86-b99b-34d8496961cc.gif)

## Related Issues

Related to: https://github.com/area17/twill/pull/1052

Original issue on Quill repository: https://github.com/quilljs/quill/issues/1374
