### PR TITLE
Add browser field support to connected fields utility

### DIFF
--- a/docs/src/form-fields/conditional-fields.md
+++ b/docs/src/form-fields/conditional-fields.md
@@ -54,3 +54,41 @@ Here's an example based on a checkbox field where the value is either true or fa
     ])
 @endformConnectedFields
 ```
+
+Here's an example based on a browser field where the fields are displayed only when the browser field is not empty:
+
+```php
+@formField('browser', [
+    'moduleName' => 'publications',
+    'name' => 'related_publications',
+    'label' => 'Related publications',
+    'max' => 4,
+])
+
+@formConnectedFields([
+    'fieldName' => 'publications',
+    'isBrowser' => true,
+    'keepAlive' => true,
+])
+    @formField('input', [
+        'name' => 'related_publications_header',
+        'label' => 'Related publications header',
+    ])
+
+    @formField('textarea', [
+        'name' => 'related_publications_copy',
+        'label' => 'Related publications copy',
+    ])
+@endformConnectedFields
+```
+
+
+| Option            | Description                                                                                      | Type              | Default value |
+|:------------------|:-------------------------------------------------------------------------------------------------|:------------------|:--------------|
+| fieldName         | Name of the connected field                                                                      | string            |               |
+| fieldValues       | Value or values of the connected field that will reveal the fields in this component's slot      | string&vert;array |               |
+| isEqual           | Controls how `fieldValues` are evaluated against the connected field                             | boolean           | true          |
+| isBrowser         | Indicates that the connected field is a `browser` field                                          | boolean           | false         |
+| matchEmptyBrowser | When set to true, the fields in this component's slot will be revealed when the browser is empty | boolean           | false         |
+| keepAlive         | When set to true, the state of the hidden fields is preserved                                    | boolean           | false         |
+| renderForBlocks   | When used inside a block, this needs to be set to true                                           | string            | false         |

--- a/frontend/js/components/ConnectorField.vue
+++ b/frontend/js/components/ConnectorField.vue
@@ -78,12 +78,13 @@
     methods: {
       toggleVisibility: function (value) {
         if (this.isBrowser) {
-          if (this.matchEmptyBrowser && (!value || value.length === 0)) {
+          const browserLength = (value && value.length) ?? 0
+          if (this.matchEmptyBrowser && (browserLength === 0)) {
             this.open = true
             return
           }
 
-          this.open = this.matchEmptyBrowser ? false : value.length > 0
+          this.open = this.matchEmptyBrowser ? false : browserLength > 0
           return
         }
 

--- a/frontend/js/components/ConnectorField.vue
+++ b/frontend/js/components/ConnectorField.vue
@@ -39,12 +39,21 @@
       isValueEqual: { // requiredFieldValues must be equal (or different) to the stored value to show
         type: Boolean,
         default: true
+      },
+      isBrowser: {
+        type: Boolean,
+        default: false
+      },
+      matchEmptyBrowser: {
+        type: Boolean,
+        default: false
       }
     },
     computed: {
       storedValue: function () {
         if (this.inModal) return this.modalFieldValueByName(this.fieldName)
-        else return this.fieldValueByName(this.fieldName)
+        if (this.isBrowser) return this.selectedBrowser[this.fieldName]
+        return this.fieldValueByName(this.fieldName)
       },
       ...mapGetters([
         'fieldValueByName',
@@ -52,7 +61,8 @@
       ]),
       ...mapState({
         fields: state => state.form.fields, // Fields in the form
-        modalFields: state => state.form.modalFields // Fields in the create/edit modal
+        modalFields: state => state.form.modalFields, // Fields in the create/edit modal
+        selectedBrowser: state => state.browser.selected
       })
     },
     data: function () {
@@ -67,6 +77,16 @@
     },
     methods: {
       toggleVisibility: function (value) {
+        if (this.isBrowser) {
+          if (this.matchEmptyBrowser && (!value || value.length === 0)) {
+            this.open = true
+            return
+          }
+
+          this.open = this.matchEmptyBrowser ? false : value.length > 0
+          return
+        }
+
         const newValue = clone(value)
         const newFieldValues = clone(this.requiredFieldValues)
 

--- a/views/partials/form/utils/_connected_fields.blade.php
+++ b/views/partials/form/utils/_connected_fields.blade.php
@@ -1,26 +1,35 @@
 @php
     $isEqual = $isEqual ?? true;
     $inModal = $fieldsInModal ?? false;
+    $isBrowser = $isBrowser ?? false;
+    $matchEmptyBrowser = $matchEmptyBrowser ?? false;
     $keepAlive = $keepAlive ?? false;
 
-    // Field values misc updates
-    $fieldType = gettype($fieldValues);
-    if ($fieldType === 'boolean') $fieldValues = $fieldValues ? "true" :  "false";
-    else if ($fieldType === 'array') $fieldValues = json_encode($fieldValues);
+    if (! $isBrowser) {
+        // Field values misc updates
+        $fieldType = gettype($fieldValues);
+        if ($fieldType === 'boolean') $fieldValues = $fieldValues ? "true" :  "false";
+        else if ($fieldType === 'array') $fieldValues = json_encode($fieldValues);
+    }
 @endphp
 <a17-connectorfield
     @if ($isEqual) :is-value-equal="true" @else :is-value-equal="false" @endif
     @if ($inModal) :in-modal="true" @endif
     @if ($keepAlive) :keep-alive="true" @endif
 
+    @if ($isBrowser) :is-browser="true" @endif
+    @if ($matchEmptyBrowser) :match-empty-browser="true" @endif
+
     @if ($renderForBlocks) :field-name="fieldName('{{ $fieldName }}')"
     @else field-name="{{ $fieldName }}"
     @endif
 
-    @if ($fieldType === 'array') :required-field-values='{!! $fieldValues !!}'
-    @elseif ($fieldType === 'string') :required-field-values="'{{ $fieldValues }}'"
-    @else :required-field-values="{{ $fieldValues }}"
-    @endif
+    @unless($isBrowser)
+        @if ($fieldType === 'array') :required-field-values='{!! $fieldValues !!}'
+        @elseif ($fieldType === 'string') :required-field-values="'{{ $fieldValues }}'"
+        @else :required-field-values="{{ $fieldValues }}"
+        @endif
+    @endunless
 >
     {{ $slot }}
 </a17-connectorfield>


### PR DESCRIPTION
## Description

- When `isBrowser` is true, the connected fields are displayed if the connected browser has selected items
- When `matchEmptyBrowser` is true,  the connected fields are displayed if the browser is empty
