### PR TITLE
fix: Call parent constructor in IconsController

### DIFF
--- a/src/Http/Controllers/Admin/IconsController.php
+++ b/src/Http/Controllers/Admin/IconsController.php
@@ -12,6 +12,8 @@ class IconsController extends Controller
 {
     public function __construct(Filesystem $files, BlockMaker $blockMaker)
     {
+        parent::__construct();
+
         $this->files = $files;
         $this->blockMaker = $blockMaker;
     }


### PR DESCRIPTION
## Description

This is a quick fix to prevent the `Route [login] not defined` error when visiting the `/admin/icons` page unauthenticated.

Note: This error may also happen with [Custom CMS pages](https://twill.io/docs/#custom-cms-pages). In this case, the recommended fix would be to ensure that the custom page controller extends `A17\Twill\Http\Controllers\Admin\Controller`.

## Related Issues

Fixes https://github.com/area17/twill/issues/1143
