### PR TITLE
Fix: NestedItem.vue - destroy functionality

### DIFF
--- a/frontend/js/components/table/nested/NestedItem.vue
+++ b/frontend/js/components/table/nested/NestedItem.vue
@@ -10,7 +10,7 @@
       <a17-table-cell-generic v-else v-bind="currentComponentProps(col)" @editInPlace="editInPlace" @update="tableCellUpdate"/>
     </span>
     <span class="nested-item__cell nested-item__cell--actions">
-      <a17-table-cell-actions v-bind="currentComponentProps()" @editInPlace="editInPlace" @update="tableCellUpdate" @restoreRow=" restoreRow" @deleteRow="deleteRow" @duplicateRow="duplicateRow"/>
+      <a17-table-cell-actions v-bind="currentComponentProps()" @editInPlace="editInPlace" @update="tableCellUpdate" @restoreRow=" restoreRow" @deleteRow="deleteRow" @destroyRow="destroyRow" @duplicateRow="duplicateRow"/>
     </span>
   </div>
 </template>


### PR DESCRIPTION
<!--
  Thanks for opening a PR! Your contribution is much appreciated.
  Do you have any questions? Check out the contributing docs at https://github.com/area17/twill/blob/2.x/CONTRIBUTING.md, 
  or ask in this Pull Request and a Twill maintainer will be happy to help :)
-->

## Description

This allows one to destroy an item from the trash. Currently you can only bulk destroy from the trash, but once this commit is added, you will be able to destroy from the dropdown at each individual item in the trash.
