### PR TITLE
Add doctrine/dbal 3.0 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "doctrine/dbal:${{ matrix.dbal }}" --no-interaction --no-update
           composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: Execute tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,7 @@ jobs:
         os: [ubuntu-latest]
         php: [8.0, 7.4, 7.3, 7.2, 7.1]
         laravel: [8.*, 7.*, 6.*, 5.8.*]
+        dbal: [^2.12, ^3.0]
         stability: [prefer-stable]
         include:
           - laravel: 8.*
@@ -40,6 +41,12 @@ jobs:
             php : 7.1
           - laravel: 5.8.*
             php: 8.0
+          - dbal: ^3.0
+            laravel: 5.8.*
+          - dbal: ^3.0
+            laravel: 6.*
+          - dbal: ^3.0
+            laravel: 7.*
 
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,6 +47,8 @@ jobs:
             laravel: 6.*
           - dbal: ^3.0
             laravel: 7.*
+          - dbal: ^2.12
+            laravel: 8.*
 
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "ext-pdo": "*",
     "astrotomic/laravel-translatable": "^11.5",
     "cartalyst/tags": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
-    "doctrine/dbal": "^2.9",
+    "doctrine/dbal": "^2.9|^3.0",
     "guzzlehttp/guzzle": "^6.2|^7.0",
     "imgix/imgix-php": "^3.0",
     "laravel/framework": "~5.6|~5.7|~5.8|^6.0|^7.0|^8.0",

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "ext-pdo": "*",
     "astrotomic/laravel-translatable": "^11.5",
     "cartalyst/tags": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
-    "doctrine/dbal": "^2.9|^3.0",
+    "doctrine/dbal": "^2.12|^3.0",
     "guzzlehttp/guzzle": "^6.2|^7.0",
     "imgix/imgix-php": "^3.0",
     "laravel/framework": "~5.6|~5.7|~5.8|^6.0|^7.0|^8.0",


### PR DESCRIPTION
<!--
  Thanks for opening a PR! Your contribution is much appreciated.
  Do you have any questions? Check out the contributing docs at https://github.com/area17/twill/blob/2.x/CONTRIBUTING.md, 
  or ask in this Pull Request and a Twill maintainer will be happy to help :)
-->

## Description

Because [this migration](https://github.com/area17/twill/blob/2.x/migrations/default/2020_02_09_000012_change_locale_column_in_twill_default_fileables.php) uses the `->change()` [helper from Laravel](https://laravel.com/docs/8.x/migrations#prerequisites), Twill needs this dependency. In Twill 3.0 the migrations will be cleaned up to avoid this need, but for now we need to add support for installing `doctrine/dbal` 3+ in host applications.

## Related Issues

Fixes #818