### PR TITLE
feat: Add TwicPics image service

### DIFF
--- a/config/twicpics.php
+++ b/config/twicpics.php
@@ -1,0 +1,65 @@
+<?php
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | TwicPics Domain
+    |--------------------------------------------------------------------------
+    |
+    | The full domain of your TwicPics account, e.g. `m1lz5gkt.twic.pics`.
+    |
+    | @see https://www.twicpics.com/docs/getting-started/subdomain
+    |
+    */
+    'domain' => env('TWICPICS_DOMAIN', ''),
+
+    /*
+    |--------------------------------------------------------------------------
+    | TwicPics Path
+    |--------------------------------------------------------------------------
+    |
+    | The single path prefix configured in your TwicPics account, e.g `images`.
+    |
+    | @see https://www.twicpics.com/docs/getting-started/subdomain
+    |
+    */
+    'path' => env('TWICPICS_PATH', ''),
+
+    /*
+    |--------------------------------------------------------------------------
+    | TwicPics API Version
+    |--------------------------------------------------------------------------
+    |
+    | The URL parameter to select the TwiPics Manipulations API.
+    |
+    | @see https://www.twicpics.com/docs/api/basics
+    |
+    */
+    'api_version' => env('TWICPICS_API_VERSION', 'v1'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | TwicPics Default Parameters
+    |--------------------------------------------------------------------------
+    |
+    | The default image manipulation parameters.
+    |
+    | @see https://www.twicpics.com/docs/api/manipulations
+    |
+    */
+    'default_params' => [
+        'quality' => '80',
+    ],
+    'lqip_default_params' => [
+        'output' => 'preview',
+    ],
+    'social_default_params' => [
+        // the 'crop' value will likely be replaced by the user selected value but it
+        // must be declared before 'cover' here to be a valid TwicPics manipulation
+        'crop' => '900x470',
+        'cover' => '900x470',
+    ],
+    'cms_default_params' => [
+        'quality' => 60,
+    ],
+];

