### PR TITLE
Ensure autoloading on cached config.

### DIFF
--- a/src/CapsulesServiceProvider.php
+++ b/src/CapsulesServiceProvider.php
@@ -11,6 +11,8 @@ class CapsulesServiceProvider extends RouteServiceProvider
 {
     use HasRoutes, HasCapsules;
 
+    public static $capsulesBootstrapped = false;
+
     protected $manager;
 
     protected function mergeTwillConfig()
@@ -22,7 +24,7 @@ class CapsulesServiceProvider extends RouteServiceProvider
 
         $this->app
             ->make('config')
-            ->set('twill.capsules.list', $this->getCapsuleList()->toArray());
+            ->set('twill.capsules.list', $this->getCapsuleList(true)->toArray());
 
         $this->app->make('config')->set('twill.capsules.loaded', true);
     }

--- a/src/CapsulesServiceProvider.php
+++ b/src/CapsulesServiceProvider.php
@@ -24,7 +24,7 @@ class CapsulesServiceProvider extends RouteServiceProvider
 
         $this->app
             ->make('config')
-            ->set('twill.capsules.list', $this->getCapsuleList(true)->toArray());
+            ->set('twill.capsules.list', $this->getCapsuleList()->toArray());
 
         $this->app->make('config')->set('twill.capsules.loaded', true);
     }
@@ -33,6 +33,7 @@ class CapsulesServiceProvider extends RouteServiceProvider
     {
         $this->registerManager();
         $this->mergeTwillConfig();
+        $this->bootCapsules();
     }
 
     public function boot()
@@ -46,6 +47,23 @@ class CapsulesServiceProvider extends RouteServiceProvider
         $this->manager->getCapsuleList()->map(function ($capsule) {
             $this->registerCapsule($capsule);
         });
+    }
+
+    /*
+     * Boot the capsules so their psr, config and service providers are booted.
+     *
+     * @see HasCapsules::bootstrapCapsule
+     */
+    public function bootCapsules()
+    {
+        if (!self::$capsulesBootstrapped) {
+            $this->getCapsuleList()
+                ->where('enabled', true)
+                ->each(function ($capsule) {
+                    $this->bootstrapCapsule($capsule);
+                });
+            self::$capsulesBootstrapped = true;
+        }
     }
 
     protected function registerCapsule($capsule)

--- a/src/Services/Capsules/HasCapsules.php
+++ b/src/Services/Capsules/HasCapsules.php
@@ -2,7 +2,6 @@
 
 namespace A17\Twill\Services\Capsules;
 
-use A17\Twill\CapsulesServiceProvider;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;
 

--- a/src/Services/Capsules/HasCapsules.php
+++ b/src/Services/Capsules/HasCapsules.php
@@ -15,11 +15,7 @@ trait HasCapsules
             : require base_path('vendor/autoload.php');
     }
 
-    /**
-     * While there are more classes using HasCapsules, only the
-     * @see CapsulesServiceProvider should be the one trying to bootstrap.
-     */
-    public function getCapsuleList(bool $shouldBootstrap = false)
+    public function getCapsuleList()
     {
         $path = $this->getCapsulesPath();
 
@@ -31,17 +27,6 @@ trait HasCapsules
                 ->map(function ($capsule) use ($path) {
                     return $this->makeCapsule($capsule, $path);
                 });
-        }
-
-        // We know that the config of capsules is now ready (it might be cached already using config:cache).
-        // What we still have to do is bootstrap them if not yet done, this needs to happen only once.
-        if ($shouldBootstrap && !CapsulesServiceProvider::$capsulesBootstrapped) {
-            $list
-                ->where('enabled', true)
-                ->each(function ($capsule) use ($path) {
-                    $this->bootstrapCapsule($capsule);
-                });
-            CapsulesServiceProvider::$capsulesBootstrapped = true;
         }
 
         return $list;


### PR DESCRIPTION
## Description

This is a bugfix that ensures bootstrapping processes such as autoloading and service provider registration are working when config is cached.

## Some things to consider

We might want to move the call to bootstrapCapsule to CapsuleServiceProvider because now there is a flag on the getCapsuleList function. But this makes less sense when reading the code.