### PR TITLE
Fix an email link in Docs

### DIFF
--- a/docs/.sections/preface.md
+++ b/docs/.sections/preface.md
@@ -196,7 +196,7 @@ The Twill software is licensed under the [Apache 2.0 license](https://www.apache
 The Twill UI, including but not limited to images, icons, patterns, and derivatives thereof are licensed under the [Creative Commons Attribution 4.0 International License](https://creativecommons.org/licenses/by/4.0/).
 
 #### Attribution
-By using the Twill UI, you agree that any application which incorporates it shall prominently display the message “Made with Twill” in a legible manner in the footer of the admin console. This message must open a link to Twill.io when clicked or touched. For permission to remove the attribution, contact us at [hello@twill.io](hello@twill.io).
+By using the Twill UI, you agree that any application which incorporates it shall prominently display the message “Made with Twill” in a legible manner in the footer of the admin console. This message must open a link to Twill.io when clicked or touched. For permission to remove the attribution, contact us at [hello@twill.io](mailto:hello@twill.io).
 
 ### 1.x documentation
 Documentation for Twill versions below 2.0 is available for reference [here](/docs/1.x).


### PR DESCRIPTION
## Description

This fixes an email link in docs. `hello@twill.io` used to link to `https://twill.io/docs/hello@twill.io`. Now it's a correct email link (`mailto:hello@twill.io`) which is good for accessibility.

## Related Issues

No related issues
