### PR TITLE
Fixed CSS files not beeing generated when running twill:build

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -106,6 +106,7 @@ const config = {
   // Remove sourcemaps for production
   productionSourceMap: false,
   css: {
+    extract: true,
     loaderOptions: {
       // define global settings imported in all components
       sass: {


### PR DESCRIPTION
## Description

After running the php artisan command `twill:build` the backend was broken, because the css files were missing.
After looking into the `twill-manifest.json` in public folder i have seen, that they were not listet. So i did a research and found the solution to add the option `extract: true` for CSS in `vue.config.js`.
With this option the CSS is generated and listed in the `twill-manifest.json`.