### PR TITLE
feat: Support vendor form fields and Vue components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ assets/dist/*
 frontend/js/components/blocks/customs/*
 frontend/js/components/customs/*
 !frontend/js/components/customs/.keep
+frontend/js/components/customs-vendor/*
+!frontend/js/components/customs-vendor/.keep
 .DS_Store
 public/
 tests/coverage

--- a/config/twill.php
+++ b/config/twill.php
@@ -181,6 +181,7 @@ return [
     'manifest_file' => 'twill-manifest.json',
     'vendor_path' => 'vendor/area17/twill',
     'custom_components_resource_path' => 'assets/js/components',
+    'vendor_components_resource_path' => 'assets/vendor/js/components',
     'build_timeout' => 300,
     'internal_icons' => [
         'content-editor.svg',

--- a/frontend/js/main-form.js
+++ b/frontend/js/main-form.js
@@ -140,6 +140,13 @@ importedComponents.keys().map(block => {
   return Vue.component(componentName, importedComponents(block).default)
 })
 
+// Vendor form components
+const importedVendorComponents = require.context('@/components/customs-vendor/', true, /\.(js|vue)$/i)
+importedVendorComponents.keys().map(block => {
+  const componentName = extractComponentNameFromContextKey(block)
+  return Vue.component(componentName, importedVendorComponents(block).default)
+})
+
 /* eslint-disable no-new */
 /* eslint no-unused-vars: "off" */
 window[process.env.VUE_APP_NAME].vm = window.vm = new Vue({

--- a/src/Commands/Build.php
+++ b/src/Commands/Build.php
@@ -84,6 +84,9 @@ class Build extends Command
         $this->copyComponents();
         sleep(1);
 
+        $this->copyVendorComponents();
+        sleep(1);
+
         $this->info('');
         $progressBar->setMessage("Building assets...\n\n");
         $progressBar->advance();
@@ -208,9 +211,30 @@ class Build extends Command
         }
 
         $this->filesystem->cleanDirectory($twillCustomComponentsPath);
+        $this->filesystem->put($twillCustomComponentsPath . '/.keep', '');
 
         if ($this->filesystem->exists($localCustomComponentsPath)) {
             $this->filesystem->copyDirectory($localCustomComponentsPath, $twillCustomComponentsPath);
+        }
+    }
+
+    /**
+     * @return void
+     */
+    private function copyVendorComponents()
+    {
+        $localVendorComponentsPath = resource_path(config('twill.vendor_components_resource_path', 'assets/vendor/js/components'));
+        $twillVendorComponentsPath = base_path(config('twill.vendor_path')) . '/frontend/js/components/customs-vendor';
+
+        if (!$this->filesystem->exists($twillVendorComponentsPath)) {
+            $this->filesystem->makeDirectory($twillVendorComponentsPath, 0755, true);
+        }
+
+        $this->filesystem->cleanDirectory($twillVendorComponentsPath);
+        $this->filesystem->put($twillVendorComponentsPath . '/.keep', '');
+
+        if ($this->filesystem->exists($localVendorComponentsPath)) {
+            $this->filesystem->copyDirectory($localVendorComponentsPath, $twillVendorComponentsPath);
         }
     }
 }

--- a/src/PackageServiceProvider.php
+++ b/src/PackageServiceProvider.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace A17\Twill;
+
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\ServiceProvider;
+
+class PackageServiceProvider extends ServiceProvider
+{
+    protected function registerVueComponentsDirectory($path)
+    {
+        $this->publishes(
+            [$path => resource_path(config('twill.vendor_components_resource_path'))],
+            'components'
+        );
+    }
+
+    protected function registerBlocksDirectory($path)
+    {
+        $blocks = Config::get('twill.block_editor.directories.source.blocks');
+
+        $blocks[] = [
+            'path' => $path,
+            'source' => 'vendor',
+        ];
+
+        Config::set('twill.block_editor.directories.source.blocks', $blocks);
+    }
+
+    protected function registerRepeatersDirectory($path)
+    {
+        $repeaters = Config::get('twill.block_editor.directories.source.repeaters');
+
+        $repeaters[] = [
+            'path' => $path,
+            'source' => 'vendor',
+        ];
+
+        Config::set('twill.block_editor.directories.source.repeaters', $repeaters);
+    }
+}

--- a/src/TwillServiceProvider.php
+++ b/src/TwillServiceProvider.php
@@ -329,6 +329,8 @@ class TwillServiceProvider extends ServiceProvider
     }
 
     /**
+     * Resolve and include a given view expression in the project, Twill internals or a package.
+     *
      * @param string $view
      * @param string $expression
      * @return string
@@ -337,7 +339,13 @@ class TwillServiceProvider extends ServiceProvider
     {
         [$name] = str_getcsv($expression, ',', '\'');
 
-        $partialNamespace = view()->exists('admin.' . $view . $name) ? 'admin.' : 'twill::';
+        if (preg_match('/::/', $name)) {
+            // if there's a namespace separator, we'll assume it's a package
+            [$namespace, $name] = preg_split('/::/', $name);
+            $partialNamespace = "$namespace::admin.";
+        } else {
+            $partialNamespace = view()->exists('admin.' . $view . $name) ? 'admin.' : 'twill::';
+        }
 
         $view = $partialNamespace . $view . $name;
 


### PR DESCRIPTION
## Description

This is an exploratory PR to add the ability to publish custom form fields and components from composer packages.

It's a bit rudimentary... Here's what's currently possible:

- publish form field partials (supports view namespacing)
- publish Vue components (no namespacing, all components go to `resources/assets/vendor/js/components/`)

Some ideas for improvements:

- [x] Publish block and repeater Blade templates
- [ ] Publish block Vue components
- [ ] Publish other types of assets (styles, icons)
- [ ] Proper namespacing of vendor assets

### Example repository

https://github.com/pboivin/twill-numeric-input

A simple form field that wraps the [`vue-numeric`](https://github.com/kevinongko/vue-numeric) package to provide a numeric input field with a few formatting options.

![numeric-input](https://user-images.githubusercontent.com/7805679/145651445-aed856f8-5ba9-4c4d-ab5d-96be95aa55bf.png)

### Installation 

Add to composer.json:
```
    "repositories": [
        {
            "type": "vcs",
            "url": "https://github.com/pboivin/twill-numeric-input"
        }
    ],
```

Run:
```
npm install vue-numeric --save

composer require pboivin/twill-numeric-input 

php artisan vendor:publish --provider='PBoivin\TwillNumericInput\ServiceProvider' --tag=components

php artisan twill:build
```

## Usage

```
    @formField('twill-numeric-input::field', [
        'name' => 'price',
        'label' => 'Price',
        'thousandSeparator' => ',',
    ])
```

## Related Issues

—