### PR TITLE
feat: Add command twill:refresh-crops

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -24,6 +24,7 @@
       <file>tests/integration/Commands/MakeSingletonTest.php</file>
       <file>tests/integration/Commands/SuperadminTest.php</file>
       <file>tests/integration/Commands/UpdateTest.php</file>
+      <file>tests/integration/Commands/RefreshCropsTest.php</file>
       <file>tests/integration/FileLibraryTest.php</file>
       <file>tests/integration/LoginTest.php</file>
       <file>tests/integration/MediaLibraryTest.php</file>

--- a/src/Commands/RefreshCrops.php
+++ b/src/Commands/RefreshCrops.php
@@ -1,0 +1,328 @@
+<?php
+
+namespace A17\Twill\Commands;
+
+use Carbon\Carbon;
+use Illuminate\Database\DatabaseManager;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+use A17\Twill\Models\Media;
+
+class RefreshCrops extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'twill:refresh-crops
+        {modelName : The fully qualified model name (e.g. App\Models\Post)}
+        {roleName : The role name for which crops will be refreshed}
+        {--dry : Print the operations that would be performed without modifying the database}
+    ';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Refresh all crops for an existing image role';
+
+    /**
+     * @var DatabaseManager
+     */
+    protected $db;
+
+    /**
+     * The model FQCN for this operation.
+     *
+     * @var string
+     */
+    protected $modelName;
+
+    /**
+     * The role name for this operation.
+     *
+     * @var string
+     */
+    protected $roleName;
+
+    /**
+     * Available crops for the given model and role name.
+     *
+     * @var Collection
+     */
+    protected $crops;
+
+    /**
+     * Print the operations that would be performed without modifying the database.
+     *
+     * @var bool
+     */
+    protected $isDryRun = false;
+
+    /**
+     * Total number of crops created.
+     *
+     * @var int
+     */
+    protected $cropsCreated = 0;
+
+    /**
+     * Total number of crops deleted.
+     *
+     * @var int
+     */
+    protected $cropsDeleted = 0;
+
+    /**
+     * Cache for Media models queried during this operation.
+     *
+     * @var array
+     */
+    protected $mediaCache = [];
+
+    /**
+     * @param DatabaseManager $db
+     */
+    public function __construct(DatabaseManager $db)
+    {
+        parent::__construct();
+
+        $this->db = $db;
+    }
+
+    public function handle()
+    {
+        $this->isDryRun = $this->option('dry');
+
+        $this->modelName = $this->locateModel($this->argument('modelName'));
+
+        if (! $this->modelName) {
+            $this->error("Model `{$this->argument('modelName')}` was not found`");
+
+            return 1;
+        }
+
+        $this->roleName = $this->argument('roleName');
+
+        $mediasParams = app($this->modelName)->mediasParams;
+
+        if (! isset($mediasParams[$this->roleName])) {
+            $this->error("Role `{$this->roleName}` was not found`");
+
+            return 1;
+        }
+
+        $this->crops = collect($mediasParams[$this->roleName]);
+
+        $mediables = $this->db
+            ->table(config('twill.mediables_table', 'twill_mediables'))
+            ->where(['mediable_type' => $this->modelName, 'role' => $this->roleName]);
+
+        if ($mediables->count() === 0) {
+            $this->warn("No mediables found for model `$this->modelName` and role `$this->roleName`");
+
+            return 1;
+        }
+
+        if ($this->isDryRun) {
+            $this->warn("**Dry Run** No changes are being made to the database");
+            $this->warn("");
+        }
+
+        foreach ($mediables->get()->groupBy('locale') as $locale => $localeItems) {
+            foreach ($localeItems->groupBy('mediable_id') as $mediableId => $items) {
+                $this->processMediables($mediableId, $items, $locale);
+            }
+        }
+
+        $this->printSummary();
+    }
+
+    /**
+     * Print a summary of all crops created and deleted at the end of the command.
+     *
+     * @return void
+     */
+    protected function printSummary()
+    {
+        if ($this->cropsCreated + $this->cropsDeleted === 0) {
+            $this->info("");
+            $this->info("No crops to create or delete for this model and role");
+            return;
+        }
+
+        $this->info("");
+        $this->info("Summary:");
+
+        $actionPrefix = $this->isDryRun ? 'to be ' : '';
+
+        if ($this->cropsCreated > 0) {
+            $noun = Str::plural('crop', $this->cropsCreated);
+            $this->info("{$this->cropsCreated} {$noun} {$actionPrefix}created");
+        }
+
+        if ($this->cropsDeleted > 0) {
+            $noun = Str::plural('crop', $this->cropsDeleted);
+            $this->info("{$this->cropsDeleted} {$noun} {$actionPrefix}deleted");
+        }
+    }
+
+    /**
+     * Process a set of mediables.
+     *
+     * @param int $mediableId
+     * @param Collection $mediables
+     * @param string $locale
+     * @return void
+     */
+    protected function processMediables($mediableId, $mediables, $locale)
+    {
+        foreach ($mediables->groupBy('media_id') as $mediaId => $items) {
+            $existingCrops = $items->keyBy('crop')->keys();
+            $allCrops = $this->crops->keys();
+
+            if ($cropsToCreate = $allCrops->diff($existingCrops)->all()) {
+                $this->createCrops($cropsToCreate, $mediableId, $mediaId, $locale);
+            }
+
+            if ($cropsToDelete = $existingCrops->diff($allCrops)->all()) {
+                $this->deleteCrops($cropsToDelete, $mediableId, $mediaId);
+            }
+        }
+    }
+
+    /**
+     * Create crops for a given item, media and locale.
+     *
+     * @param string[] $crops
+     * @param int $mediableId
+     * @param int $mediaId
+     * @param string $locale
+     * @return void
+     */
+    protected function createCrops($crops, $mediableId, $mediaId, $locale)
+    {
+        $this->cropsCreated += count($crops);
+
+        if ($this->isDryRun) {
+            $cropNames = collect($crops)->join(', ');
+            $noun = Str::plural('crop', count($crops));
+            $this->info("Create {$noun} `$cropNames` for mediable_id=`$mediableId` and media_id=`$mediaId`");
+            return;
+        }
+
+        foreach ($crops as $crop) {
+            $ratio = $this->crops[$crop][0];
+            $cropParams = $this->getCropParams($mediaId, $ratio['ratio']);
+
+            $this->db
+                ->table(config('twill.mediables_table', 'twill_mediables'))
+                ->insert([
+                    'created_at' => Carbon::now(),
+                    'updated_at' => Carbon::now(),
+                    'mediable_id' => $mediableId,
+                    'mediable_type' => $this->modelName,
+                    'media_id' => $mediaId,
+                    'role' => $this->roleName,
+                    'crop' => $crop,
+                    'lqip_data' => null,
+                    'ratio' => $ratio['name'],
+                    'metadatas' => '{"video": null, "altText": null, "caption": null}',
+                    'locale' => $locale,
+                ] + $cropParams);
+        }
+    }
+
+    /**
+     * Delete unused crops for a given item and media.
+     *
+     * @param string[] $crops
+     * @param int $mediableId
+     * @param int $mediaId
+     * @return void
+     */
+    protected function deleteCrops($crops, $mediableId, $mediaId)
+    {
+        $this->cropsDeleted += count($crops);
+
+        if ($this->isDryRun) {
+            $cropNames = collect($crops)->join(', ');
+            $noun = Str::plural('crop', count($crops));
+            $this->info("Delete {$noun} `$cropNames` for mediable_id=`$mediableId` and media_id=`$mediaId`");
+            return;
+        }
+
+        $this->db
+            ->table(config('twill.mediables_table', 'twill_mediables'))
+            ->where([
+                'mediable_type' => $this->modelName,
+                'mediable_id' => $mediableId,
+                'media_id' => $mediaId,
+                'role' => $this->roleName,
+            ])
+            ->whereIn('crop', $crops)
+            ->delete();
+    }
+
+    /**
+     * Attempt to locate the model from the given command argument.
+     *
+     * @param string $modelName
+     * @return string|null  The model FQCN.
+     */
+    protected function locateModel($modelName)
+    {
+        $modelName = ltrim($modelName, "\\");
+        $modelStudly = Str::studly($modelName);
+        $moduleName = Str::plural($modelStudly);
+        $namespace = config('twill.namespace', 'App');
+
+        $attempts = [
+            $modelName,
+            "$namespace\\Models\\$modelStudly",
+            "$namespace\\Twill\\Capsules\\$moduleName\\Models\\$modelStudly",
+        ];
+
+        foreach ($attempts as $phpClass) {
+            if (class_exists($phpClass)) {
+                return $phpClass;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Calculate crop params for a media from a given ratio.
+     *
+     * @param int $mediaId
+     * @param float $ratio
+     * @return array
+     */
+    protected function getCropParams($mediaId, $ratio)
+    {
+        if (!isset($this->mediaCache[$mediaId])) {
+            $this->mediaCache[$mediaId] = Media::find($mediaId);
+        }
+
+        $width = $this->mediaCache[$mediaId]->width;
+        $height = $this->mediaCache[$mediaId]->height;
+        $originalRatio = $width / $height;
+
+        if ($originalRatio <= $ratio) {
+            $crop_w = $width;
+            $crop_h = $width / $ratio;
+            $crop_x = 0;
+            $crop_y = ($height - $crop_h) / 2;
+        } else {
+            $crop_h = $height;
+            $crop_w = $height * $ratio;
+            $crop_y = 0;
+            $crop_x = ($width - $crop_w) / 2;
+        }
+
+        return compact('crop_w', 'crop_h', 'crop_x', 'crop_y');
+    }
+}

--- a/src/TwillServiceProvider.php
+++ b/src/TwillServiceProvider.php
@@ -17,6 +17,7 @@ use A17\Twill\Commands\MakeSingleton;
 use A17\Twill\Commands\ModuleMake;
 use A17\Twill\Commands\ModuleMakeDeprecated;
 use A17\Twill\Commands\RefreshLQIP;
+use A17\Twill\Commands\RefreshCrops;
 use A17\Twill\Commands\SyncLang;
 use A17\Twill\Commands\Update;
 use A17\Twill\Http\ViewComposers\ActiveNavigation;
@@ -317,6 +318,7 @@ class TwillServiceProvider extends ServiceProvider
             ListBlocks::class,
             CreateSuperAdmin::class,
             RefreshLQIP::class,
+            RefreshCrops::class,
             GenerateBlocks::class,
             Build::class,
             Update::class,

--- a/tests/integration/Commands/RefreshCropsTest.php
+++ b/tests/integration/Commands/RefreshCropsTest.php
@@ -1,0 +1,356 @@
+<?php
+
+namespace A17\Twill\Tests\Integration\Commands;
+
+use Illuminate\Database\DatabaseManager;
+use Illuminate\Support\Carbon;
+use A17\Twill\Tests\Integration\TestCase;
+use A17\Twill\Repositories\MediaRepository;
+use App\Repositories\AuthorRepository;
+
+class RefreshCropsTest extends TestCase
+{
+    /**
+     * @var DatabaseManager
+     */
+    protected $db;
+
+    protected $allFiles = [
+        '{$stubs}/modules/authors/Author.php' => '{$app}/Models/',
+        '{$stubs}/modules/authors/AuthorRepository.php' => '{$app}/Repositories/',
+        '{$stubs}/modules/authors/AuthorTranslation.php' => '{$app}/Models/Translations/',
+        '{$stubs}/modules/authors/AuthorSlug.php' => '{$app}/Models/Slugs/',
+        '{$stubs}/modules/authors/AuthorRevision.php' => '{$app}/Models/Revisions/',
+        '{$stubs}/modules/authors/2019_10_18_193753_create_authors_tables.php' => '{$database}/migrations/',
+    ];
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->copyFiles($this->allFiles);
+
+        $this->loadModulesConfig();
+
+        $this->migrate();
+
+        $this->db = app(DatabaseManager::class);
+    }
+
+    public function createAuthor($name = 'Alice')
+    {
+        return app(AuthorRepository::class)->create([
+            'name' => [
+                'en' => $name,
+                'fr' => $name,
+            ],
+            'published' => true,
+        ]);
+    }
+
+    public function createMedia($attributes = [])
+    {
+        return app(MediaRepository::class)->create(array_merge([
+            'filename' => 'not-a-real-image.jpg',
+            'uuid' => uniqid() . '/not-a-real-image.jpg',
+            'width' => 1920,
+            'height' => 1080,
+        ], $attributes));
+    }
+
+    public function createMediable($attributes = [])
+    {
+        $this->db
+            ->table(config('twill.mediables_table', 'twill_mediables'))
+            ->insert(array_merge([
+                'created_at' => Carbon::now(),
+                'updated_at' => Carbon::now(),
+                'mediable_id' => 1,
+                'mediable_type' => 'App\\Models\\Author',
+                'media_id' => 1,
+                'role' => 'avatar',
+                'crop' => 'default',
+                'lqip_data' => null,
+                'ratio' => 'landscape',
+                'metadatas' => '{"video": null, "altText": null, "caption": null}',
+                'locale' => 'en',
+            ], $attributes));
+    }
+
+    public function mediables()
+    {
+        return $this->db->table(config('twill.mediables_table', 'twill_mediables'));
+    }
+
+    public function testCanLocateShortModelName()
+    {
+        $this->createAuthor();
+        $this->createMedia();
+        $this->createMediable();
+
+        $this->artisan('twill:refresh-crops', [
+                'modelName' => 'Author',
+                'roleName' => 'avatar',
+            ])
+            ->assertExitCode(0);
+    }
+
+    public function testCanLocateFullModelName()
+    {
+        $this->createAuthor();
+        $this->createMedia();
+        $this->createMediable();
+
+        $this->artisan('twill:refresh-crops', [
+                'modelName' => 'App\Models\Author',
+                'roleName' => 'avatar',
+            ])
+            ->assertExitCode(0);
+    }
+
+    public function testFailsIfModelNotFound()
+    {
+        $this->createAuthor();
+        $this->createMedia();
+        $this->createMediable();
+
+        $this->artisan('twill:refresh-crops', [
+                'modelName' => 'App\Models\Post',
+                'roleName' => 'avatar',
+            ])
+            ->assertExitCode(1);
+    }
+
+    public function testFailsIfRoleNotFound()
+    {
+        $this->createAuthor();
+        $this->createMedia();
+        $this->createMediable();
+
+        $this->artisan('twill:refresh-crops', [
+                'modelName' => 'App\Models\Author',
+                'roleName' => 'photo',
+            ])
+            ->assertExitCode(1);
+    }
+
+    public function testFailsIfNoMediables()
+    {
+        $this->createAuthor();
+        $this->createMedia();
+
+        $this->artisan('twill:refresh-crops', [
+                'modelName' => 'App\Models\Author',
+                'roleName' => 'avatar',
+            ])
+            ->assertExitCode(1);
+    }
+    public function testCanDoDryRun()
+    {
+        $this->createAuthor();
+        $this->createMedia();
+        $this->createMediable();
+
+        $this->assertEquals(1, $this->mediables()->count());
+
+        $this->artisan('twill:refresh-crops', [
+                'modelName' => 'App\Models\Author',
+                'roleName' => 'avatar',
+                '--dry' => 'true',
+            ])
+            ->assertExitCode(0);
+
+        $this->assertEquals(1, $this->mediables()->count());
+    }
+
+    public function testCanGenerateMissingCrop()
+    {
+        $this->createAuthor();
+        $this->createMedia();
+        $this->createMediable(['crop' => 'default']);
+
+        $mediables = $this->mediables()->get();
+        $this->assertEquals(1, $mediables->count());
+        $this->assertEquals('default', $mediables[0]->crop);
+
+        $this->artisan('twill:refresh-crops', [
+                'modelName' => 'App\Models\Author',
+                'roleName' => 'avatar',
+            ])
+            ->assertExitCode(0);
+
+        $mediables = $this->mediables()->get();
+        $this->assertEquals(2, $mediables->count());
+        $this->assertEquals('default', $mediables[0]->crop);
+        $this->assertEquals('mobile', $mediables[1]->crop);
+    }
+
+    public function testCanDeleteUnusedCrop()
+    {
+        $this->createAuthor();
+        $this->createMedia();
+        $this->createMediable(['crop' => 'default']);
+        $this->createMediable(['crop' => 'mobile']);
+        $this->createMediable(['crop' => 'unused']);
+
+        $this->assertEquals(3, $this->mediables()->count());
+
+        $this->artisan('twill:refresh-crops', [
+                'modelName' => 'App\Models\Author',
+                'roleName' => 'avatar',
+            ])
+            ->assertExitCode(0);
+
+        $mediables = $this->mediables()->get();
+        $this->assertEquals(2, $mediables->count());
+        $this->assertEquals('default', $mediables[0]->crop);
+        $this->assertEquals('mobile', $mediables[1]->crop);
+    }
+
+    public function testCanGenerateMissingCropForLocale()
+    {
+        $this->createAuthor();
+        $this->createMedia();
+        $this->createMediable(['crop' => 'default', 'locale' => 'en']);
+        $this->createMediable(['crop' => 'mobile', 'locale' => 'en']);
+        $this->createMediable(['crop' => 'default', 'locale' => 'fr']);
+
+        $this->assertEquals(3, $this->mediables()->count());
+
+        $this->artisan('twill:refresh-crops', [
+                'modelName' => 'App\Models\Author',
+                'roleName' => 'avatar',
+            ])
+            ->assertExitCode(0);
+
+        $mediables = $this->mediables()->get();
+        $this->assertEquals(4, $mediables->count());
+        $this->assertEquals('default', $mediables[0]->crop);
+        $this->assertEquals('en', $mediables[0]->locale);
+        $this->assertEquals('default', $mediables[0]->crop);
+        $this->assertEquals('en', $mediables[1]->locale);
+        $this->assertEquals('default', $mediables[2]->crop);
+        $this->assertEquals('fr', $mediables[2]->locale);
+        $this->assertEquals('mobile', $mediables[3]->crop);
+        $this->assertEquals('fr', $mediables[3]->locale);
+    }
+
+    public function testCanDeleteUnusedCropForLocale()
+    {
+        $this->createAuthor();
+        $this->createMedia();
+        $this->createMediable(['crop' => 'default', 'locale' => 'en']);
+        $this->createMediable(['crop' => 'mobile', 'locale' => 'en']);
+        $this->createMediable(['crop' => 'default', 'locale' => 'fr']);
+        $this->createMediable(['crop' => 'mobile', 'locale' => 'fr']);
+        $this->createMediable(['crop' => 'unused', 'locale' => 'fr']);
+
+        $this->assertEquals(5, $this->mediables()->count());
+
+        $this->artisan('twill:refresh-crops', [
+                'modelName' => 'App\Models\Author',
+                'roleName' => 'avatar',
+            ])
+            ->assertExitCode(0);
+
+        $mediables = $this->mediables()->get();
+        $this->assertEquals(4, $mediables->count());
+        $this->assertEquals('default', $mediables[0]->crop);
+        $this->assertEquals('en', $mediables[0]->locale);
+        $this->assertEquals('default', $mediables[0]->crop);
+        $this->assertEquals('en', $mediables[1]->locale);
+        $this->assertEquals('default', $mediables[2]->crop);
+        $this->assertEquals('fr', $mediables[2]->locale);
+        $this->assertEquals('mobile', $mediables[3]->crop);
+        $this->assertEquals('fr', $mediables[3]->locale);
+    }
+
+    public function testCanDoMultipleOperations()
+    {
+        // 6 crops
+        $completeAuthors = collect([1, 2, 3])->map(function () {
+            $author = $this->createAuthor();
+            $media = $this->createMedia();
+            $this->createMediable(['crop' => 'default', 'mediable_id' => $author->id, 'media_id' => $media->id]);
+            $this->createMediable(['crop' => 'mobile', 'mediable_id' => $author->id, 'media_id' => $media->id]);
+            return $author;
+        });
+
+        // 2 crops, 2 missing
+        $authorsMissingCrops = collect([1, 2])->map(function () {
+            $author = $this->createAuthor();
+            $media = $this->createMedia();
+            $this->createMediable(['crop' => 'default', 'mediable_id' => $author->id, 'media_id' => $media->id]);
+            return $author;
+        });
+
+        // 15 crops, 5 unused
+        $authorsWithUnusedCrops = collect([1, 2, 3, 4, 5])->map(function () {
+            $author = $this->createAuthor();
+            $media = $this->createMedia();
+            $this->createMediable(['crop' => 'default', 'mediable_id' => $author->id, 'media_id' => $media->id]);
+            $this->createMediable(['crop' => 'mobile', 'mediable_id' => $author->id, 'media_id' => $media->id]);
+            $this->createMediable(['crop' => 'unused', 'mediable_id' => $author->id, 'media_id' => $media->id]);
+            return $author;
+        });
+
+        $this->assertEquals(23, $this->mediables()->count());
+
+        $this->artisan('twill:refresh-crops', [
+                'modelName' => 'App\Models\Author',
+                'roleName' => 'avatar',
+            ])
+            ->assertExitCode(0);
+
+        // 2 crop added, 5 crops removed
+        $this->assertEquals(20, $this->mediables()->count());
+    }
+
+    public function testCanGenerateMissingCropForSlideshow()
+    {
+        $author = $this->createAuthor();
+
+        $slideshow = collect([1, 2, 3, 4, 5])->map(function () use ($author) {
+            $media = $this->createMedia();
+            $this->createMediable(['crop' => 'default', 'mediable_id' => $author->id, 'media_id' => $media->id]);
+            return $author;
+        });
+
+        $this->assertEquals(5, $this->mediables()->count());
+
+        $this->artisan('twill:refresh-crops', [
+                'modelName' => 'App\Models\Author',
+                'roleName' => 'avatar',
+            ])
+            ->assertExitCode(0);
+
+        $this->assertEquals(10, $this->mediables()->count());
+    }
+
+    public function testGeneratedCropsUseCorrectRatio()
+    {
+        // missing mobile crop
+        $author = $this->createAuthor();
+        $media = $this->createMedia();
+        $this->createMediable(['crop' => 'default', 'mediable_id' => $author->id, 'media_id' => $media->id]);
+
+        // missing default crop
+        $author2 = $this->createAuthor();
+        $media2 = $this->createMedia();
+        $this->createMediable(['crop' => 'mobile', 'mediable_id' => $author2->id, 'media_id' => $media2->id]);
+
+        $this->artisan('twill:refresh-crops', [
+                'modelName' => 'App\Models\Author',
+                'roleName' => 'avatar',
+            ])
+            ->assertExitCode(0);
+
+        // generated mobile crop
+        $imageData = $author->imageAsArray('avatar', 'mobile');
+        $this->assertEquals(1, $imageData['width'] / $imageData['height']);
+
+        // generated default crop
+        $imageData = $author2->imageAsArray('avatar', 'default');
+        $this->assertEquals(16/9, $imageData['width'] / $imageData['height']);
+    }
+}

--- a/tests/integration/Commands/RefreshCropsTest.php
+++ b/tests/integration/Commands/RefreshCropsTest.php
@@ -145,6 +145,7 @@ class RefreshCropsTest extends TestCase
             ])
             ->assertExitCode(1);
     }
