### PR TITLE
Fix admin HTTP exception views detection

### DIFF
--- a/src/Exceptions/Handler.php
+++ b/src/Exceptions/Handler.php
@@ -35,9 +35,9 @@ class Handler extends ExceptionHandler
     protected function getHttpExceptionView(HttpExceptionInterface $e)
     {
         $usesAdminPath = !empty(config('twill.admin_app_path'));
-        $adminAppUrl = parse_url(config('twill.admin_app_url'));
+        $adminAppUrl = config('twill.admin_app_url');
 
-        $isSubdomainAdmin = !$usesAdminPath && $adminAppUrl['host'] == Request::getHost();
+        $isSubdomainAdmin = !$usesAdminPath && Str::contains(Request::url(), $adminAppUrl);
         $isSubdirectoryAdmin = $usesAdminPath && Str::startsWith(Request::path(), config('twill.admin_app_path'));
 
         return $this->getTwillErrorView($e->getStatusCode(), !($isSubdomainAdmin || $isSubdirectoryAdmin));


### PR DESCRIPTION
This is an alternative PR for #1159 addressing the same issue as well as making sure all configurations effectively use the custom errors views from Twill for exceptions in the CMS.
