### PR TITLE
Handle many-to-many relations in index columns

### DIFF
--- a/src/Http/Controllers/Admin/ModuleController.php
+++ b/src/Http/Controllers/Admin/ModuleController.php
@@ -7,6 +7,7 @@ use A17\Twill\Models\Behaviors\HasSlug;
 use A17\Twill\Services\Blocks\BlockCollection;
 use A17\Twill\Services\Capsules\HasCapsules;
 use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;

--- a/src/Http/Controllers/Admin/ModuleController.php
+++ b/src/Http/Controllers/Admin/ModuleController.php
@@ -7,7 +7,6 @@ use A17\Twill\Models\Behaviors\HasSlug;
 use A17\Twill\Services\Blocks\BlockCollection;
 use A17\Twill\Services\Capsules\HasCapsules;
 use Illuminate\Contracts\Foundation\Application;
-use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;

--- a/src/Http/Controllers/Admin/ModuleController.php
+++ b/src/Http/Controllers/Admin/ModuleController.php
@@ -1081,7 +1081,15 @@ abstract class ModuleController extends Controller
 
         if (isset($column['relationship'])) {
             $field = $column['relationship'] . ucfirst($column['field']);
-            $value = Arr::get($item, "{$column['relationship']}.{$column['field']}");
+
+            $relation = $item->{$column['relationship']}();
+
+            if($relation instanceof BelongsToMany) {
+                $value = implode(', ', Arr::pluck($relation->get(), $column['field']));
+            }
+            else {
+                $value = Arr::get($item, "{$column['relationship']}.{$column['field']}");
+            }
         } elseif (isset($column['present']) && $column['present']) {
             $value = $item->presentAdmin()->{$column['field']};
         }

--- a/src/Http/Controllers/Admin/ModuleController.php
+++ b/src/Http/Controllers/Admin/ModuleController.php
@@ -1085,12 +1085,9 @@ abstract class ModuleController extends Controller
 
             $relation = $item->{$column['relationship']}();
 
-            if($relation instanceof BelongsToMany) {
-                $value = implode(', ', Arr::pluck($relation->get(), $column['field']));
-            }
-            else {
-                $value = Arr::get($item, "{$column['relationship']}.{$column['field']}");
-            }
+            $value = collect($relation->get())
+                ->pluck($column['field'])
+                ->join(', ');
         } elseif (isset($column['present']) && $column['present']) {
             $value = $item->presentAdmin()->{$column['field']};
         }

--- a/tests/integration/ModulesAuthorsTest.php
+++ b/tests/integration/ModulesAuthorsTest.php
@@ -3,6 +3,7 @@
 namespace A17\Twill\Tests\Integration;
 
 use App\Models\Author;
+use App\Models\Category;
 use App\Models\Revisions\AuthorRevision;
 use Illuminate\Support\Facades\Schema;
 
@@ -313,6 +314,26 @@ class ModulesAuthorsTest extends ModulesTestBase
         $this->assertEquals(
             5,
             count(json_decode($this->content(), true)['tableData'])
+        );
+    }
+
+    public function testCanShowAuthorRelationshipColumn()
+    {
+        $this->createAuthor(1);
+        $author = Author::first();
+
+        $this->createCategory(2);
+        $categories = Category::all();
+
+        $author->categories()->attach($categories);
+
+        $this->ajax('/twill/personnel/authors')->assertStatus(200);
+
+        $content = json_decode($this->content(), true);
+
+        $this->assertEquals(
+            $content['tableData'][0]['categoriesTitle'],
+            $categories->pluck('title')->join(', ')
         );
     }
 

--- a/tests/stubs/modules/authors/2019_10_18_193753_create_authors_tables.php
+++ b/tests/stubs/modules/authors/2019_10_18_193753_create_authors_tables.php
@@ -57,6 +57,10 @@ class CreateAuthorsTables extends Migration
         Schema::create('author_revisions', function (Blueprint $table) {
             createDefaultRevisionsTableFields($table, 'author');
         });
+
+        Schema::create('author_category', function (Blueprint $table) {
+            createDefaultRelationshipTableFields($table, 'author', 'category');
+        });
     }
 
     public function down()

--- a/tests/stubs/modules/authors/Author.php
+++ b/tests/stubs/modules/authors/Author.php
@@ -81,4 +81,9 @@ class Author extends Model implements Sortable
     {
         return $this->hasMany(AuthorRevision::class);
     }
+
+    public function categories()
+    {
+        return $this->belongsToMany(Category::class);
+    }
 }

--- a/tests/stubs/modules/authors/AuthorController.php
+++ b/tests/stubs/modules/authors/AuthorController.php
@@ -49,6 +49,12 @@ class AuthorController extends ModuleController
             'title' => 'Birth day',
             'sort' => true,
         ],
+
+        'categories' => [
+            'relationship' => 'categories',
+            'field' => 'title',
+            'title' => 'Categories',
+        ],
     ];
 
     protected $titleColumnKey = 'name';


### PR DESCRIPTION
## Description

I had a many-to-many relationship that I wanted to print as a column but only single `BelongsTo` relations were supported through the use of `Arr::get($item, "{$column['relationship']}.{$column['field']}");`.

This change adds a check for `BelongsToMany`, plucks the `$column['field']` values, and concatenates them together for printing.

## Related Issues

None