### PR TITLE
Handle JSON columns with Laravel casts in Model and its translations

### DIFF
--- a/src/Repositories/Behaviors/HandleFieldsGroups.php
+++ b/src/Repositories/Behaviors/HandleFieldsGroups.php
@@ -3,10 +3,10 @@
 namespace A17\Twill\Repositories\Behaviors;
 
 use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 
 trait HandleFieldsGroups
 {
-
     /**
      * @param \A17\Twill\Models\Model $object
      * @param array|null $fields
@@ -16,7 +16,10 @@ trait HandleFieldsGroups
     {
         foreach ($this->fieldsGroups as $group => $groupFields) {
             if ($object->$group) {
-                $object->$group = json_encode($object->$group);
+                $casts = $this->getModelCasts($object);
+                if (!array_key_exists($group, $casts) || (array_key_exists($group, $casts) && $casts[$group] !== 'array')) {
+                    $object->$group = json_encode($object->$group);
+                }
             }
         }
 
@@ -51,10 +54,23 @@ trait HandleFieldsGroups
     {
         foreach ($this->fieldsGroups as $group => $groupFields) {
             if ($object->$group) {
-                $decoded_fields = json_decode($object->$group, true) ?? [];
+                $casts = $this->getModelCasts($object);
+                if (array_key_exists($group, $casts) && $casts[$group] === 'array') {
+                    $decoded_fields = $object->$group;
+                } else {
+                    $decoded_fields = json_decode($object->$group, true) ?? [];
+                }
+
                 // In case that some field read the value through $item->$name
-                foreach($decoded_fields as $field_name => $field_value) {
-                    $object->setAttribute($field_name, $field_value);
+                foreach ($decoded_fields as $field_name => $field_value) {
+                    if ($this->fieldsGroupsFormFieldNameSeparator !== null) {
+                        $decoded_fields[$group . $this->fieldsGroupsFormFieldNameSeparator . $field_name] = $field_value;
+                        unset($decoded_fields[$field_name]);
+
+                        $object->setAttribute($group . $this->fieldsGroupsFormFieldNameSeparator . $field_name, $field_value);
+                    } else {
+                        $object->setAttribute($field_name, $field_value);
+                    }
                 }
                 $fields = array_merge($fields, $decoded_fields);
             }
@@ -63,11 +79,36 @@ trait HandleFieldsGroups
         return $fields;
     }
 
-    protected function handleFieldsGroups($fields) {
+    protected function handleFieldsGroups($fields)
+    {
         foreach ($this->fieldsGroups as $group => $groupFields) {
+            if ($this->fieldsGroupsFormFieldNameSeparator !== null) {
+                $groupFields = array_map(function ($field_name) use ($group) {
+                    return $group . $this->fieldsGroupsFormFieldNameSeparator . $field_name;
+                }, $groupFields);
+            }
+
             $fields[$group] = Arr::where(Arr::only($fields, $groupFields), function ($value, $key) {
                 return !empty($value);
             });
+
+            if ($this->fieldsGroupsFormFieldNameSeparator !== null) {
+                $fieldsGroupWithGroupSeparator = [];
+                foreach ($fields[$group] as $key => $value) {
+                    $fieldsGroupWithGroupSeparator[Str::replaceFirst($group . $this->fieldsGroupsFormFieldNameSeparator, '', $key)] = $value;
+                }
+                $fields[$group] = $fieldsGroupWithGroupSeparator;
+            }
+
+            if (in_array($group, $this->model->translatedAttributes) && is_array($fields[$group])) {
+                $fieldForTranslationTrait = [];
+                foreach ($fields[$group] as $field => $translatedValues) {
+                    foreach ($translatedValues as $locale => $value) {
+                        $fieldForTranslationTrait[$locale][$field] = $value;
+                    }
+                }
+                $fields[$group] = $fieldForTranslationTrait;
+            }
 
             if (empty($fields[$group])) {
                 $fields[$group] = null;
@@ -77,5 +118,19 @@ trait HandleFieldsGroups
         }
 
         return $fields;
+    }
+
+    /**
+     * @param \A17\Twill\Models\Model $object
+     * @return array
+     */
+    protected function getModelCasts($object)
+    {
+        $casts = $object->getCasts();
+        if ($this->model->isTranslatable()) {
+            $casts = $casts + (new ($this->model->getTranslationModelNameDefault()))->getCasts();
+        }
+
+        return $casts;
     }
 }

