### PR TITLE
Fix for missing scheme on ADMIN_APP_URL

### DIFF
--- a/src/Exceptions/Handler.php
+++ b/src/Exceptions/Handler.php
@@ -37,7 +37,9 @@ class Handler extends ExceptionHandler
         $usesAdminPath = !empty(config('twill.admin_app_path'));
         $adminAppUrl = parse_url(config('twill.admin_app_url'));
 
-        $isSubdomainAdmin = !$usesAdminPath && $adminAppUrl['host'] == Request::getHost();
+        $host = isset($adminAppUrl['host']) ? $adminAppUrl['host'] : null;
+
+        $isSubdomainAdmin = !$usesAdminPath && $host == Request::getHost();
         $isSubdirectoryAdmin = $usesAdminPath && Str::startsWith(Request::path(), config('twill.admin_app_path'));
 
         return $this->getTwillErrorView($e->getStatusCode(), !($isSubdomainAdmin || $isSubdirectoryAdmin));


### PR DESCRIPTION
## Description

If we set the application URLs as 

```
APP_URL=https://domain.com
ADMIN_APP_URL=admin.domain.com
```

Twill Exception handler will end abnormally the application if an exception occurs:

```
[2021-09-17 18:15:42] dev.ERROR: Uncaught ErrorException: Undefined array key "host" in /sites/domain.com/vendor/area17/twill/src/Exceptions/Handler.php:40
Stack trace:
#0 /sites/domain.com/vendor/area17/twill/src/Exceptions/Handler.php(40): Illuminate\Foundation\Bootstrap\HandleExceptions->handleError()
#1 /sites/domain.com/vendor/laravel/framework/src/Illuminate/Foundation/Exceptions/Handler.php(569): A17\Twill\Exceptions\Handler->getHttpExceptionView()
#2 /sites/domain.com/vendor/laravel/framework/src/Illuminate/Foundation/Exceptions/Handler.php(478): Illuminate\Foundation\Exceptions\Handler->renderHttpException()
#3 /sites/domain.com/vendor/laravel/framework/src/Illuminate/Foundation/Exceptions/Handler.php(356): Illuminate\Foundation\Exceptions\Handler->prepareResponse()
#4 /sites/domain.com/vendor/laravel/framework/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php(119): Illuminate\Foundation\Exceptions\Handler->render()
#5 /sites/domain.com/vendor/laravel/framework/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php(96): Illuminate\Foundation\Bootstrap\HandleExceptions->renderHttpResponse()
#6 [internal function]: Illuminate\Foundation\Bootstrap\HandleExceptions->handleException()
#7 {main}
  thrown {"exception":"[object] (Symfony\\Component\\ErrorHandler\\Error\\FatalError(code: 0): Uncaught ErrorException: Undefined array key \"host\" in /sites/domain.com/vendor/area17/twill
```

For this to work, people need to remember to add the scheme to the Twill's admin URL too:

```
APP_URL=https://domain.com
ADMIN_APP_URL=https://admin.domain.com
```

This is happening because parse_url() needs the scheme to correctly parse the URL, so this is good as it parses and finds the host:

``` php
parse_url('https://admin.domain.com');

[
     "scheme" => "https",
     "host" => "admin.domain.com",
]
```

But without the scheme we get:

``` php
parse_url('admin.domain.com');

[
     "path" => "admin.domain.com",
]
```

This PR a quick fix for it, but this problem is actually deeper and needs us to fix it for good on 3.0.