### PR TITLE
feat: Add self-nested module slug helpers

### DIFF
--- a/docs/.sections/crud-modules.md
+++ b/docs/.sections/crud-modules.md
@@ -670,7 +670,7 @@ protected function previewData($item)
 
 ### Nested Module
 
-Modules can be visually nested within the listing view:
+Module items can be visually nested within the listing view:
 
 ![screenshot](/docs/_media/nested-module.png)
 
@@ -686,6 +686,56 @@ This feature requires the `laravel-nestedset` package, which can be installed vi
 
 ```
 composer require kalnoy/nestedset
+```
+
+#### Working with nested items
+
+A few accessors and methods are available to work with nested item slugs:
+
+```php
+// Get the combined slug for all ancestors of an item in the current locale:
+$slug = $item->ancestorsSlug;
+
+// for a specific locale:
+$slug = $item->getAncestorsSlug($lang);
+
+// Get the combined slug for an item including all ancestors:
+$slug = $item->nestedSlug;
+
+// for a specific locale:
+$slug = $item->getNestedSlug($lang);
+```
+
+To include all ancestor slugs in the permalink of an item in the CMS, you can dynamically set the `$permalinkBase` property from the `form()` method of your module controller:
+
+```php
+class PageController extends ModuleController
+{
+    //...
+
+    protected function form($id, $item = null)
+    {
+        $item = $this->repository->getById($id, $this->formWith, $this->formWithCount);
+
+        $this->permalinkBase = $item->ancestorsSlug;
+
+        return parent::form($id, $item);
+    }
+}
+```
+
+To implement routing for nested items, you can combine the `forNestedSlug()` method from `HandleNesting` with a wildcard route parameter:
+
+```php
+// file: routes/web.php
+
+Route::get('{slug}', function ($slug) {
+    $page = app(PageRepository::class)->forNestedSlug($slug);
+
+    abort_unless($page, 404);
+
+    return view('site.page', ['page' => $page]);
+})->where('slug', '.*');
 ```
 
 For more information on how to work with nested items in your application, you can refer to the 

--- a/src/Models/Behaviors/HasNesting.php
+++ b/src/Models/Behaviors/HasNesting.php
@@ -8,6 +8,48 @@ trait HasNesting
 {
     use NodeTrait;
 
+    /**
+     * Returns the combined slug for this item including all ancestors.
+     *
+     * @param string|null $locale
+     * @return string
+     */
+    public function getNestedSlug($locale = null)
+    {
+        return collect([$this->getAncestorsSlug($locale), $this->getSlug($locale)])
+            ->filter()
+            ->implode('/');
+    }
+
+    /**
+     * @return string
+     */
+    public function getNestedSlugAttribute()
+    {
+        return $this->getNestedSlug();
+    }
+
+    /**
+     * Returns the combined slug for all ancestors of this item.
+     *
+     * @param string|null $locale
+     * @return string
+     */
+    public function getAncestorsSlug($locale = null)
+    {
+        return collect($this->ancestors ?? [])
+            ->map(function ($i) use ($locale) { return $i->getSlug($locale); })
+            ->implode('/');
+    }
+
+    /**
+     * @return string
+     */
+    public function getAncestorsSlugAttribute()
+    {
+        return $this->getAncestorsSlug();
+    }
+
     public static function saveTreeFromIds($nodeTree)
     {
         $nodeModels = self::all();

--- a/src/Repositories/Behaviors/HandleNesting.php
+++ b/src/Repositories/Behaviors/HandleNesting.php
@@ -13,6 +13,26 @@ trait HandleNesting
      */
     protected $reorderNestedModuleItemsJobQueue = 'default';
 
+    /**
+     * @param string $nestedSlug
+     * @param array $with
+     * @param array $withCount
+     * @param array $scopes
+     * @return \A17\Twill\Models\Model|null
+     */
+    public function forNestedSlug($nestedSlug, $with = [], $withCount = [], $scopes = [])
+    {
+        $targetSlug = collect(explode('/', $nestedSlug))->last();
+
+        $targetItem = $this->forSlug($targetSlug, $with, $withCount, $scopes);
+
+        if (!$targetItem || $nestedSlug !== $targetItem->nestedSlug) {
+            return null;
+        }
+
+        return $targetItem;
+    }
+
     public function setNewOrder($ids)
     {
         ReorderNestedModuleItems::dispatch($this->model, $ids)

--- a/src/Repositories/Behaviors/HandleSlugs.php
+++ b/src/Repositories/Behaviors/HandleSlugs.php
@@ -90,7 +90,7 @@ trait HandleSlugs
      * @param array $with
      * @param array $withCount
      * @param array $scopes
-     * @return \A17\Twill\Models\Model
+     * @return \A17\Twill\Models\Model|null
      */
     public function forSlug($slug, $with = [], $withCount = [], $scopes = [])
     {


### PR DESCRIPTION
## Description

This adds some helpful accessors and methods to work with self-nested module slugs (aka. nested module items). This can be used to query items using nested slugs and implement routing. Some quick examples are also added to the docs.

<!-- Write a description of the changes introduced by this PR -->
<!-- If this is introducing a new feature, it would be great if you can create a stub for documentation including bullet points for how to use the feature, code snippets, etc. -->

## Related

This is follows https://github.com/area17/twill/pull/1140
