### PR TITLE
fix per default collapsed repeater blocks

### DIFF
--- a/frontend/js/components/Repeater.vue
+++ b/frontend/js/components/Repeater.vue
@@ -128,9 +128,8 @@
     },
     mounted: function () {
       const self = this
-      // if there are blocks, these should be all collapse by default
       this.$nextTick(function () {
-        if (self.savedBlocks.length > 0) self.collapseAllBlocks()
+        self.collapseAllBlocks()
       })
     }
   }


### PR DESCRIPTION
## Description

This problem is related to repeater blocks (https://twill.io/docs/#repeater). I found out in the code that child blocks within the repeater should be collapsed by default (e.g. when reloading the page). The small change in this pull request fixes the bug that this just doesn't happen and all child blocks are expanded by default.


