### PR TITLE
#1160: Allow media to be deleted.

### DIFF
--- a/src/Models/Behaviors/HasMedias.php
+++ b/src/Models/Behaviors/HasMedias.php
@@ -3,6 +3,7 @@
 namespace A17\Twill\Models\Behaviors;
 
 use A17\Twill\Models\Media;
+use A17\Twill\Models\Model;
 use Illuminate\Support\Arr;
 use ImageService;
 
@@ -14,6 +15,16 @@ trait HasMedias
         'crop_w',
         'crop_h',
     ];
+
+    public static function bootHasMedias(): void
+    {
+        self::deleted(static function (Model $model) {
+            if ($model->isForceDeleting()) {
+                /** @var \A17\Twill\Models\Behaviors\HasMedias $model */
+                $model->medias()->detach();
+            }
+        });
+    }
 
     /**
      * Defines the many-to-many relationship for media objects.

--- a/src/Models/Media.php
+++ b/src/Models/Media.php
@@ -143,7 +143,7 @@ class Media extends Model
         if ($this->update($fields) && $this->isReferenced())
         {
             DB::table(config('twill.mediables_table', 'twill_mediables'))->where('media_id', $this->id)->get()->each(function ($mediable) use ($prevWidth, $prevHeight) {
-                
+
                 if ($prevWidth != $this->width) {
                     $mediable->crop_x = 0;
                     $mediable->crop_w = $this->width;
@@ -157,6 +157,14 @@ class Media extends Model
                 DB::table(config('twill.mediables_table', 'twill_mediables'))->where('id', $mediable->id)->update((array)$mediable);
             });
         }
+    }
+
+    public function delete()
+    {
+        if ($this->canDeleteSafely()) {
+            return parent::delete();
+        }
+        return false;
     }
 
     public function getTable()

--- a/tests/integration/MediaLibraryTest.php
+++ b/tests/integration/MediaLibraryTest.php
@@ -157,6 +157,9 @@ class MediaLibraryTest extends ModulesTestBase
         $this->assertEquals(0, $media->unused()->count());
         $this->assertFalse($media->refresh()->canDeleteSafely());
 
+        // Should not be able to delete media here.
+        $this->assertFalse($media->delete());
+
         // Check we cannot remove it via the api.
         $this->deleteJson(route('admin.media-library.medias.destroy', ['media' => $media]))->assertJson([
             'message' => 'Media was not moved to trash. Something wrong happened!',
@@ -170,6 +173,9 @@ class MediaLibraryTest extends ModulesTestBase
         $this->assertCount(1, $author->medias);
         $this->assertEquals(0, $media->unused()->count());
         $this->assertFalse($media->refresh()->canDeleteSafely());
+
+        // Should not be able to delete media here.
+        $this->assertFalse($media->delete());
 
         // Check we continue to be unable to remove.
         $this->deleteJson(route('admin.media-library.medias.destroy', ['media' => $media]))->assertJson([

--- a/tests/integration/ModulesTestBase.php
+++ b/tests/integration/ModulesTestBase.php
@@ -2,6 +2,7 @@
 
 namespace A17\Twill\Tests\Integration;
 
+use A17\Twill\Models\Model;
 use Illuminate\Support\Str;
 use App\Models\Translations\AuthorTranslation;
 use App\Models\Translations\CategoryTranslation;
@@ -202,7 +203,7 @@ abstract class ModulesTestBase extends TestCase
         $this->assertEquals($data['endpointType'], 'App\Models\Author');
     }
 
-    protected function createAuthor($count = 1)
+    protected function createAuthor($count = 1): Model
     {
         foreach (range(1, $count) as $c) {
             $this->httpRequestAssert(
@@ -221,6 +222,8 @@ abstract class ModulesTestBase extends TestCase
         $this->assertNotNull($this->translation);
 
         $this->assertCount(3, $this->author->slugs);
+
+        return $this->author;
     }
 
     protected function destroyAuthor()


### PR DESCRIPTION
## Description

This adds a test + force delete check for media.

I wonder:
- [x] Should we avoid $media->delete() when it is still in use?
- [x] the admin.media-library.medias.destroy API returns 200 even when it fails, should we change that?

## Related Issues

Fixes: #1160 