### PR TITLE
Adds relatedBrowser option to indexColumns

### DIFF
--- a/docs/.sections/crud-modules.md
+++ b/docs/.sections/crud-modules.md
@@ -423,6 +423,11 @@ public function hydrate($object, $fields)
             'title' => 'Field title',
             'field' => 'presenterMethod',
             'present' => true,
+        ],
+        'relatedBrowserFieldName' => [ // related browser column
+            'title' => 'Field title',
+            'field' => 'relatedFieldToDisplay',
+            'relatedBrowser' => 'browserName',
         ]
     ];
 

--- a/src/Http/Controllers/Admin/ModuleController.php
+++ b/src/Http/Controllers/Admin/ModuleController.php
@@ -1098,6 +1098,13 @@ abstract class ModuleController extends Controller
             $value = $item->presentAdmin()->{$column['field']};
         }
 
+        if (isset($column['relatedBrowser']) && $column['relatedBrowser']) {
+            $field = 'relatedBrowser' . ucfirst($column['relatedBrowser']) . ucfirst($column['field']);
+            $value = $item->getRelated($column['relatedBrowser'])
+                ->pluck($column['field'])
+                ->join(', ');
+        }
+
         return [
             "$field" => $value,
         ];
@@ -1156,9 +1163,15 @@ abstract class ModuleController extends Controller
         unset($this->indexColumns[$this->titleColumnKey]);
 
         foreach ($this->indexColumns as $column) {
-            $columnName = isset($column['relationship'])
-            ? $column['relationship'] . ucfirst($column['field'])
-            : (isset($column['nested']) ? $column['nested'] : $column['field']);
+            if (isset($column['relationship'])) {
+                $columnName = $column['relationship'] . ucfirst($column['field']);
+            } elseif (isset($column['nested'])) {
+                $columnName = $column['nested'];
+            } elseif (isset($column['relatedBrowser'])) {
+                $columnName = 'relatedBrowser' . ucfirst($column['relatedBrowser']) . ucfirst($column['field']);
+            } else {
+                $columnName = $column['field'];
+            }
 
             array_push($tableColumns, [
                 'name' => $columnName,


### PR DESCRIPTION
<!--
  Thanks for opening a PR! Your contribution is much appreciated.
  Do you have any questions? Check out the contributing docs at https://github.com/area17/twill/blob/2.x/CONTRIBUTING.md, 
  or ask in this Pull Request and a Twill maintainer will be happy to help :)
-->

## Description

<!-- Write a description of the changes introduced by this PR -->
<!-- If this is introducing a new feature, it would be great if you can create a stub for documentation including bullet points for how to use the feature, code snippets, etc. -->

This PR allows `$indexColumns` to reference a value selected from a browser and stored in the related table:

```
class PostController extends BaseModuleController
{
    protected $indexColumns = [
        'author' => [
            'title' => 'Author',
            'field' => 'name',
            'relatedBrowser' => 'authors',
        ],
    ];
}
```

While this was possible using the presenter that seemed overkill to just show a related value.

## Alternative approach

Instead of having a separate `relatedBrowser` key I considered adding additional logic to the `relationship` type as it is a relationship we're accessing, just a special. It could look something like this:

```
protected $indexColumns = [
    'author' => [
        'title' => 'Author',
        'field' => 'name',
        'relationship' => 'relatedAuthors',
    ],
];
```
