### PR TITLE
#1305: Do not show dialog when content is not changed + ...

### DIFF
--- a/frontend/js/components/Publisher.vue
+++ b/frontend/js/components/Publisher.vue
@@ -11,9 +11,6 @@
       <div class="publisher__item" v-if="revisions.length">
         <a href="#" class="publisher__link" @click.prevent="openPreview"><span v-svg symbol="preview"></span><span class="f--link-underlined--o">{{ $trans('publisher.preview') }}</span></a>
       </div>
-      <div class="publisher__item publisher__unsaved-changes" v-if="hasUnsavedChanges">
-        <span v-svg symbol="edit"></span> {{ $trans('publisher.unsaved-changes') }}
-      </div>
       <div class="publisher__item publisher__item--btns">
         <a17-multibutton @button-clicked="buttonClicked" :options="submitOptions" type="submit" :message="submitDisableMessage"></a17-multibutton>
       </div>

--- a/frontend/js/components/Publisher.vue
+++ b/frontend/js/components/Publisher.vue
@@ -11,6 +11,9 @@
       <div class="publisher__item" v-if="revisions.length">
         <a href="#" class="publisher__link" @click.prevent="openPreview"><span v-svg symbol="preview"></span><span class="f--link-underlined--o">{{ $trans('publisher.preview') }}</span></a>
       </div>
+      <div class="publisher__item publisher__unsaved-changes" v-if="hasUnsavedChanges">
+        <span v-svg symbol="edit"></span> {{ $trans('publisher.unsaved-changes') }}
+      </div>
       <div class="publisher__item publisher__item--btns">
         <a17-multibutton @button-clicked="buttonClicked" :options="submitOptions" type="submit" :message="submitDisableMessage"></a17-multibutton>
       </div>
@@ -122,7 +125,8 @@
         visibility: state => state.publication.visibility,
         visibilityOptions: state => state.publication.visibilityOptions,
         reviewProcess: state => state.publication.reviewProcess,
