### PR TITLE
#1203: Add typecasting to select dropdown

### DIFF
--- a/frontend/js/components/VSelect.vue
+++ b/frontend/js/components/VSelect.vue
@@ -1,25 +1,26 @@
 <template>
   <div class="vselectOuter">
-    <a17-inputframe :error="error" :label="label" :note="note" :size="size" :name="name" :label-for="uniqId" :required="required" :add-new="addNew">
+    <a17-inputframe :error="error" :label="label" :note="note" :size="size" :name="name" :label-for="uniqId"
+                    :required="required" :add-new="addNew">
       <div class="vselect" :class="vselectClasses">
         <div class="vselect__field">
-          <input type="hidden" :name="name" :id="uniqId" :value="inputValue" />
+          <input type="hidden" :name="name" :id="uniqId" :value="inputValue"/>
           <v-select
-            :multiple="multiple"
-            :placeholder="placeholder"
-            :value="value"
-            :options="currentOptions"
-            :searchable="searchable"
-            :clearSearchOnSelect="clearSearchOnSelect"
-            :label="optionsLabel"
-            :on-search="getOptions"
-            :taggable="taggable"
-            :pushTags="pushTags"
-            :transition="transition"
-            :requiredValue="required"
-            :maxHeight="maxHeight"
-            :disabled="disabled"
-            @input="updateValue"
+              :multiple="multiple"
+              :placeholder="placeholder"
+              :value="value"
+              :options="currentOptions"
+              :searchable="searchable"
+              :clearSearchOnSelect="clearSearchOnSelect"
+              :label="optionsLabel"
+              :on-search="getOptions"
+              :taggable="taggable"
+              :pushTags="pushTags"
+              :transition="transition"
+              :requiredValue="required"
+              :maxHeight="maxHeight"
+              :disabled="disabled"
+              @input="updateValue"
           >
             <span slot="no-options">{{ emptyText }}</span>
           </v-select>
@@ -40,7 +41,9 @@
   import FormStoreMixin from '@/mixins/formStore'
   import InputframeMixin from '@/mixins/inputFrame'
   import AttributesMixin from '@/mixins/addAttributes'
-  import extendedVSelect from '@/components/VSelect/ExtendedVSelect.vue' // check full options of the vueSelect here : http://sagalbot.github.io/vue-select/
+  import extendedVSelect from '@/components/VSelect/ExtendedVSelect.vue'
+  import _ from 'lodash'
+  // check full options of the vueSelect here : http://sagalbot.github.io/vue-select/
   // import vSelect from 'vue-select' // check full options of the vueSelect here : http://sagalbot.github.io/vue-select/
 
   export default {
@@ -92,7 +95,9 @@
         }
       },
       options: {
-        default: function () { return [] }
+        default: function () {
+          return []
+        }
       },
       optionsLabel: { // label in vueselect
         type: String,
@@ -163,7 +168,14 @@
               this.value = this.options.filter(o => value.includes(o.value))
             }
           } else {
-            this.value = this.options.find(o => o.value === value)
+            this.value = this.options.find(o => {
+              // Try to always compare to the same type. But we only check for a numeric value. Because it can only be
+              // a string or a number for now.
+              if (typeof o.value === 'number') {
+                return o.value === parseInt(value)
+              }
+              return o.value === _.unescape(String(value))
+            })
           }
         }
       },

--- a/frontend/js/components/VSelect.vue
+++ b/frontend/js/components/VSelect.vue
@@ -42,7 +42,6 @@
   import InputframeMixin from '@/mixins/inputFrame'
   import AttributesMixin from '@/mixins/addAttributes'
   import extendedVSelect from '@/components/VSelect/ExtendedVSelect.vue'
-  import _ from 'lodash'
   // check full options of the vueSelect here : http://sagalbot.github.io/vue-select/
   // import vSelect from 'vue-select' // check full options of the vueSelect here : http://sagalbot.github.io/vue-select/
 
@@ -174,7 +173,7 @@
               if (typeof o.value === 'number') {
                 return o.value === parseInt(value)
               }
-              return o.value === _.unescape(String(value))
+              return o.value === String(value)
             })
           }
         }


### PR DESCRIPTION
## Description

This pr adds typecasting to the select options based on the value coming from the form.

Also, it unescapes using lodash so that special characters are allowed. -> This I am not 100% sure is a way to go. Special characters in option values should maybe just be forbidden security-wise? Or we specifically only fix &amp; for ampersands.

What is your view @ifox?

## Related Issues

Fixes #1203 
