### PR TITLE
Repeater feature to allow repeatable blocks of varying types

### DIFF
--- a/frontend/js/components/RepeaterArray.vue
+++ b/frontend/js/components/RepeaterArray.vue
@@ -1,0 +1,209 @@
+<template>
+  <div class="content">
+    <draggable class="content__content" v-model="blocks" :options="dragOptions">
+      <transition-group name="draggable_list" tag='div'>
+        <div class="content__item" v-for="(block, index) in blocks" :key="block.id">
+          <a17-block :block="block" :index="index" :size="blockSize" :opened="opened" @open="setOpened">
+            <a17-button slot="block-actions" variant="icon" data-action @click="duplicateBlock(index)"  v-if="hasRemainingBlocks"><span v-svg symbol="add"></span></a17-button>
+            <div slot="dropdown-action">
+              <button type="button" @click="collapseAllBlocks()">Collapse All</button>
+              <button type="button" @click="deleteBlock(index)">Delete</button>
+              <button type="button" @click="duplicateBlock(index)" v-if="hasRemainingBlocks">Duplicate</button>
+            </div>
+          </a17-block>
+        </div>
+      </transition-group>
+    </draggable>
+    <div class="content__trigger">
+      <a17-dropdown ref="repeaterOptions"
+                    position="top-center"
+                    v-if="blockTypes.length"
+                    :arrow="true"
+                    :offset="10"
+                    :maxHeight="430">
+
+        <a17-button size="small"
+                    variant="dropdown"
+                    @click="$refs.repeaterOptions.toggle()">Repeater Type
+        </a17-button>
+
+        <div slot="dropdown__content">
+          <template v-for="(blockType) in blockTypes">
+            <button
+              class="blocks__addButton"
+              type="button"
+              :key="blockType.type"
+              @click="addBlock(blockType.type, blockType.trigger)"
+            >
+              <span class="blocks__title">{{ blockType.trigger }}</span>
+            </button>
+          </template>
+        </div>
+      </a17-dropdown>
+    </div>
+  </div>
+</template>
+
+<script>
+  import { mapState } from 'vuex'
+  import { FORM } from '@/store/mutations'
+
+  import draggable from 'vuedraggable'
+  import draggableMixin from '@/mixins/draggable'
+  import BlockEditorItem from '@/components/blocks/BlockEditorItem.vue'
+
+  export default {
+    name: 'A17RepeaterArray',
+    components: {
+      'a17-block': BlockEditorItem,
+      draggable
+    },
+    mixins: [draggableMixin],
+    props: {
+      types: {
+        type: Array,
+        required: true
+      },
+      name: {
+        type: String,
+        required: true
+      }
+    },
+    data: function () {
+      return {
+        opened: true,
+        handle: '.block__handle' // drag handle
+      }
+    },
+    computed: {
+      triggerVariant: function () {
+        return this.inContentEditor ? 'aslink' : 'action'
+      },
+      triggerSize: function () {
+        return this.inContentEditor ? 'small' : ''
+      },
+      triggerClass: function () {
+        return this.inContentEditor ? 'content__button' : ''
+      },
+      blockSize: function () {
+        return this.inContentEditor ? 'small' : ''
+      },
+      inContentEditor: function () {
+        return typeof this.$parent.repeaterName !== 'undefined'
+      },
+      hasRemainingBlocks: function () {
+        // return !this.blockType.hasOwnProperty('max') || (this.blockType.max > this.blocks.length)
+        return true
+      },
+      blockTypes: function () {
+        const blockTypes = []
+        const availableBlocks = this.availableBlocks
+        this.types.forEach(function (t, i) {
+          blockTypes.push(availableBlocks[t.key])
+          blockTypes[i].type = t.key
+          blockTypes[i].trigger = t.name
+        })
+        return blockTypes
+      },
+      blocks: {
+        get () {
+          if (this.savedBlocks.hasOwnProperty(this.name)) {
+            return this.savedBlocks[this.name] || []
+          } else {
+            return []
+          }
+        },
+        set (value) {
+          this.$store.commit(FORM.REORDER_FORM_BLOCKS, {
+            type: this.type,
+            name: this.name,
+            blocks: value
+          })
+        }
+      },
+      ...mapState({
+        savedBlocks: state => state.repeaters.repeaters,
+        availableBlocks: state => state.repeaters.availableRepeaters
+      })
+    },
+    methods: {
+      setOpened: function (value) {
+        this.opened = value
+      },
+      addBlock: function (type, name) {
+        this.opened = true
+        this.$store.commit(FORM.ADD_FORM_BLOCK, { type: type, name: this.name })
+      },
+      duplicateBlock: function (index) {
+        this.opened = true
+        this.$store.commit(FORM.DUPLICATE_FORM_BLOCK, {
+          type: this.type,
+          name: this.name,
+          index: index
+        })
+      },
+      deleteBlock: function (index) {
+        this.$store.commit(FORM.DELETE_FORM_BLOCK, {
+          type: this.type,
+          name: this.name,
+          index: index
+        })
+      },
+      collapseAllBlocks: function () {
+        this.opened = false
+      }
+    },
+    mounted: function () {
+      const self = this
+      // if there are blocks, these should be all collapse by default
+      this.$nextTick(function () {
+        if (self.savedBlocks.length > 0) self.collapseAllBlocks()
+      })
+    }
+  }
+</script>
+
+<style lang="scss" scoped>
+  @import '~styles/setup/_mixins-colors-vars.scss';
+
+  .content {
+    margin-top:20px; // margin-top:35px;
+  }
+
+  .content__content {
+    margin-bottom:20px;
+
+    + .dropdown {
+      display:inline-block;
+    }
+  }
+
+  .content__item {
+    border:1px solid $color__border;
+    border-top:0 none;
+
+    &.sortable-ghost {
+      opacity:0.5;
+    }
+  }
+
+  .content__item:first-child {
+    border-top:1px solid $color__border;
+  }
+
+  .content__trigger {
+    display:flex;
+  }
+
+  .content__button {
+    display:block;
+    width:100%;
+    text-align:center;
+    margin-top:-5px;
+  }
+
+  .content__note {
+    flex-grow:1;
+    text-align:right;
+  }
+</style>

