### PR TITLE
Fix dynamic repeater title / prefix on json Repeaters

### DIFF
--- a/src/Repositories/Behaviors/HandleJsonRepeaters.php
+++ b/src/Repositories/Behaviors/HandleJsonRepeaters.php
@@ -77,6 +77,8 @@ trait HandleJsonRepeaters
                 'id' => $id,
                 'type' => $repeatersList[$repeaterName]['component'],
                 'title' => $repeatersList[$repeaterName]['title'],
+                'titleField' => $repeatersList[$repeaterName]['titleField'],
+                'hideTitlePrefix' => $repeatersList[$repeaterName]['hideTitlePrefix'],
             ];
 
             if (isset($repeaterItem['browsers'])) {


### PR DESCRIPTION
Add in 2 missing lines from getFormFieldsForRepeaters that set the titleField and hideTitlePrefix values to support dynamic repeater titles when used outside the block editor with HandleJsonRepeaters trait

<!--
  Thanks for opening a PR! Your contribution is much appreciated.
  Do you have any questions? Check out the contributing docs at https://github.com/area17/twill/blob/2.x/CONTRIBUTING.md, 
  or ask in this Pull Request and a Twill maintainer will be happy to help :)
-->

## Description

<!-- Write a description of the changes introduced by this PR -->
<!-- If this is introducing a new feature, it would be great if you can create a stub for documentation including bullet points for how to use the feature, code snippets, etc. -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
