### PR TITLE
Detect when the user has entered a lat/lng into the location field and set the map to that position

### DIFF
--- a/frontend/js/components/LocationField.vue
+++ b/frontend/js/components/LocationField.vue
@@ -172,6 +172,11 @@
 
         this.address = newValue
         this.$emit('change', newValue)
+
+        const latlng = newValue.match(/^(-?\d+(?:\.\d+)?),+ *(-?\d+(?:\.\d+)?)$/)
+        if (latlng) {
+          this.onLatLngEntered(latlng[1], latlng[2]);
+        }
       },
       onPlaceChanged: function () {
         const place = this.autocompletePlace.getPlace()
@@ -213,6 +218,23 @@
 
         if (this.map) {
           this.addMarker(latlng)
+        }
+
+        // see formStore mixin
+        this.saveIntoStore()
+      },
+      onLatLngEntered: function (lat, lng) {
+        const latlng = new google.maps.LatLng(lat, lng)
+
+        this.clearMarkers()
+        this.clearLatLng()
+
+        this.address = [latlng.lat(), latlng.lng()].join(',')
+        this.setLatLng(latlng)
+
+        if (this.map) {
+          this.addMarker(latlng)
+          this.map.setCenter(latlng)
         }
 
         // see formStore mixin

--- a/frontend/js/components/LocationField.vue
+++ b/frontend/js/components/LocationField.vue
@@ -175,7 +175,7 @@
 
         const latlng = newValue.match(/^(-?\d+(?:\.\d+)?),+ *(-?\d+(?:\.\d+)?)$/)
         if (latlng) {
-          this.onLatLngEntered(latlng[1], latlng[2]);
+          this.onLatLngEntered(latlng[1], latlng[2])
         }
       },
       onPlaceChanged: function () {


### PR DESCRIPTION
## Description

I had a bunch of specific lat/lng's that didn't correspond to addresses so there was no autocomplete option, and I cbf punching each one into google maps so I could then click-to-place in the Location field's map.

This pull request uses regex to detect when the user has entered a lat/lng string like `-38.149926, 144.361808` and sets the map to there.

## Related Issues

None.