### PR TITLE
#1356: Add question to generate preview files for modules and blocks.

### DIFF
--- a/src/Commands/BlockMake.php
+++ b/src/Commands/BlockMake.php
@@ -54,12 +54,15 @@ class BlockMake extends Command
      */
     public function handle()
     {
+        $generateView = $this->confirm('Should we also generate a view file for rendering the block?');
+
         $this->blockMaker
             ->setCommand($this)
             ->make(
                 $this->argument('name'),
                 $this->argument('base') ?? 'text',
-                $this->argument('icon') ?? 'text'
+                $this->argument('icon') ?? 'text',
+                $generateView
             );
 
         return parent::handle();

--- a/src/Commands/ModuleMake.php
+++ b/src/Commands/ModuleMake.php
@@ -603,7 +603,7 @@ class ModuleMake extends Command
      * @return void
      * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
      */
-    private function createViews($moduleName = 'items')
+    private function createViews(string $moduleName = 'items'): void
     {
         $viewsPath = $this->viewPath($moduleName);
 
@@ -614,6 +614,11 @@ class ModuleMake extends Command
         twill_put_stub($viewsPath . '/form.blade.php', $this->files->get(__DIR__ . '/stubs/' . $formView . '.blade.stub'));
 
         $this->info("Form view created successfully! Include your form fields using @formField directives!");
+
+        if($this->confirm("Do you also want to generate the preview file?")) {
+            $previewViewsPath = $this->previewViewPath();
+            twill_put_stub($previewViewsPath . '/' . Str::singular($moduleName) . '.blade.php', $this->files->get(__DIR__ . '/stubs/preview_module.blade.stub'));
+        }
     }
 
     /**
@@ -787,13 +792,24 @@ class ModuleMake extends Command
         return $this->capsule[$type] . $class;
     }
 
-    public function viewPath($moduleName)
+    public function viewPath(string $moduleName): string
     {
         if (!$this->isCapsule) {
-            return $viewsPath = $this->config->get('view.paths')[0] . '/admin/' . $moduleName;
+            return $this->config->get('view.paths')[0] . '/admin/' . $moduleName;
         }
 
         $this->makeDir($dir = "{$this->moduleBasePath}/resources/views/admin");
+
+        return $dir;
+    }
+
+    public function previewViewPath(): string
+    {
+        if (!$this->isCapsule) {
+            return $this->config->get('view.paths')[0] . '/site/';
+        }
+
+        $this->makeDir($dir = "{$this->moduleBasePath}/resources/views");
 
         return $dir;
     }

--- a/src/Commands/stubs/preview_module.blade.stub
+++ b/src/Commands/stubs/preview_module.blade.stub
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <title>Demo page</title>
+    <link rel="stylesheet" href="{{ mix('css/app.css') }}">
+</head>
+<body>
+<div>
+    Example preview. See <a href="https://twill.io/docs/crud-modules/revisions-and-previewing.html">documentation.</a>
+    <br />
+    {{ $item->title }}
+    <br />
+    {{ $item->description }}
+</div>
+<script src="{{ mix('js/app.js') }}"></script>
+</body>
+</html>

--- a/src/Services/Blocks/BlockMaker.php
+++ b/src/Services/Blocks/BlockMaker.php
@@ -62,11 +62,12 @@ class BlockMaker
      * @param $blockName
      * @param $baseName
      * @param $iconName
+     * @param bool $generateView
      * @return mixed
      * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
      * @throws \Exception
      */
-    public function make($blockName, $baseName, $iconName)
+    public function make($blockName, $baseName, $iconName, bool $generateView = false)
     {
         $this->info('Creating block...');
 
@@ -112,7 +113,8 @@ class BlockMaker
             $blockName,
             $blockFile,
             $repeaters,
-            $blockIdentifier
+            $blockIdentifier,
+            $generateView
         );
     }
 
@@ -502,11 +504,20 @@ class BlockMaker
         $blockName,
         string $blockFile,
         $repeaters,
-        string $blockIdentifier
+        string $blockIdentifier,
+        bool $generateView = false
     ) {
         $this->put($blockFile, $this->blockBase);
 
         $this->info("Block {$blockName} was created.");
+
+        if ($generateView) {
+            $this->put(
+                str_replace('views/admin/blocks', 'views/site/blocks', $blockFile),
+                'This is a basic preview. You can use dd($block) to view the data you have access to.'
+            );
+            $this->info("Block {$blockName} blank render view was created.");
+        }
 
         foreach ($repeaters as $repeater) {
             $this->put(


### PR DESCRIPTION
## Description

This adds a question to generate a module preview file and a block rendering file:

<img width="789" alt="Screenshot 2022-01-14 at 13 34 29" src="https://user-images.githubusercontent.com/866743/149516281-1d9fe45a-bc12-4505-a7cb-a6b45321f999.png">

<img width="711" alt="Screenshot 2022-01-14 at 13 34 54" src="https://user-images.githubusercontent.com/866743/149516311-f3cdfca1-5ed4-4537-a1fa-66b76633fd1c.png">

## Related Issues

fixes #1356 
