### PR TITLE
feat: Add support to generate nestable modules

### DIFF
--- a/src/Commands/stubs/controller.stub
+++ b/src/Commands/stubs/controller.stub
@@ -7,9 +7,30 @@ use {{baseController}};
 class {{controllerClassName}} extends ModuleController
 {
     protected $moduleName = '{{moduleName}}';
-    {{!hasSlug}}
+
     protected $indexOptions = [
-        'permalink' => false
-    ];
-    {{/!hasSlug}}
+        {{permalinkOption}}
+        {{reorderOption}}
+    ];{{hasNesting}}
+
+    protected function indexData($request)
+    {
+        return [
+            'nested' => true,
+            'nestedDepth' => 1, // controls the allowed depth in UI
+        ];
+    }
+
+    protected function transformIndexItems($items)
+    {
+        return $items->toTree();
+    }
+
+    protected function indexItemData($item)
+    {
+        return ($item->children ? [
+            'children' => $this->getIndexTableData($item->children),
+        ] : []);
+    }
+    {{/hasNesting}}
 }

--- a/src/Commands/stubs/migration.stub
+++ b/src/Commands/stubs/migration.stub
@@ -21,7 +21,9 @@ class Create{{tableClassName}}Tables extends Migration
             {{/hasPosition}}
             // add those 2 columns to enable publication timeframe fields (you can use publish_start_date only if you don't need to provide the ability to specify an end date)
             // $table->timestamp('publish_start_date')->nullable();
-            // $table->timestamp('publish_end_date')->nullable();
+            // $table->timestamp('publish_end_date')->nullable();{{hasNesting}}
+
+            $table->nestedSet();{{/hasNesting}}
         });
 
         {{hasTranslation}}Schema::create('{{singularTableName}}_translations', function (Blueprint $table) {

--- a/src/Models/Behaviors/HasNesting.php
+++ b/src/Models/Behaviors/HasNesting.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace A17\Twill\Models\Behaviors;
+
+use Kalnoy\Nestedset\NodeTrait;
+
+trait HasNesting
+{
+    use NodeTrait;
+
+    public static function saveTreeFromIds($nodeTree)
+    {
+        $nodeModels = self::all();
+        $nodeArrays = self::flattenTree($nodeTree);
+
+        foreach ($nodeArrays as $nodeArray) {
+            $nodeModel = $nodeModels->where('id', $nodeArray['id'])->first();
+
+            if ($nodeArray['parent_id'] === null) {
+                if (!$nodeModel->isRoot() || $nodeModel->position !== $nodeArray['position']) {
+                    $nodeModel->position = $nodeArray['position'];
+                    $nodeModel->saveAsRoot();
+                }
+            } else {
+                if ($nodeModel->position !== $nodeArray['position'] || $nodeModel->parent_id !== $nodeArray['parent_id']) {
+                    $nodeModel->position = $nodeArray['position'];
+                    $nodeModel->parent_id = $nodeArray['parent_id'];
+                    $nodeModel->save();
+                }
+            }
+        }
+    }
+
+    public static function flattenTree(array $nodeTree, int $parentId = null)
+    {
+        $nodeArrays = [];
+        $position = 0;
+
+        foreach ($nodeTree as $node) {
+            $nodeArrays[] = [
+                'id' => $node['id'],
+                'position' => $position++,
+                'parent_id' => $parentId,
+            ];
+
+            if (count($node['children']) > 0) {
+                $childArrays = self::flattenTree($node['children'], $node['id']);
+                $nodeArrays = array_merge($nodeArrays, $childArrays);
+            }
+        }
+
+        return $nodeArrays;
+    }
+}

--- a/src/Repositories/Behaviors/HandleNesting.php
+++ b/src/Repositories/Behaviors/HandleNesting.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace A17\Twill\Repositories\Behaviors;
+
+use Illuminate\Support\Facades\DB;
+
+trait HandleNesting
+{
+    public function setNewOrder($ids)
+    {
+        DB::transaction(function () use ($ids) {
+            $this->model->saveTreeFromIds($ids);
+        }, 3);
+    }
+}


### PR DESCRIPTION
## Description

An exploratory PR to add an `-N | --hasNesting` switch to the `twill:make:module` command. Using this will scaffold the module to support visual nesting in the index UI, as described in the documentation : https://twill.io/docs/#nested-module

It introduces 2 new behaviors that are extracted from the current example in the docs.

<br> 

![2021-09-08_17-07](https://user-images.githubusercontent.com/7805679/132585800-95e4b98e-b8ce-475c-8f04-ecde064fa8e5.png)


## Related Issues

—