### PR TITLE
#1352: Ensure lqip data is always available.

### DIFF
--- a/config/glide.php
+++ b/config/glide.php
@@ -14,7 +14,7 @@ return [
     'source' => env('GLIDE_SOURCE', storage_path('app/public/' . config('twill.media_library.local_path'))),
     'cache' => env('GLIDE_CACHE', storage_path('app')),
     'cache_path_prefix' => env('GLIDE_CACHE_PATH_PREFIX', 'glide_cache'),
-    'base_url' => env('GLIDE_BASE_URL', null),
+    'base_url' => env('GLIDE_BASE_URL', config('app.url')),
     'base_path' => env('GLIDE_BASE_PATH', 'img'),
     'use_signed_urls' => env('GLIDE_USE_SIGNED_URLS', false),
     'sign_key' => env('GLIDE_SIGN_KEY'),

--- a/src/Commands/RefreshLQIP.php
+++ b/src/Commands/RefreshLQIP.php
@@ -71,12 +71,9 @@ class RefreshLQIP extends Command
 
                     $url = ImageService::getLQIPUrl($uuid, $crop_params + ['w' => $lqip_width]);
 
-                    if ($imageService === Glide::class) {
-                        // Glide is a local imaging service so we should make sure we also utilize the local url.
-                        // This solution might not work at all in some cases.
-                        // I feel like this is not optimal and we could maybe directly use the glide api in this case
-                        // but maybe that is not worth the effort (for now).
-                        $url = url($url);
+                    if (($imageService === Glide::class) && !config('twill.glide.base_url')) {
+                        $this->error('Cannot generate LQIP. Missing glide base url. Please set GLIDE_BASE_URL in your .env');
+                        return;
                     }
 
                     try {

--- a/src/Models/Behaviors/HasMedias.php
+++ b/src/Models/Behaviors/HasMedias.php
@@ -4,7 +4,7 @@ namespace A17\Twill\Models\Behaviors;
 
 use A17\Twill\Models\Media;
 use Illuminate\Support\Arr;
-use ImageService;
+use A17\Twill\Services\MediaLibrary\ImageService;
 
 trait HasMedias
 {

--- a/src/Models/Media.php
+++ b/src/Models/Media.php
@@ -2,11 +2,10 @@
 
 namespace A17\Twill\Models;
 
-use Exception;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
-use ImageService;
+use A17\Twill\Services\MediaLibrary\ImageService;
 
 class Media extends Model
 {
@@ -78,6 +77,7 @@ class Media extends Model
             'tags' => $this->tags->map(function ($tag) {
                 return $tag->name;
             }),
+            'lqip_data' => $this->pivot->lqip_data ?? null,
             'deleteUrl' => $this->canDeleteSafely() ? moduleRoute('medias', 'media-library', 'destroy', $this->id) : null,
             'updateUrl' => route('admin.media-library.medias.single-update'),
             'updateBulkUrl' => route('admin.media-library.medias.bulk-update'),
@@ -143,7 +143,7 @@ class Media extends Model
         if ($this->update($fields) && $this->isReferenced())
         {
             DB::table(config('twill.mediables_table', 'twill_mediables'))->where('media_id', $this->id)->get()->each(function ($mediable) use ($prevWidth, $prevHeight) {
-                
+
                 if ($prevWidth != $this->width) {
                     $mediable->crop_x = 0;
                     $mediable->crop_w = $this->width;

--- a/src/Models/Media.php
+++ b/src/Models/Media.php
@@ -77,7 +77,6 @@ class Media extends Model
             'tags' => $this->tags->map(function ($tag) {
                 return $tag->name;
             }),
-            'lqip_data' => $this->pivot->lqip_data ?? null,
             'deleteUrl' => $this->canDeleteSafely() ? moduleRoute('medias', 'media-library', 'destroy', $this->id) : null,
             'updateUrl' => route('admin.media-library.medias.single-update'),
             'updateBulkUrl' => route('admin.media-library.medias.bulk-update'),

--- a/src/Repositories/Behaviors/HandleMedias.php
+++ b/src/Repositories/Behaviors/HandleMedias.php
@@ -91,7 +91,6 @@ trait HandleMedias
                                     'crop_h' => $cropData['height'],
                                     'crop_x' => $cropData['x'],
                                     'crop_y' => $cropData['y'],
-                                    'lqip_data' => $media['lqip_data'] ?? null,
                                     'metadatas' => json_encode($customMetadatas),
                                 ]);
                             }
@@ -107,7 +106,6 @@ trait HandleMedias
                                     'crop_h' => null,
                                     'crop_x' => null,
                                     'crop_y' => null,
-                                    'lqip_data' => $media['lqip_data'] ?? null,
                                     'metadatas' => json_encode($customMetadatas),
                                 ]);
                             }

--- a/src/Repositories/Behaviors/HandleMedias.php
+++ b/src/Repositories/Behaviors/HandleMedias.php
@@ -91,6 +91,7 @@ trait HandleMedias
                                     'crop_h' => $cropData['height'],
                                     'crop_x' => $cropData['x'],
                                     'crop_y' => $cropData['y'],
+                                    'lqip_data' => $media['lqip_data'] ?? null,
                                     'metadatas' => json_encode($customMetadatas),
                                 ]);
                             }
