### PR TITLE
fix: Use case insensitive like operator in filterHandleTranslations

### DIFF
--- a/src/Repositories/Behaviors/HandleTranslations.php
+++ b/src/Repositories/Behaviors/HandleTranslations.php
@@ -109,7 +109,7 @@ trait HandleTranslations
             $query->whereHas('translations', function ($q) use ($scopes, $attributes) {
                 foreach ($attributes as $attribute) {
                     if (isset($scopes[$attribute]) && is_string($scopes[$attribute])) {
-                        $q->where($attribute, 'like', '%' . $scopes[$attribute] . '%');
+                        $q->where($attribute, $this->getLikeOperator(), '%' . $scopes[$attribute] . '%');
                     }
                 }
             });

--- a/src/Repositories/ModuleRepository.php
+++ b/src/Repositories/ModuleRepository.php
@@ -917,7 +917,7 @@ abstract class ModuleRepository
     /**
      * @return string
      */
-    private function getLikeOperator()
+    protected function getLikeOperator()
     {
         if (DB::connection()->getPDO()->getAttribute(PDO::ATTR_DRIVER_NAME) === 'pgsql') {
             return 'ILIKE';


### PR DESCRIPTION
## Description

Small fix to ensure case insensitive searches on PostgreSQL.

The `getLikeOperator` method visibility was changed from `private` to `protected` to favor extensibility.

## Related Issues

https://github.com/area17/twill/discussions/1320