### PR TITLE
call view:clear when updating assets

### DIFF
--- a/src/Commands/Update.php
+++ b/src/Commands/Update.php
@@ -17,6 +17,7 @@ class Update extends Command
     {
         $this->publishAssets();
         $this->call('cache:clear');
+        $this->call('view:clear');
     }
 
     /**


### PR DESCRIPTION
Per #1135, this clears the view cache when publishing/updating Twill assets to accomodate for changes made between releases.