### PR TITLE
Fix edit link feature regression in Quill WYSIWYG

### DIFF
--- a/frontend/js/components/Wysiwyg.vue
+++ b/frontend/js/components/Wysiwyg.vue
@@ -270,30 +270,9 @@
       getTextLength: function () {
         // see https://quilljs.com/docs/api/#getlength
         return this.quill.getLength() - (this.value.length === 0 ? 2 : 1)
-      },
-      preventEditorScroll: function () {
-        // see https://github.com/quilljs/quill/issues/482
-        this.$nextTick(() => {
-          const tooltips = document.querySelectorAll('.ql-tooltip')
-          tooltips.forEach((tooltip) => {
-            const action = tooltip.querySelector('.ql-action')
-            let scrollPosition
-            action.addEventListener('mouseover', () => {
-              scrollPosition = this.$refs.editorcontainer.scrollTop
-            })
-            tooltip.addEventListener('mouseup', (event) => {
-              setTimeout(() => {
-                this.$refs.editorcontainer.scrollTop = scrollPosition
-              }, 0)
-              event.preventDefault()
-              event.stopPropagation()
-            })
-          })
-        })
       }
     },
     mounted: function () {
-      this.preventEditorScroll()
 
       if (this.quill) return
 

--- a/frontend/js/components/Wysiwyg.vue
+++ b/frontend/js/components/Wysiwyg.vue
@@ -273,7 +273,6 @@
       }
     },
     mounted: function () {
-
       if (this.quill) return
 
       /* global hljs */


### PR DESCRIPTION
The combination of 51302a151fdb22e3f5bf0fb99ee21c07c72273af and f8276462fdfb32fe0d425cff7536991078c3b12b created an issue where links could not be edited anymore. It appears that this code is not necessary now that the scroll container is using `html`.