--- a/frontend/js/main-form.js
+++ b/frontend/js/main-form.js
@@ -19,6 +19,7 @@ import a17Publisher from '@/components/Publisher.vue'
 import a17PageNav from '@/components/PageNav.vue'
 import a17Blocks from '@/components/blocks/Blocks.vue'
 import a17Repeater from '@/components/Repeater.vue'
+import a17RepeaterArray from '@/components/RepeaterArray.vue'
 import a17LocationField from '@/components/LocationField.vue'
 import a17ConnectorField from '@/components/ConnectorField.vue'
 
@@ -85,6 +86,7 @@ Vue.component('a17-spinner', a17Spinner)
 
 // Browser
 Vue.component('a17-repeater', a17Repeater)
+Vue.component('a17-repeater_array', a17RepeaterArray)
 Vue.component('a17-browser', a17Browser)
 
 // Form : connector fields

--- a/views/partials/form/_repeater_array.blade.php
+++ b/views/partials/form/_repeater_array.blade.php
@@ -1,0 +1,22 @@
+<a17-repeater_array
+    :types='{!! json_encode($types) !!}'
+    @if ($renderForBlocks) :name="repeaterName('{{ $name }}')" @else name="{{ $name }}" @endif
+></a17-repeater_array>
+
+@push('vuexStore')
+    @foreach($form_fields['repeaterFields'][$name] ?? [] as $field)
+        window['{{ config('twill.js_namespace') }}'].STORE.form.fields.push({!! json_encode($field) !!})
+    @endforeach
+
+    @foreach($form_fields['repeaterMedias'][$name] ?? [] as $repeater => $medias)
+        window['{{ config('twill.js_namespace') }}'].STORE.medias.selected["{{ $repeater }}"] = {!! json_encode($medias) !!}
+    @endforeach
+
+    @foreach($form_fields['repeaterFiles'][$name] ?? [] as $repeater => $files)
+        window['{{ config('twill.js_namespace') }}'].STORE.medias.selected["{{ $repeater }}"] = {!! json_encode($files) !!}
+    @endforeach
+
+    @foreach($form_fields['repeaterBrowsers'][$name] ?? [] as $repeater => $fields)
+        window['{{ config('twill.js_namespace') }}'].STORE.browser.selected["{{ $repeater }}"] = {!! json_encode($fields) !!}
+    @endforeach
+@endpush


### PR DESCRIPTION
## Description

This feature adds the possibility of using an array of block options as repeatable blocks. 

Use in a form blade looks like this: 

```
@formField('repeater_array', [
    'name' => 'machine_name_for_field',
    'types' => [
        [
            'key' => 'machine_name_for_repeater_block_type',
            'name' => 'Name for Block Type',
        ],
        ...
    ],
])
```

## Related Issues

* Originally had a discussion with @ifox and @antonioribeiro around this feature about a year ago. Finally got around to updating the UI as I had a need for a longer list of block options.