### PR TITLE
fix: Remove references to FatalThrowableError class

### DIFF
--- a/src/Services/Blocks/BladeCompiler.php
+++ b/src/Services/Blocks/BladeCompiler.php
@@ -2,11 +2,9 @@
 
 namespace A17\Twill\Services\Blocks;
 
-use Exception;
 use Throwable;
 use Illuminate\View\Factory;
 use Illuminate\Support\Facades\Blade;
-use Symfony\Component\Debug\Exception\FatalThrowableError;
 
 class BladeCompiler
 {
@@ -24,7 +22,7 @@ class BladeCompiler
     /**
      * @param string $php
      * @param array $data
-     * @throws \Symfony\Component\Debug\Exception\FatalThrowableError
+     * @throws \Throwable
      */
     protected static function compile(string $php, array $data)
     {
@@ -34,16 +32,11 @@ class BladeCompiler
             extract(self::absorbApplicationEnvironment($data), EXTR_SKIP);
 
             eval('?' . '>' . $php);
-        } catch (Exception $e) {
-            while (ob_get_level() > $obLevel) {
-                ob_end_clean();
-            }
-            throw $e;
         } catch (Throwable $e) {
             while (ob_get_level() > $obLevel) {
                 ob_end_clean();
             }
-            throw new FatalThrowableError($e);
+            throw $e;
         }
     }
 
@@ -71,7 +64,7 @@ class BladeCompiler
      * @param $string
      * @param $data
      * @return false|string
-     * @throws \Symfony\Component\Debug\Exception\FatalThrowableError
+     * @throws \Throwable
      */
     public static function render($string, $data)
     {

--- a/src/Services/Blocks/Block.php
+++ b/src/Services/Blocks/Block.php
@@ -359,7 +359,7 @@ class Block
 
     /**
      * @return string
-     * @throws \Symfony\Component\Debug\Exception\FatalThrowableError
+     * @throws \Throwable
      */
     public function render()
     {


### PR DESCRIPTION
## Description

This removes all references to the [`FatalThrowableError`](https://symfony.com/components/Debug) class, which seems to have been deprecated since Symfony 4.4 and removed in a subsequent version. 

## Related Issues

Fixes https://github.com/area17/twill/issues/1263
