### PR TITLE
Move development specific autoload components

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,11 @@
   },
   "autoload": {
     "psr-4": {
-      "A17\\Twill\\": "src/",
+      "A17\\Twill\\": "src/"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
       "A17\\Twill\\Tests\\Unit\\": "tests/unit",
       "A17\\Twill\\Tests\\Integration\\": "tests/integration",
       "App\\": "vendor/orchestra/testbench-core/laravel/app"


### PR DESCRIPTION
This components must not be in autoload for production optimized projects.

Example: https://github.com/laravel/laravel/blob/8.x/composer.json#L30