--- a/config/twicpics.php
+++ b/config/twicpics.php
@@ -30,7 +30,7 @@ return [
     | TwicPics API Version
     |--------------------------------------------------------------------------
     |
-    | The URL parameter to select the TwiPics Manipulations API.
+    | The API version used for image manipulations parameters.
     |
     | @see https://www.twicpics.com/docs/api/basics
     |

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -13,6 +13,9 @@
 >
   <testsuites>
     <testsuite name="Twill Test Suites">
+      <file>tests/unit/ValidationTest.php</file>
+      <file>tests/unit/MediaLibrary/AbstractParamsProcessorTest.php</file>
+      <file>tests/unit/MediaLibrary/TwicPicsParamsProcessorTest.php</file>
       <file>tests/integration/Commands/BuildTest.php</file>
       <file>tests/integration/Commands/ListBlocksTest.php</file>
       <file>tests/integration/Commands/ListIconsTest.php</file>

--- a/src/Services/MediaLibrary/AbstractParamsProcessor.php
+++ b/src/Services/MediaLibrary/AbstractParamsProcessor.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace A17\Twill\Services\MediaLibrary;
+
+/**
+ * Base class to implement image service parameter compatibility.
+ *
+ * This class was introduced along with the TwicPics image service to implement a basic
+ * compatibility layer with Imgix-type parameters. There are a few instances in the
+ * Twill and Twill Image [1] source code where parameters were hardcoded, such as:
+ *
+ * - `w`
+ * - `h`
+ * - `fm`
+ * - `q`
+ * - `fit=crop`
+ *
+ * This was adopted internally as the minimum set of parameters for which
+ * Twill image services need to provide compatibility.
+ *
+ * [1] https://github.com/area17/twill-image
+ *
+ * @see TwicPicsParamsProcessor
+ */
+abstract class AbstractParamsProcessor
+{
+    const COMPATIBLE_PARAMS = [
+        'w' => 'width',
+        'h' => 'height',
+        'fm' => 'format',
+        'q' => 'quality',
+        'fit' => 'fit',
+    ];
+
+    protected $params;
+    protected $width;
+    protected $height;
+    protected $format;
+    protected $quality;
+    protected $fit;
+
+    /**
+     * Abstract method to be implemented in concrete params processor classes.
+     * This method is called after all parameters have been processed and
+     * must return a finalized params array to generate the image URL.
+     *
+     * @return array
+     */
+    abstract public function finalizeParams();
+
+    /**
+     * Receives the original params array and calls the appropriate handler method
+     * for each param. Custom handlers can be defined by following this naming
+     * convention: `handleParamNAME`, where NAME is the name of the param.
+     *
+     * @param array $params
+     * @return array
+     */
+    public function process($params)
+    {
+        $this->params = $params;
+
+        foreach ($params as $key => $value) {
+            $handler = "handleParam{$key}";
+
+            if (method_exists($this, $handler)) {
+                $this->{$handler}($key, $value);
+            } else {
+                $this->handleParam($key, $value);
+            }
+        }
+
+        return $this->finalizeParams();
+    }
+
+    /**
+     * The generic param handler. Known parameter values will be extracted into the
+     * corresponding properties as defined in COMPATIBLE_PARAMS. Unknown params
+     * will remain untouched.
+     *
+     * @param string $key
+     * @param string $value
+     * @return void
+     */
+    protected function handleParam($key, $value)
+    {
+        if ($property = static::COMPATIBLE_PARAMS[$key] ?? false) {
+            $this->{$property} = $value;
+
+            unset($this->params[$key]);
+        }
+    }
+}

--- a/src/Services/MediaLibrary/AbstractParamsProcessor.php
+++ b/src/Services/MediaLibrary/AbstractParamsProcessor.php
@@ -79,7 +79,7 @@ abstract class AbstractParamsProcessor
      * will remain untouched.
      *
      * @param string $key
-     * @param string $value
+     * @param mixed $value
      * @return void
      */
     protected function handleParam($key, $value)

--- a/src/Services/MediaLibrary/TwicPics.php
+++ b/src/Services/MediaLibrary/TwicPics.php
@@ -1,0 +1,197 @@
+<?php
+
+namespace A17\Twill\Services\MediaLibrary;
+
+use Illuminate\Support\Arr;
+
+class TwicPics implements ImageServiceInterface
+{
+    use ImageServiceDefaults;
+
+    protected $paramsProcessor;
+
+    public function __construct(TwicPicsParamsProcessor $paramsProcessor)
+    {
+        $this->paramsProcessor = $paramsProcessor;
+    }
+
+    /**
+     * @param string $id
+     * @param array $params
+     * @return string
+     */
+    public function getUrl($id, array $params = [])
+    {
+        $defaultParams = config('twill.twicpics.default_params');
+
+        return $this->createUrl($id, array_replace($defaultParams, $params));
+    }
+
+    /**
+     * @param string $id
+     * @param array $crop_params
+     * @param array $params
+     * @return string
+     */
+    public function getUrlWithCrop($id, array $cropParams, array $params = [])
+    {
+        return $this->getUrl($id, $this->getCrop($cropParams) + $params);
+    }
+
+    /**
+     * @param string $id
+     * @param array $cropParams
+     * @param int $width
+     * @param int $height
+     * @param array $params
+     * @return string
+     */
+    public function getUrlWithFocalCrop($id, array $cropParams, $width, $height, array $params = [])
+    {
+        return $this->getUrl($id, $this->getFocalPointCrop($cropParams, $width, $height) + $params);
+
+    }
+
+    /**
+     * @param string $id
+     * @param array $params
+     * @return string
+     */
+    public function getLQIPUrl($id, array $params = [])
+    {
+        $defaultParams = config('twill.twicpics.lqip_default_params');
+
+        return $this->getUrlWithDefaultParams($id, $params, $defaultParams);
+    }
+
+    /**
+     * @param string $id
+     * @param array $params
+     * @return string
+     */
+    public function getSocialUrl($id, array $params = [])
+    {
+        $defaultParams = config('twill.twicpics.social_default_params');
+
+        return $this->getUrlWithDefaultParams($id, $params, $defaultParams);
+    }
+
+    /**
+     * @param string $id
+     * @param array $params
+     * @return string
+     */
+    public function getCmsUrl($id, array $params = [])
+    {
+        $defaultParams = config('twill.twicpics.cms_default_params');
+
+        return $this->getUrlWithDefaultParams($id, $params, $defaultParams);
+    }
+
+    /**
+     * @param string $id
+     * @return string
+     */
+    public function getRawUrl($id)
+    {
+        $domain = config('twill.twicpics.domain');
+        $path = config('twill.twicpics.path');
+
+        if (! empty($path)) {
+            $path = "{$path}/";
+        }
+
+        return "https://{$domain}/{$path}{$id}";
+    }
+
+    /**
+     * @param string $id
+     * @return array|null
+     */
+    public function getDimensions($id)
+    {
+        return null;
+    }
+
+    /**
+     * @param string $id
+     * @param array $params
+     * @return string
+     */
+    protected function createUrl($id, $params = [])
+    {
+        $rawUrl = $this->getRawUrl($id);
+
+        $apiVersion = config('twill.twicpics.api_version');
+
+        $params = $this->paramsProcessor->process($params);
+
+        $manipulations = collect($params)->map(function ($value, $key) {
+            return "{$key}={$value}";
+        })->join('/');
+
+        return "{$rawUrl}?twic={$apiVersion}/{$manipulations}";
+    }
+
+    /**
+     * @param string $id
+     * @param array $params
+     * @param array $defaultParams
+     * @return string
+     */
+    protected function getUrlWithDefaultParams($id, $params = [], $defaultParams = [])
+    {
+        $cropParams = Arr::has($params, $this->cropParamsKeys) ? $this->getCrop($params) : [];
+
+        $params = Arr::except($params, $this->cropParamsKeys);
+
+        return $this->getUrl($id, array_replace($defaultParams, $cropParams + $params));
+    }
+
+    /**
+     * @param array $cropParams
+     * @return array
+     */
+    protected function getCrop($cropParams)
+    {
+        $cropW = $cropParams['crop_w'] ?? null;
+        $cropH = $cropParams['crop_h'] ?? null;
+        $cropX = $cropParams['crop_x'] ?? null;
+        $cropY = $cropParams['crop_y'] ?? null;
+
+        if (!filled($cropW) || !filled($cropH)) {
+            return [];
+        }
+
+        $expression = "{$cropW}x{$cropH}";
+
+        if (filled($cropX) && filled($cropY)) {
+            $expression .= "@{$cropX}x{$cropY}";
+        }
+
+        return ['crop' => $expression];
+    }
+
+    /**
+     * @param array $cropParams
+     * @param int $width
+     * @param int $height
+     * @return array
+     */
+    protected function getFocalPointCrop($cropParams, $width, $height)
+    {
+        if (empty($cropParams)) {
+            return [];
+        }
+
+        $cropW = $cropParams['crop_w'] ?? 0;
+        $cropH = $cropParams['crop_h'] ?? 0;
+        $cropX = $cropParams['crop_x'] ?? 0;
+        $cropY = $cropParams['crop_y'] ?? 0;
+
+        $focusX = $cropW / 2 + $cropX;
+        $focusY = $cropH / 2 + $cropY;
+
+        return ['focus' => "{$focusX}x{$focusY}"];
+    }
+}

--- a/src/Services/MediaLibrary/TwicPicsParamsProcessor.php
+++ b/src/Services/MediaLibrary/TwicPicsParamsProcessor.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace A17\Twill\Services\MediaLibrary;
+
+class TwicPicsParamsProcessor extends AbstractParamsProcessor
+{
+    protected $cropFit;
+
+    public function finalizeParams()
+    {
+        if ($this->format) {
+            $this->params['output'] = $this->format;
+        }
+
+        if ($this->quality) {
+            $this->params['quality'] = $this->quality;
+        }
+
+        if ($this->width || $this->height) {
+            $this->width = $this->width ?: '-';
+            $this->height = $this->height ?: '-';
+
+            if ($this->cropFit) {
+                $this->params['crop'] = "{$this->width}x{$this->height}";
+            } else {
+                $this->params['resize'] = "{$this->width}x{$this->height}";
+            }
+        }
+
+        return $this->params;
+    }
+
+    protected function handleParamFit($key, $value)
+    {
+        if ($value !== 'crop') {
+            return;
+        }
+
+        if (isset($this->params['crop'])) {
+            return;
+        }
+
+        $this->cropFit = true;
+
+        unset($this->params[$key]);
+    }
+}

--- a/src/TwillServiceProvider.php
+++ b/src/TwillServiceProvider.php
@@ -225,6 +225,7 @@ class TwillServiceProvider extends ServiceProvider
         $this->mergeConfigFrom(__DIR__ . '/../config/media-library.php', 'twill.media_library');
         $this->mergeConfigFrom(__DIR__ . '/../config/imgix.php', 'twill.imgix');
         $this->mergeConfigFrom(__DIR__ . '/../config/glide.php', 'twill.glide');
+        $this->mergeConfigFrom(__DIR__ . '/../config/twicpics.php', 'twill.twicpics');
         $this->mergeConfigFrom(__DIR__ . '/../config/dashboard.php', 'twill.dashboard');
         $this->mergeConfigFrom(__DIR__ . '/../config/oauth.php', 'twill.oauth');
         $this->mergeConfigFrom(__DIR__ . '/../config/disks.php', 'filesystems.disks');

--- a/tests/unit/MediaLibrary/AbstractParamsProcessorTest.php
+++ b/tests/unit/MediaLibrary/AbstractParamsProcessorTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace A17\Twill\Tests\Unit;
+
+use A17\Twill\Services\MediaLibrary\AbstractParamsProcessor;
+
+class AbstractParamsProcessorTest extends TestCase
+{
+    public function testProcessesCompatibleParams()
+    {
+        $processedParams = (new DummyParamsProcessor)->process([
+            'w' => '111',
+            'h' => '222',
+            'fm' => 'gif',
+            'q' => '99',
+            'fit' => 'crop',
+        ]);
+
+        $this->assertEquals([
+            'width' => '111',
+            'height' => '222',
+            'format' => 'gif',
+            'quality' => '99',
+            'fit' => 'crop',
+        ], $processedParams);
+    }
+
+    public function testPreservesUnknownParams()
+    {
+        $processedParams = (new DummyParamsProcessor)->process([
+            'w' => '111',
+            'h' => '222',
+            'unknown' => 'zzz',
+        ]);
+
+        $this->assertEquals([
+            'width' => '111',
+            'height' => '222',
+            'unknown' => 'zzz',
+        ], $processedParams);
+    }
+
+    public function testSupportsCustomHandlers()
+    {
+        $processedParams = (new DummyParamsProcessor)->process([
+            'custom' => 'this_is_a_custom_value'
+        ]);
+
+        $this->assertEquals([
+            'custom' => 'THIS_IS_A_CUSTOM_VALUE'
+        ], $processedParams);
+
+    }
+}
+
+/**
+ * DummyParamsProcessor simply returns the processed params with modified key names.
+ */
+class DummyParamsProcessor extends AbstractParamsProcessor
+{
+    protected $custom;
+
+    public function finalizeParams()
+    {
+        return collect(
+            $this->params + [
+                'width' => $this->width,
+                'height' => $this->height,
+                'format' => $this->format,
+                'quality' => $this->quality,
+                'fit' => $this->fit,
+                'custom' => $this->custom,
+            ]
+        )->filter()->toArray();
+    }
+
+    public function handleParamCUSTOM($key, $value)
+    {
+        $this->custom = strtoupper($value);
+
+        unset($this->params['custom']);
+    }
+}

--- a/tests/unit/MediaLibrary/AbstractParamsProcessorTest.php
+++ b/tests/unit/MediaLibrary/AbstractParamsProcessorTest.php
@@ -49,7 +49,6 @@ class AbstractParamsProcessorTest extends TestCase
         $this->assertEquals([
             'custom' => 'THIS_IS_A_CUSTOM_VALUE'
         ], $processedParams);
-
     }
 }
 

