### PR TITLE
fix: Prevent multiple preview AJAX requests in EditorPreview

### DIFF
--- a/frontend/js/components/editor/EditorPreview.vue
+++ b/frontend/js/components/editor/EditorPreview.vue
@@ -80,9 +80,6 @@
       return {
         loading: false,
         blockSelectIndex: -1,
-        unSubscribe: function () {
-          return null
-        },
         handle: '.editorPreview__dragger' // Drag handle override
       }
     },
@@ -126,9 +123,11 @@
         if (fn) {
           this.selectBlock(fn, index)
         }
+
         if (this.blockSelectIndex !== index) {
+          this.unSubscribe()
           this.blockSelectIndex = index
-          this.unSubscribe = this.$store.subscribe((mutation) => {
+          this._unSubscribeInternal = this.$store.subscribe((mutation) => {
             // console.log('mutation', mutation)
             // Don't trigger a refresh of the preview every single time, just when necessary
             if (PREVIEW.REFRESH_BLOCK_PREVIEW.includes(mutation.type)) {
@@ -143,10 +142,16 @@
         }
       },
       _unselectBlock (fn, index = this.blockSelectIndex) {
+        this.unSubscribe()
         this.getPreview(index)
         this.unselectBlock(fn, index)
         this.blockSelectIndex = -1
         this.unSubscribe()
+      unSubscribe () {
+        if (!this._unSubscribeInternal) return
+
+        this._unSubscribeInternal()
+        this._unSubscribeInternal = null
       },
 
       // Previews management

--- a/frontend/js/components/editor/EditorPreview.vue
+++ b/frontend/js/components/editor/EditorPreview.vue
@@ -28,7 +28,7 @@
                                       @block:select="_selectBlock(edit, blockIndex)"
                                       @block:unselect="_unselectBlock(unEdit, blockIndex)"
                                       @block:move="move"
-                                      @block:delete="deleteBlock(remove)"
+                                      @block:delete="_deleteBlock(remove)"
                                       @scroll-to="scrollToActive"/>
           </a17-blockeditor-model>
         </template>
@@ -146,7 +146,11 @@
         this.getPreview(index)
         this.unselectBlock(fn, index)
         this.blockSelectIndex = -1
+      },
+      _deleteBlock (fn) {
         this.unSubscribe()
+        this.deleteBlock(fn)
+      },
       unSubscribe () {
         if (!this._unSubscribeInternal) return
 

--- a/frontend/js/components/editor/EditorPreview.vue
+++ b/frontend/js/components/editor/EditorPreview.vue
@@ -128,10 +128,8 @@
           this.unSubscribe()
           this.blockSelectIndex = index
           this._unSubscribeInternal = this.$store.subscribe((mutation) => {
-            // console.log('mutation', mutation)
             // Don't trigger a refresh of the preview every single time, just when necessary
             if (PREVIEW.REFRESH_BLOCK_PREVIEW.includes(mutation.type)) {
-              // console.log('Editor - store changed : ' + mutation.type)
               if (PREVIEW.REFRESH_BLOCK_PREVIEW_ALL.includes(mutation.type)) {
                 this.getAllPreviews()
               } else {


### PR DESCRIPTION
## Description

This is a fix to the `EditorPreview` component, specifically around the internal listener for Vuex store mutations. This ensures that only one listener can be active at a time (for the most recently selected block), and ensures that listeners are properly removed when a block is unselected or deleted.

## Related Issues

Addresses https://github.com/area17/twill/pull/1161