-        submitDisableMessage: state => state.publication.submitDisableMessage
+        submitDisableMessage: state => state.publication.submitDisableMessage,
+        hasUnsavedChanges: state => state.publication.hasUnsavedChanges
       }),
       ...mapGetters([
         'publishedLanguages',
@@ -199,6 +203,14 @@
 
   .revisionaccordion__list {
     padding:20px;
+  }
+
+  .publisher__unsaved-changes {
+    height:$trigger_height;
+    line-height:$trigger_height;
+    color: $color__warningDark;
+    padding:0 20px;
+    display:block;
   }
 
   .publisher__link {

--- a/frontend/js/main-form.js
+++ b/frontend/js/main-form.js
@@ -1,7 +1,7 @@
 import Vue from 'vue'
 import { mapState, mapGetters } from 'vuex'
 import store from '@/store'
-import { FORM } from '@/store/mutations'
+import { FORM, PUBLICATION } from '@/store/mutations'
 import ACTIONS from '@/store/actions'
 import { FORM_MUTATIONS_TO_SUBSCRIBE } from '@/store/mutations/subscribers'
 
@@ -58,6 +58,7 @@ import formatPermalink from '@/mixins/formatPermalink'
 import editorMixin from '@/mixins/editor.js'
 import BlockMixin from '@/mixins/block'
 import retrySubmitMixin from '@/mixins/retrySubmit'
+import _ from 'lodash'
 
 // configuration
 Vue.use(A17Config)
@@ -207,13 +208,61 @@ window[process.env.VUE_APP_NAME].vm = window.vm = new Vue({
           this.unSubscribe()
         }
       })
+    },
+    watchForFormUpdates (module, prop) {
+      const sortArrays = module === 'form' && (prop === 'fields' || prop === 'modalFields')
+      // Store the original form state, we will compare against this. It is important to sort it the same way as when
+      // we are comparing so that order changes in the fields dont matter.
+      const originalForm = this.sortObjectArraysDeep(_.cloneDeep(this.$store.state[module][prop]), sortArrays)
+      this.$store.watch((state) => {
+        return state[module][prop]
+      }, (newForm) => {
+        const compareTo = this.sortObjectArraysDeep(_.cloneDeep(newForm), sortArrays)
+        this.isFormUpdated = !_.isEqual(originalForm, compareTo)
+        this.$store.commit(PUBLICATION.UPDATE_HAS_UNSAVED_CHANGES, this.isFormUpdated)
+      }, {
+        deep: true
+      })
+    },
+    sortArrayByFirstKey (data) {
+      return _.sortBy(data, (o) => {
+        if (typeof o === 'object') {
+          const firstKey = Object.keys(o)[0]
+          return o[firstKey]
+        }
+        return o
+      })
+    },
+    sortObjectArraysDeep (data, sortArrays = false) {
+      if (Array.isArray(data) && sortArrays) {
+        data = this.sortArrayByFirstKey(data)
+      } else {
+        Object.keys(data).forEach(key => {
+          if (Array.isArray(data[key])) {
+            if (sortArrays) {
+              data[key] = this.sortArrayByFirstKey(data[key])
+            }
+          } else if (typeof data[key] === 'object') {
+            data[key] = this.sortObjectArraysDeep(data[key])
+          }
+        })
+      }
+
+      return data
     }
   },
   mounted: function () {
+    // Hook up the confirmation popup.
+    window.onbeforeunload = this.confirmExit
+
     // Form : confirm exit or lock panel if form is changed
     this.$nextTick(() => {
-      window.onbeforeunload = this.confirmExit
-      this.mutationsSubscribe()
+      this.watchForFormUpdates('mediaLibrary', 'selected')
+      this.watchForFormUpdates('form', 'fields')
+      this.watchForFormUpdates('form', 'modalFields')
+      this.watchForFormUpdates('blocks', 'blocks')
+      this.watchForFormUpdates('browser', 'selected')
+      this.watchForFormUpdates('repeaters', 'repeaters')
     })
   },
   beforeDestroy: function () {

--- a/frontend/js/store/modules/publication.js
+++ b/frontend/js/store/modules/publication.js
@@ -12,6 +12,7 @@ const state = {
   visibility: window[process.env.VUE_APP_NAME].STORE.publication.visibility || false,
   reviewProcess: window[process.env.VUE_APP_NAME].STORE.publication.reviewProcess || [],
   createWithoutModal: window[process.env.VUE_APP_NAME].STORE.publication.createWithoutModal || false,
+  hasUnsavedChanges: false,
   saveType: undefined,
   visibilityOptions: [
     {
@@ -160,6 +161,9 @@ const mutations = {
   },
   [PUBLICATION.UPDATE_SAVE_TYPE] (state, newValue) {
     state.saveType = newValue
+  },
+  [PUBLICATION.UPDATE_HAS_UNSAVED_CHANGES] (state, newValue) {
+    state.hasUnsavedChanges = newValue
   }
 }
 

--- a/frontend/js/store/mutations/publication.js
+++ b/frontend/js/store/mutations/publication.js
@@ -6,6 +6,7 @@ export const UPDATE_PUBLISH_SUBMIT = 'updatePublishSubmit'
 export const UPDATE_PUBLISH_VISIBILITY = 'updatePublishVisibility'
 export const UPDATE_REVIEW_PROCESS = 'updateReviewProcess'
 export const UPDATE_SAVE_TYPE = 'updateSaveType'
+export const UPDATE_HAS_UNSAVED_CHANGES = 'updateHasUnsavedChanges'
 
 export default {
   UPDATE_PUBLISH_START_DATE,
@@ -14,5 +15,6 @@ export default {
   UPDATE_PUBLISH_VISIBILITY,
   UPDATE_REVIEW_PROCESS,
   UPDATE_PUBLISH_SUBMIT,
-  UPDATE_SAVE_TYPE
+  UPDATE_SAVE_TYPE,
+  UPDATE_HAS_UNSAVED_CHANGES
 }

--- a/frontend/scss/setup/_colors.scss
+++ b/frontend/scss/setup/_colors.scss
@@ -2,6 +2,7 @@
 $color__red: #e61414;
 $color__yellow: #f2f034;
 $color__orange: #fffcb1;
+$color__orangeDark: #b39946;
 $color__green: #1d9f3c;
 $color__lightGreen: #D3ECD9;
 $color__green--hover: #1A8F36;
@@ -90,6 +91,7 @@ $color__error--hover: darken($color__red, 10%);
 $color__error--active: darken($color__red, 15%);
 
 $color__warning: $color__orange;
+$color__warningDark: $color__orangeDark;
 
 $color__action: $color__darkBlue;
 $color__action--hover: $color__darkBlue--hover;

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -396,6 +396,7 @@ return [
         'parent-page' => 'Parent page',
         'review-status' => 'Review status',
         'visibility' => 'Visibility',
+        'unsaved-changes' => 'There are unsaved changes',
     ],
     'select' => [
         'empty-text' => 'Sorry, no matching options.',


### PR DESCRIPTION
## Description

Currently on any state change there would be a trigger that would make the popup show on page refresh or navigation.

This change is a bit more specific about what changes to look for.

By doing this, we also now know when content is actually changed, and we can use this to display a "content changed" message.

We could also use this for autosaving content if we add this in the future.

## Related Issues

Fixes #1305 

# Todo

If the approach is ok, I still need to make sure the original state is updated when the form is actually submitted.