### PR TITLE
Adds titleKey to relatedBrowsers

### DIFF
--- a/src/Repositories/Behaviors/HandleRelatedBrowsers.php
+++ b/src/Repositories/Behaviors/HandleRelatedBrowsers.php
@@ -52,7 +52,7 @@ trait HandleRelatedBrowsers
     public function getFormFieldsHandleRelatedBrowsers($object, $fields)
     {
         foreach ($this->getRelatedBrowsers() as $browser) {
-            $fields['browsers'][$browser['browserName']] = $this->getFormFieldsForRelatedBrowser($object, $browser['relation']);
+            $fields['browsers'][$browser['browserName']] = $this->getFormFieldsForRelatedBrowser($object, $browser['relation'], $browser['titleKey']);
         }
 
         return $fields;
@@ -74,6 +74,7 @@ trait HandleRelatedBrowsers
                 'relation' => !empty($browser['relation']) ? $browser['relation'] : $this->inferRelationFromBrowserName($browserName),
                 'model' => !empty($browser['model']) ? $browser['model'] : $this->inferModelFromModuleName($moduleName),
                 'browserName' => $browserName,
+                'titleKey' => $browser['titleKey'] ?? 'title',
             ];
         })->values();
     }

--- a/src/Repositories/Behaviors/HandleRelatedBrowsers.php
+++ b/src/Repositories/Behaviors/HandleRelatedBrowsers.php
@@ -25,6 +25,7 @@ trait HandleRelatedBrowsers
      *  'publication' => [
      *      'relation' => 'magazine',
      *      'model' => 'Magazine'
+     *      'titleKey' => 'name'
      *  ]
      * ]
      *


### PR DESCRIPTION
<!--
  Thanks for opening a PR! Your contribution is much appreciated.
  Do you have any questions? Check out the contributing docs at https://github.com/area17/twill/blob/2.x/CONTRIBUTING.md, 
  or ask in this Pull Request and a Twill maintainer will be happy to help :)
-->

## Description

<!-- Write a description of the changes introduced by this PR -->
<!-- If this is introducing a new feature, it would be great if you can create a stub for documentation including bullet points for how to use the feature, code snippets, etc. -->

This PR allows developers to specify a custom title field when using the `$relatedBrowsers` to relate models:

```
class PostRepository extends ModuleRepository
{
    protected $relatedBrowsers = [
        'author' => ['titleKey' => 'name'],
    ];
}
```

Currently the titles are missing in the edit form unless you add a workaround like an attribute accessor for the title attribute.

I'd prefer if the system automatically defaulted to the value of `$titleColumnKey` specified in the author Controller but this doesn't appear to be possible

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->

#75
