### PR TITLE
Fixes nested module count pluralisation

### DIFF
--- a/src/Http/Controllers/Admin/ModuleController.php
+++ b/src/Http/Controllers/Admin/ModuleController.php
@@ -1080,9 +1080,7 @@ abstract class ModuleController extends Controller
             $module = Str::singular(last(explode('.', $this->moduleName)));
             $value = '<a href="';
             $value .= moduleRoute("$this->moduleName.$field", $this->routePrefix, 'index', [$module => $item[$this->identifierColumnKey]]);
-            $value .= '">' . $nestedCount . " " . (strtolower($nestedCount > 1
-                ? Str::plural($column['title'])
-                : Str::singular($column['title']))) . '</a>';
+            $value .= '">' . $nestedCount . " " . (strtolower(Str::plural($column['title'], $nestedCount))) . '</a>';
         } else {
             $field = $column['field'];
             $value = $item->$field;


### PR DESCRIPTION
<!--
  Thanks for opening a PR! Your contribution is much appreciated.
  Do you have any questions? Check out the contributing docs at https://github.com/area17/twill/blob/2.x/CONTRIBUTING.md, 
  or ask in this Pull Request and a Twill maintainer will be happy to help :)
-->

## Description

<!-- Write a description of the changes introduced by this PR -->
<!-- If this is introducing a new feature, it would be great if you can create a stub for documentation including bullet points for how to use the feature, code snippets, etc. -->

Simplifies the pluralisation of the nested module count. It also fixes an edge case: When the count is 0 the name should be pluralised: `0 things` rather than `0 thing`
