### PR TITLE
fix: Hydrate related browser fields for preview and restore

### DIFF
--- a/src/Repositories/Behaviors/HandleRevisions.php
+++ b/src/Repositories/Behaviors/HandleRevisions.php
@@ -4,7 +4,6 @@ namespace A17\Twill\Repositories\Behaviors;
 
 use A17\Twill\Models\Behaviors\HasRelated;
 use A17\Twill\Models\RelatedItem;
-use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
@@ -18,12 +17,10 @@ trait HandleRevisions
      */
     public function hydrateHandleRevisions($object, $fields)
     {
-        // HandleRepeaters trait => getRepeaters
         foreach($this->getRepeaters() as $repeater) {
             $this->hydrateRepeater($object, $fields, $repeater['relation'], $repeater['model']);
         }
 
-        // HandleBrowers trait => getBrowsers
         foreach($this->getBrowsers() as $browser) {
             $this->hydrateBrowser($object, $fields, $browser['relation'], $browser['positionAttribute'], $browser['model']);
         }
@@ -133,7 +130,7 @@ trait HandleRevisions
      */
     public function hydrateBrowser($object, $fields, $relationship, $positionAttribute = 'position', $model = null)
     {
-        return $this->hydrateOrderedBelongsTomany($object, $fields, $relationship, $positionAttribute, $model);
+        return $this->hydrateOrderedBelongsToMany($object, $fields, $relationship, $positionAttribute, $model);
     }
 
     /**
@@ -144,7 +141,7 @@ trait HandleRevisions
      * @param \A17\Twill\Models\Model|null $model
      * @return void
      */
-    public function hydrateOrderedBelongsTomany($object, $fields, $relationship, $positionAttribute = 'position', $model = null)
+    public function hydrateOrderedBelongsToMany($object, $fields, $relationship, $positionAttribute = 'position', $model = null)
     {
         $fieldsHasElements = isset($fields['browsers'][$relationship]) && !empty($fields['browsers'][$relationship]);
         $relatedElements = $fieldsHasElements ? $fields['browsers'][$relationship] : [];

--- a/tests/integration/BrowsersTest.php
+++ b/tests/integration/BrowsersTest.php
@@ -307,9 +307,21 @@ class BrowsersTest extends TestCase
         $writers = $this->createWriters();
         $book = $this->createBookWithWriters($writers);
 
-        // User can preview
-        $this->httpRequestAssert("/twill/books/preview/{$book->id}", 'PUT', []);
+        // User can preview modifications
+        $this->httpRequestAssert("/twill/books/preview/{$book->id}", 'PUT', [
+            'browsers' => [
+                'writers' => [
+                    [
+                        'id' => 3,
+                        'name' => 'Charlie',
+                        'endpointType' => 'App\\Models\\Writer',
+                        'edit' => '',
+                    ],
+                ],
+            ],
+        ]);
         $this->assertSee('This is a book');
+        $this->assertSee('Writers: Charlie');
     }
 
     public function testBrowserRelatedPreviewRevisions()
@@ -319,9 +331,10 @@ class BrowsersTest extends TestCase
 
         // User can preview revisions
         $this->httpRequestAssert("/twill/books/preview/{$book->id}", 'PUT', [
-            'revisionId' => Book::first()->revisions->last()->id,
+            'revisionId' => Book::first()->revisions->first()->id,
         ]);
         $this->assertSee('This is a book');
+        $this->assertSee('No writers');
     }
 
     public function testBrowserRelatedRestoreRevisions()

--- a/tests/integration/BrowsersTest.php
+++ b/tests/integration/BrowsersTest.php
@@ -259,9 +259,21 @@ class BrowsersTest extends TestCase
         $writers = $this->createWriters();
         $bio = $this->createBioWithWriter($writers[0]);
 
-        // User can preview
-        $this->httpRequestAssert("/twill/bios/preview/{$bio->id}", 'PUT', []);
+        // User can preview modifications
+        $this->httpRequestAssert("/twill/bios/preview/{$bio->id}", 'PUT', [
+            'browsers' => [
+                'writer' => [
+                    [
+                        'id' => 3,
+                        'name' => 'Charlie',
+                        'endpointType' => 'App\\Models\\Writer',
+                        'edit' => '',
+                    ],
+                ],
+            ],
+        ]);
         $this->assertSee('This is a bio');
