### PR TITLE
fix: Initialize undefined crops using first available ratio

### DIFF
--- a/frontend/js/components/Cropper.vue
+++ b/frontend/js/components/Cropper.vue
@@ -79,7 +79,7 @@
         return this.currentMedia.crops[this.currentCrop] || {}
       },
       multiCrops: function () {
-        return Object.keys(this.media.crops).length > 1
+        return Object.keys(this.cropOptions).length > 1
       },
       ratiosByContext: function () {
         const filtered = this.cropOptions[this.currentCrop]

--- a/frontend/js/components/Cropper.vue
+++ b/frontend/js/components/Cropper.vue
@@ -76,7 +76,7 @@
         return {}
       },
       crop: function () {
-        return this.currentMedia.crops[this.currentCrop]
+        return this.currentMedia.crops[this.currentCrop] || {}
       },
       multiCrops: function () {
         return Object.keys(this.media.crops).length > 1
@@ -154,7 +154,9 @@
       },
       changeCrop: function (cropName, index) {
         this.currentCrop = cropName
-        this.currentRatioName = this.crop.name
+        // If the current crop doesn't exist on the current media, the cropper will
+        // be set at the center of the image, using the first available ratio.
+        this.currentRatioName = this.crop.name || this.cropOptions[cropName][0].name
         this.toggleBreakpoint = index
 
         this.updateCrop()


### PR DESCRIPTION
## Description

This is a quick fix to the Cropper component to prevent errors when selecting a new crop that is not actually defined on the current media. Here's a quick demo:

Context:
- the image field is previously saved with 2 crops: `default` and `mobile`
- a new crop `small` with a ratio of `1` is added in `$mediaParams`
- the page is refreshed
- the video starts

https://user-images.githubusercontent.com/7805679/142676046-ff465b19-8b23-4cfe-942d-b17b5e807fe8.mp4

## Related Issues

Fixes https://github.com/area17/twill/issues/1193