+
     public function testCanDoDryRun()
     {
         $this->createAuthor();
@@ -352,5 +353,24 @@ class RefreshCropsTest extends TestCase
         // generated default crop
         $imageData = $author2->imageAsArray('avatar', 'default');
         $this->assertEquals(16/9, $imageData['width'] / $imageData['height']);
+    }
+
+    public function testPreservesMetadataForGeneratedCrops()
+    {
+        $this->createAuthor();
+        $this->createMedia();
+        $this->createMediable([
+            'crop' => 'default',
+            'metadatas' => '{"video": "/video.mp4", "altText": "Lorem ipsum", "caption": "Lorem ipsum"}',
+        ]);
+
+        $this->artisan('twill:refresh-crops', [
+                'modelName' => 'App\Models\Author',
+                'roleName' => 'avatar',
+            ])
+            ->assertExitCode(0);
+
+        $mediables = $this->mediables()->get();
+        $this->assertEquals($mediables[0]->metadatas, $mediables[1]->metadatas);
     }
 }


### PR DESCRIPTION
## Description

This complements https://github.com/area17/twill/pull/1258 and adds a new `twill:refresh-crops` Artisan command. The command takes a model name (FQCN or short name) and a role name. It then scans the existing `mediables` records to determine which crops are to be created or deleted. It supports a `--dry` flag to get an overview of the modifications to be made without actually touching the DB.

## Related Issues

Related to https://github.com/area17/twill/pull/1258

Addresses https://github.com/area17/twill/issues/1193