### PR TITLE
#1351: Add crop missing exception

### DIFF
--- a/src/Exceptions/MediaCropNotFoundException.php
+++ b/src/Exceptions/MediaCropNotFoundException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace A17\Twill\Exceptions;
+
+class MediaCropNotFoundException extends \Exception
+{
+    public function __construct(string $crop)
+    {
+        $message = "Found media but could not find the crop '$crop'";
+        parent::__construct($message);
+    }
+}

--- a/src/Models/Behaviors/HasMedias.php
+++ b/src/Models/Behaviors/HasMedias.php
@@ -66,7 +66,7 @@ trait HasMedias
             });
         }
 
-        if ($foundMedia && !$media && !app()->environment('production')) {
+        if ($foundMedia && !$media && config('app.debug')) {
             // In this case we found the media but not the crop because our result is still empty.
             throw new MediaCropNotFoundException($crop);
         }


### PR DESCRIPTION
## Description

This pr now throws an exception when a media is found but there is no crop found.

`"message": "Found media but could not find the crop 'test' (View: /Users/rob/Sites/twill/resources/views/site/blocks/example.blade.php)",`

Together with the changes made in #1308, it will be clear during block development that something is missing.

The exception will not be thrown in a production environment.

## Related Issues

Fixes #1351 