@@ -106,6 +107,7 @@ trait HandleMedias
                                     'crop_h' => null,
                                     'crop_x' => null,
                                     'crop_y' => null,
+                                    'lqip_data' => $media['lqip_data'] ?? null,
                                     'metadatas' => json_encode($customMetadatas),
                                 ]);
                             }

--- a/src/Services/MediaLibrary/Glide.php
+++ b/src/Services/MediaLibrary/Glide.php
@@ -262,9 +262,7 @@ class Glide implements ImageServiceInterface
             $fpY = number_format($fpY, 0, ".", "");
             $fpZ = number_format($fpZ, 4, ".", "");
 
-            $params = ['fit' => 'crop-' . $fpX . '-' . $fpY . '-' . $fpZ];
-
-            return $params;
+            return ['fit' => 'crop-' . $fpX . '-' . $fpY . '-' . $fpZ];
         }
 
         return [];
@@ -296,6 +294,8 @@ class Glide implements ImageServiceInterface
             case 'azure':
                 $endpoint = azureEndpoint($libraryDisk);
                 break;
+            default:
+                $endpoint = '';
         }
 
         return $endpoint . '/' . $id;

--- a/src/Services/MediaLibrary/Glide.php
+++ b/src/Services/MediaLibrary/Glide.php
@@ -271,7 +271,7 @@ class Glide implements ImageServiceInterface
     }
 
     /**
-     * @param string $id 
+     * @param string $id
      * @return string
      */
     private function getOriginalMediaUrl($id)
@@ -285,9 +285,6 @@ class Glide implements ImageServiceInterface
         if ((Str::endsWith($id, '.svg') && $addParamsToSvgs) || !Str::endsWith($id, $originalMediaForExtensions)) {
             return null;
         }
-
-        /** @var string $endpoint */
-        $endpoint;
 
         switch ($endpointType) {
             case 'local':

--- a/src/Services/MediaLibrary/ImageServiceDefaults.php
+++ b/src/Services/MediaLibrary/ImageServiceDefaults.php
@@ -12,10 +12,7 @@ trait ImageServiceDefaults
         'crop_h',
     ];
 
-    /**
-     * @return string
-     */
-    public function getSocialFallbackUrl()
+    public function getSocialFallbackUrl(): string
     {
         if ($id = config("twill.seo.image_default_id")) {
             return $this->getSocialUrl($id);
@@ -24,10 +21,7 @@ trait ImageServiceDefaults
         return config("twill.seo.image_local_fallback");
     }
 
-    /**
-     * @return string
-     */
-    public function getTransparentFallbackUrl()
+    public function getTransparentFallbackUrl(): string
     {
         return "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7";
     }


### PR DESCRIPTION
## Description

This pr ensures that lqip_data is always passed around to make sure the get method works.

If there are more ways to get lqip data let me know so I can double check.

I also made a change in the method for generating lqip, but please have a look at it yourself @ifox  as I am not entirely sure of that solution.

## Related Issues

Fixes #1352
