### PR TITLE
#1031: Add metadata documentation for media.

### DIFF
--- a/docs/src/.vuepress/sidebar.js
+++ b/docs/src/.vuepress/sidebar.js
@@ -262,6 +262,10 @@ module.exports = [
             "path": "/media-library/file-library.html",
           },
           {
+            "title": "Custom metadata",
+            "path": "/media-library/custom-metadata.html",
+          },
+          {
             "title": "Imgix and S3 Direct Uploads",
             "path": "/media-library/imgix-and-s3-direct-uploads.html",
           },

--- a/docs/src/media-library/custom-metadata.md
+++ b/docs/src/media-library/custom-metadata.md
@@ -1,0 +1,70 @@
+---
+pageClass: twill-doc
+---
+
+# Custom metadata
+
+By default media comes with a few metadata attributes that can be filled in from the media managers: 
+Tags, Alt text and caption.
+
+Say we want to add more metadata, some of which might be translatable. To do this we have to go through a few
+steps. In the steps below we will add a translatable field for attribution and a non translatable field for source.
+
+First thing we have to do is add the new metadata fields in the twill settings.
+
+In the twill config (`config/twill.php`) we add the following:
+
+```php
+return [
+    'media_library' => [
+        'extra_metadatas_fields' => [
+            [
+                'name' => 'source',
+                'label' => 'source',
+            ],
+            [
+                'name' => 'attribution',
+                'label' => 'attribution',
+            ],
+        ],
+        'translatable_metadatas_fields' => [
+            'attribution',
+        ],
+    ],
+];
+```
+
+This will already ensure the fields are visible from the media manager. However saving is not yet possible because the
+database fields are missing. So to make everything work we have to write a migration.
+
+For regular fields, it is best to use a text field, for translatable fields we suggest to use a json field.
+
+```php
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddFieldsToMedia extends Migration
+{
+    public function up()
+    {
+        Schema::table(config('twill.medias_table', 'twill_medias'), function (Blueprint $table) {
+            $table->text('source')->nullable();
+            $table->json('attribution')->nullable();
+        });
+    }
+
+    public function down()
+    {
+        Schema::table(config('twill.medias_table', 'twill_medias'), function (Blueprint $table) {
+            $table->dropColumn('source');
+            $table->dropColumn('attribution');
+        });
+    }
+}
+```
+
+And that is all. The most important part is to make sure your migration fields are named the same as your custom metadata
+values in the twill config.


### PR DESCRIPTION
## Description

Adds documentation on how to use custom metadata for media

Direct link to read: https://github.com/area17/twill/blob/8d80b88fb3ff187801f2610f268dae7cebb763f2/docs/src/media-library/custom-metadata.md

## Related Issues

Fixes #1031
