### PR TITLE
use namespace when importing model class in repository

### DIFF
--- a/src/Commands/ModuleMake.php
+++ b/src/Commands/ModuleMake.php
@@ -443,7 +443,7 @@ class ModuleMake extends Command
     {
         $modelsDir = $this->isCapsule ? $this->capsule['repositories_dir'] : 'Repositories';
 
-        $modelClass = $this->isCapsule ? $this->capsule['model'] : "App\Models\\{$this->capsule['singular']}";
+        $modelClass = $this->isCapsule ? $this->capsule['model'] : config('twill.namespace') . "\Models\\{$this->capsule['singular']}";
 
         $this->makeTwillDirectory($modelsDir);
 


### PR DESCRIPTION
## Description
Use the configured twill namespace when importing the model in the repository template.
Currently this is using a hard codded references to the `App` namespace rather than whatever the user has configured.