+        $this->assertSee('Writer: Charlie');
     }
 
     public function testBrowserBelongsToPreviewRevisions()
@@ -271,9 +283,10 @@ class BrowsersTest extends TestCase
 
         // User can preview revisions
         $this->httpRequestAssert("/twill/bios/preview/{$bio->id}", 'PUT', [
-            'revisionId' => Bio::first()->revisions->last()->id,
+            'revisionId' => Bio::first()->revisions->first()->id,
         ]);
         $this->assertSee('This is a bio');
+        $this->assertSee('No writer');
     }
 
     public function testBrowserBelongsToRestoreRevisions()

--- a/tests/integration/BrowsersTest.php
+++ b/tests/integration/BrowsersTest.php
@@ -143,7 +143,7 @@ class BrowsersTest extends TestCase
 
         $bios = collect([1, 2])->map(function ($i) {
             return app(BioRepository::class)->create([
-                'title' => 'Lorem ipsum dolor sit amet',
+                'title' => 'Biography ' . $i,
                 'published' => true,
             ]);
         });
@@ -378,9 +378,21 @@ class BrowsersTest extends TestCase
     {
         $writer = $this->createWriterWithBios();
 
-        // User can preview
-        $this->httpRequestAssert("/twill/writers/preview/{$writer->id}", 'PUT', []);
+        // User can preview modifications
+        $this->httpRequestAssert("/twill/writers/preview/{$writer->id}", 'PUT', [
+            'browsers' => [
+                'bios' => [
+                    [
+                        'id' => 2,
+                        'name' => 'Biography 2',
+                        'endpointType' => 'App\\Models\\Writer',
+                        'edit' => '',
+                    ],
+                ],
+            ],
+        ]);
         $this->assertSee('This is a writer');
+        $this->assertSee('Bios: Biography 2');
     }
 
     public function testBrowserHasManyPreviewRevisions()
@@ -389,9 +401,10 @@ class BrowsersTest extends TestCase
 
         // User can preview revisions
         $this->httpRequestAssert("/twill/writers/preview/{$writer->id}", 'PUT', [
-            'revisionId' => $writer->revisions->last()->id,
+            'revisionId' => $writer->revisions->first()->id,
         ]);
         $this->assertSee('This is a writer');
+        $this->assertSee('No bios');
     }
 
     public function testBrowserHasManyRestoreRevisions()

--- a/tests/stubs/browsers/bios-view.blade.php
+++ b/tests/stubs/browsers/bios-view.blade.php
@@ -1,1 +1,9 @@
 <div>This is a bio</div>
+
+<div>
+    @if ($writer = $item->writer->first())
+        Writer: {{ $writer->title }}
+    @else
+        No writer
+    @endif
+</div>

--- a/tests/stubs/browsers/books-view.blade.php
+++ b/tests/stubs/browsers/books-view.blade.php
@@ -1,1 +1,11 @@
 <div>This is a book</div>
+
+<div>
+    @php $names = $item->getRelated('writers')->pluck('title'); @endphp
+
+    @if ($names->isNotEmpty())
+        Writers: {{ $names->sort()->join(', ') }}
+    @else
+        No writers
+    @endif
+</div>

--- a/tests/stubs/browsers/writers-view.blade.php
+++ b/tests/stubs/browsers/writers-view.blade.php
@@ -1,1 +1,11 @@
 <div>This is a writer</div>
+
+<div>
+    @php $titles = $item->bios->pluck('title'); @endphp
+
+    @if ($titles->isNotEmpty())
+        Bios: {{ $titles->sort()->join(', ') }}
+    @else
+        No bios
+    @endif
+</div>


### PR DESCRIPTION
## Description

This adds the missing steps to hydrate browser fields implemented through `HasRelated`. Special attention is paid to the content of `relatedItems` when hydrating, in order to preserve any related item that is not directly tied to a known browser field.

The tests were updated to cover this new behavior. The tests for `belongsTo` and `hasMany` browsers were also updated along the same lines.


## Related Issues

Fixes https://github.com/area17/twill/issues/1117

Related to https://github.com/area17/twill/pull/1085 https://github.com/area17/twill/pull/1087