--- a/src/Repositories/Behaviors/HandleTranslations.php
+++ b/src/Repositories/Behaviors/HandleTranslations.php
@@ -81,7 +81,21 @@ trait HandleTranslations
             foreach ($object->translations as $translation) {
                 foreach ($object->translatedAttributes as $attribute) {
                     unset($fields[$attribute]);
-                    $fields['translations'][$attribute][$translation->locale] = $translation->{$attribute};
+
+                    if (array_key_exists($attribute, $this->fieldsGroups) && is_array($translation->{$attribute})) {
+                        foreach ($this->fieldsGroups[$attribute] as $field_name) {
+                            if (isset($translation->{$attribute}[$field_name])) {
+                                if ($this->fieldsGroupsFormFieldNameSeparator !== null) {
+                                    $fields['translations'][$attribute . $this->fieldsGroupsFormFieldNameSeparator . $field_name][$translation->locale] = $translation->{$attribute}[$field_name];
+                                } else {
+                                    $fields['translations'][$field_name][$translation->locale] = $translation->{$attribute}[$field_name];
+                                }
+                            }
+                        }
+                        unset($fields['translations'][$attribute]);
+                    } else {
+                        $fields['translations'][$attribute][$translation->locale] = $translation->{$attribute};
+                    }
                 }
             }
         }

--- a/src/Repositories/ModuleRepository.php
+++ b/src/Repositories/ModuleRepository.php
@@ -45,6 +45,11 @@ abstract class ModuleRepository
     protected $fieldsGroups = [];
 
     /**
+     * @var string|null
+     */
+    public $fieldsGroupsFormFieldNameSeparator = null;
+
+    /**
      * @param array $with
      * @param array $scopes
      * @param array $orders


### PR DESCRIPTION
<!--
  Thanks for opening a PR! Your contribution is much appreciated.
  Do you have any questions? Check out the contributing docs at https://github.com/area17/twill/blob/2.x/CONTRIBUTING.md, 
  or ask in this Pull Request and a Twill maintainer will be happy to help :)
-->

## Description

When I wanted to use JSON columns in admin forms with the `HandleFieldsGroup`, I noticed a few things:

- The Trait handle JSON encode / decode by itself preventing the use of standard Laravel casts mechanism
- It doesn't work on Translation associated Model
- The fields in the admin form have to be named from the name of the fields of the `fieldsGroups` (the repercussion is you can't have a standard `title` field in your Model and a `title` field in a `fieldsGroups`, or many `title` in different `fieldsGroups`, they will be overwritten)


The purpose of this PR is to allow this, without breaking the current functionality:

- If you provide a cast as an array for your field, the JSON encode / decode is handled by Laravel (and the improvment), if not, it works like before
- You now can have translated JSON fields
- There is new `fieldsGroupsFormFieldNameSeparator` attribute on the `ModuleRepository` which is `null` by default (to keep backward compatibility), but you can provide a value that will be used to prefix the field names in the admin form:
    - $fieldsGroupsFormFieldNameSeparator = null => a `client_id` field of a `settings` `fieldsGroups` will have to be named `client_id`
    - $fieldsGroupsFormFieldNameSeparator = '_' => a `client_id` field of a `settings` `fieldsGroups` will have to be named `settings_client_id`


The code might probably be cleaned, it seems to work in all the cases