### PR TITLE
Fix singleton routing for primary and secondary navigation support

### DIFF
--- a/src/Helpers/routes_helpers.php
+++ b/src/Helpers/routes_helpers.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Support\Facades\Request;
 use Illuminate\Support\Str;
+use Illuminate\Support\Facades\Route;
 
 if (!function_exists('moduleRoute')) {
     /**
@@ -12,7 +13,7 @@ if (!function_exists('moduleRoute')) {
      * @param bool $absolute
      * @return string
      */
-    function moduleRoute($moduleName, $prefix, $action='', $parameters = [], $absolute = true)
+    function moduleRoute($moduleName, $prefix, $action = '', $parameters = [], $absolute = true)
     {
         // Fix module name case
         $moduleName = Str::camel($moduleName);
@@ -65,7 +66,6 @@ if (!function_exists('getNavigationUrl')) {
 
         return !empty($element['route']) ? route($element['route'], $element['params'] ?? []) : '#';
     }
-
 }
 
 if (!function_exists('isActiveNavigation')) {
@@ -86,5 +86,39 @@ if (!function_exists('isActiveNavigation')) {
         $urlsAreMatching = ($navigationElement['raw'] ?? false) && Str::endsWith(Request::url(), $navigationElement['route']);
 
         return $urlsAreMatching;
+    }
+}
+
+if (!function_exists('twillRouteGroupPrefix')) {
+    function twillRouteGroupPrefix()
+    {
+        $groupPrefix = trim(
+            str_replace('/', '.', Route::getLastGroupPrefix()),
+            '.'
+        );
+
+        if (!empty(config('twill.admin_app_path'))) {
+            $groupPrefix = ltrim(
+                str_replace(
+                    config('twill.admin_app_path'),
+                    '',
+                    $groupPrefix
+                ),
+                '.'
+            );
+        }
+
+        return $groupPrefix;
+    }
+}
+
+if (!function_exists('lastRouteGroupName')) {
+    function lastRouteGroupName()
+    {
+        // Get the current route groups
+        $routeGroups = Route::getGroupStack() ?? [];
+
+        // Get the name prefix of the last group
+        return end($routeGroups)['as'] ?? '';
     }
 }

--- a/src/Helpers/routes_helpers.php
+++ b/src/Helpers/routes_helpers.php
@@ -2,7 +2,6 @@
 
 use Illuminate\Support\Facades\Request;
 use Illuminate\Support\Str;
-use Illuminate\Support\Facades\Route;
 
 if (!function_exists('moduleRoute')) {
     /**
@@ -86,39 +85,5 @@ if (!function_exists('isActiveNavigation')) {
         $urlsAreMatching = ($navigationElement['raw'] ?? false) && Str::endsWith(Request::url(), $navigationElement['route']);
 
         return $urlsAreMatching;
-    }
-}
-
-if (!function_exists('twillRouteGroupPrefix')) {
-    function twillRouteGroupPrefix()
-    {
-        $groupPrefix = trim(
-            str_replace('/', '.', Route::getLastGroupPrefix()),
-            '.'
-        );
-
-        if (!empty(config('twill.admin_app_path'))) {
-            $groupPrefix = ltrim(
-                str_replace(
-                    config('twill.admin_app_path'),
-                    '',
-                    $groupPrefix
-                ),
-                '.'
-            );
-        }
-
-        return $groupPrefix;
-    }
-}
-
-if (!function_exists('lastRouteGroupName')) {
-    function lastRouteGroupName()
-    {
-        // Get the current route groups
-        $routeGroups = Route::getGroupStack() ?? [];
-
-        // Get the name prefix of the last group
-        return end($routeGroups)['as'] ?? '';
     }
 }

--- a/src/RouteServiceProvider.php
+++ b/src/RouteServiceProvider.php
@@ -290,18 +290,12 @@ class RouteServiceProvider extends ServiceProvider
                 );
             }
 
-            $lastRouteGroupName = RouteServiceProvider::lastRouteGroupName();
+            $lastRouteGroupName = RouteServiceProvider::getLastRouteGroupName();
 
-            $groupPrefix = RouteServiceProvider::twillRouteGroupPrefix();
+            $groupPrefix = RouteServiceProvider::getGroupPrefix();
 
             // Check if name will be a duplicate, and prevent if needed/allowed
-            if (!empty($groupPrefix) &&
-                (
-                    blank($lastRouteGroupName) ||
-                    config('twill.allow_duplicates_on_route_names', true) ||
-                    (!Str::endsWith($lastRouteGroupName, ".{$groupPrefix}."))
-                )
-            ) {
+            if (RouteServiceProvider::shouldPrefixRouteName($groupPrefix, $lastRouteGroupName)) {
                 $customRoutePrefix = "{$groupPrefix}.{$slug}";
                 $resourceCustomGroupPrefix = "{$groupPrefix}.";
             } else {
@@ -384,18 +378,12 @@ class RouteServiceProvider extends ServiceProvider
 
             Route::module($pluralSlug, $options, $resource_options, $resource);
 
-            $lastRouteGroupName = RouteServiceProvider::lastRouteGroupName();
+            $lastRouteGroupName = RouteServiceProvider::getLastRouteGroupName();
 
-            $groupPrefix = RouteServiceProvider::twillRouteGroupPrefix();
+            $groupPrefix = RouteServiceProvider::getGroupPrefix();
 
             // Check if name will be a duplicate, and prevent if needed/allowed
-            if (
-                !empty($groupPrefix) &&
-                (blank($lastRouteGroupName) ||
-                    config('twill.allow_duplicates_on_route_names', true) ||
-                    (!Str::endsWith($lastRouteGroupName, ".{$groupPrefix}."))
-                )
-            ) {
+            if (RouteServiceProvider::shouldPrefixRouteName($groupPrefix, $lastRouteGroupName)) {
                 $singletonRouteName = "{$groupPrefix}.{$slug}";
             } else {
                 $singletonRouteName = $slug;
@@ -405,7 +393,14 @@ class RouteServiceProvider extends ServiceProvider
         });
     }
 
-    public static function lastRouteGroupName()
+    public static function shouldPrefixRouteName($groupPrefix, $lastRouteGroupName)
+    {
+        return !empty($groupPrefix) && (blank($lastRouteGroupName) ||
+            config('twill.allow_duplicates_on_route_names', true) ||
+            (!Str::endsWith($lastRouteGroupName, ".{$groupPrefix}.")));
+    }
+
+    public static function getLastRouteGroupName()
     {
         // Get the current route groups
         $routeGroups = Route::getGroupStack() ?? [];
@@ -414,7 +409,7 @@ class RouteServiceProvider extends ServiceProvider
         return end($routeGroups)['as'] ?? '';
     }
 
-    public static function twillRouteGroupPrefix()
+    public static function getGroupPrefix()
     {
         $groupPrefix = trim(
             str_replace('/', '.', Route::getLastGroupPrefix()),

--- a/src/RouteServiceProvider.php
+++ b/src/RouteServiceProvider.php
@@ -29,7 +29,6 @@ class RouteServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        require_once __DIR__ . '/Helpers/routes_helpers.php';
         $this->registerRouteMiddlewares($this->app->get('router'));
         $this->registerMacros();
         parent::boot();
@@ -291,9 +290,9 @@ class RouteServiceProvider extends ServiceProvider
                 );
             }
 
-            $lastRouteGroupName = lastRouteGroupName();
+            $lastRouteGroupName = RouteServiceProvider::lastRouteGroupName();
 
-            $groupPrefix = twillRouteGroupPrefix();
+            $groupPrefix = RouteServiceProvider::twillRouteGroupPrefix();
 
             // Check if name will be a duplicate, and prevent if needed/allowed
             if (!empty($groupPrefix) &&
@@ -385,9 +384,9 @@ class RouteServiceProvider extends ServiceProvider
 
             Route::module($pluralSlug, $options, $resource_options, $resource);
 
-            $lastRouteGroupName = lastRouteGroupName();
+            $lastRouteGroupName = RouteServiceProvider::lastRouteGroupName();
 
-            $groupPrefix = twillRouteGroupPrefix();
+            $groupPrefix = RouteServiceProvider::twillRouteGroupPrefix();
 
             // Check if name will be a duplicate, and prevent if needed/allowed
             if (
@@ -404,5 +403,35 @@ class RouteServiceProvider extends ServiceProvider
 
             Route::get($slug, $modelName . 'Controller@editSingleton')->name($singletonRouteName);
         });
+    }
+
+    public static function lastRouteGroupName()
+    {
+        // Get the current route groups
+        $routeGroups = Route::getGroupStack() ?? [];
+
+        // Get the name prefix of the last group
+        return end($routeGroups)['as'] ?? '';
+    }
+
+    public static function twillRouteGroupPrefix()
+    {
+        $groupPrefix = trim(
+            str_replace('/', '.', Route::getLastGroupPrefix()),
+            '.'
+        );
+
+        if (!empty(config('twill.admin_app_path'))) {
+            $groupPrefix = ltrim(
+                str_replace(
+                    config('twill.admin_app_path'),
+                    '',
+                    $groupPrefix
+                ),
+                '.'
+            );
+        }
+
+        return $groupPrefix;
     }
 }


### PR DESCRIPTION
<!--
  Thanks for opening a PR! Your contribution is much appreciated.
  Do you have any questions? Check out the contributing docs at https://github.com/area17/twill/blob/2.x/CONTRIBUTING.md, 
  or ask in this Pull Request and a Twill maintainer will be happy to help :)
-->

## Description

When using the new `singleton` route macro, it was not possible to prefix it in a router group so that it could be configured to be accessible from the primary or secondary level of navigation. This PR fixes the issue by refactoring some of the logic in the `module` macro into helpers.

## Related Issues

Related to #1178 