--- a/tests/unit/MediaLibrary/TwicPicsParamsProcessorTest.php
+++ b/tests/unit/MediaLibrary/TwicPicsParamsProcessorTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace A17\Twill\Tests\Unit;
+
+use A17\Twill\Services\MediaLibrary\TwicPicsParamsProcessor;
+
+class TwicPicsParamsProcessorTest extends TestCase
+{
+    public function testProcessesCompatibleParams()
+    {
+        $processedParams = (new TwicPicsParamsProcessor)->process([
+            'w' => '111',
+            'h' => '222',
+            'fm' => 'gif',
+            'q' => '99',
+        ]);
+
+        $this->assertEquals([
+            'output' => 'gif',
+            'quality' => '99',
+            'resize' => '111x222',
+        ], $processedParams);
+    }
+
+    public function testProcessesFitCropValue()
+    {
+        $processedParams = (new TwicPicsParamsProcessor)->process([
+            'w' => '111',
+            'h' => '222',
+            'fit' => 'crop',
+        ]);
+
+        $this->assertEquals([
+            'crop' => '111x222',
+        ], $processedParams);
+    }
+
+    public function testIgnoresOtherFitValues()
+    {
+        $processedParams = (new TwicPicsParamsProcessor)->process([
+            'fit' => 'fill',
+        ]);
+
+        $this->assertEquals([
+            'fit' => 'fill',
+        ], $processedParams);
+    }
+}


### PR DESCRIPTION
## Description

This adds a new image service for Twill to easily integrate with [TwicPics](https://www.twicpics.com/docs/getting-started/overview), an on-demand image optimization SaaS.

In the process, the need for basic URL params compatibility between the different image services was identified. The `AbstractParamsProcessor` class was introduced as a first step to implement this compatibility layer.