### PR TITLE
Updated docblock in HandleSlugs

### DIFF
--- a/src/Repositories/Behaviors/HandleSlugs.php
+++ b/src/Repositories/Behaviors/HandleSlugs.php
@@ -86,7 +86,7 @@ trait HandleSlugs
     }
 
     /**
-     * @param array $slug
+     * @param string $slug
      * @param array $with
      * @param array $withCount
      * @param array $scopes
@@ -123,7 +123,7 @@ trait HandleSlugs
     }
 
     /**
-     * @param array $slug
+     * @param string $slug
      * @param array $with
      * @param array $withCount
      * @return \A17\Twill\Models\Model


### PR DESCRIPTION
## Description

Changed the type of Parameter `$slug` in docblock from `array` to `string` in Methods `forSlug()` and `forSlugPreview()`.
