### PR TITLE
Add `connectedBrowserField` option to the browser form field

### DIFF
--- a/docs/src/form-fields/browser.md
+++ b/docs/src/form-fields/browser.md
@@ -15,23 +15,24 @@ pageClass: twill-doc
 ])
 ```
 
-| Option      | Description                                                                     | Type    | Default value |
-|:------------|:--------------------------------------------------------------------------------| :-------| :------------ |
-| name        | Name of the field                                                               | string  |               |
-| label       | Label of the field                                                              | string  |               |
-| moduleName  | Name of the module (single related module)                                      | string  |               |
-| modules     | Array of modules (multiple related modules), must include _name_                | array   |               |
-| endpoints   | Array of endpoints (multiple related modules), must include _value_ and _label_ | array   |               |
-| params      | Array of query params (key => value) to be passed to the browser endpoint       | array   |               |
-| max         | Max number of attached items                                                    | integer | 1             |
-| note        | Hint message displayed in the field                                             | string  |               |
-| fieldNote   | Hint message displayed above the field                                          | string  |               |
-| browserNote | Hint message displayed inside the browser modal                                 | string  |               |
-| itemLabel   | Label used for the `Add` button                                                 | string  |               |
-| buttonOnTop | Displays the `Add` button above the items                                       | boolean | false         |
-| wide        | Expands the browser modal to fill the viewport                                  | boolean | false         |
-| sortable    | Allows manually sorting the attached items                                      | boolean | true          |
-| disabled    | Disables the field                                                              | boolean | false         | 
+| Option                | Description                                                                     | Type    | Default value |
+|:----------------------|:--------------------------------------------------------------------------------|:--------|:--------------|
+| name                  | Name of the field                                                               | string  |               |
+| label                 | Label of the field                                                              | string  |               |
+| moduleName            | Name of the module (single related module)                                      | string  |               |
+| modules               | Array of modules (multiple related modules), must include _name_                | array   |               |
+| endpoints             | Array of endpoints (multiple related modules), must include _value_ and _label_ | array   |               |
+| params                | Array of query params (key => value) to be passed to the browser endpoint       | array   |               |
+| max                   | Max number of attached items                                                    | integer | 1             |
+| note                  | Hint message displayed in the field                                             | string  |               |
+| fieldNote             | Hint message displayed above the field                                          | string  |               |
+| browserNote           | Hint message displayed inside the browser modal                                 | string  |               |
+| itemLabel             | Label used for the `Add` button                                                 | string  |               |
+| buttonOnTop           | Displays the `Add` button above the items                                       | boolean | false         |
+| wide                  | Expands the browser modal to fill the viewport                                  | boolean | false         |
+| sortable              | Allows manually sorting the attached items                                      | boolean | true          |
+| disabled              | Disables the field                                                              | boolean | false         | 
+| connectedBrowserField | Name of another browser field to connect to                                     | string  |               |
 
 <br/>
 
@@ -158,3 +159,47 @@ To retrieve the items in the frontend, you can use the `getRelated` method on mo
 ## Using browser fields and custom pivot tables
 
 Checkout this [Spectrum tutorial](https://spectrum.chat/twill/tips-and-tricks/step-by-step-ii-creating-a-twill-app~37c36601-1198-4c53-857a-a2b47c6d11aa) that walks through the entire process of using browser fields with custom pivot tables.
+
+## Connecting 2 browser fields
+
+The following example demonstrates how to make a browser field depend on the selected items of another browser field.
+
+```php
+@formField('browser', [
+    'label' => 'Product',
+    'name' => 'product',
+    'moduleName' => 'products',
+    'max' => 1,
+])
+
+@formField('browser', [
+    'label' => 'Product variant',
+    'name' => 'product_variant',
+    'moduleName' => 'productVariants',
+    'connectedBrowserField' => 'product',
+    'note' => 'Select a product to enable this field.'
+    'max' => 1,
+])
+```
+
+The second browser is using the `connectedBrowserField` option, which will:
+
+- add the connected browser's selected items IDs to the browser endpoint url, using the `connectedBrowserIds` query parameter,
+- disable the browser field when the connected browser is empty,
+- empty the browser field automatically when removing all items from the connected browser.
+
+From your module's controller, you can then use `connectedBrowserIds` to do something like:
+
+```php
+public function getBrowserData($prependScope = [])
+{
+  if ($this->request->has('connectedBrowserIds')) {
+    $products = collect(json_decode($this->request->get('connectedBrowserIds')));
+    $prependScope['product_id'] = $products->toArray();
+  }
+
+  return parent::getBrowserData($prependScope);
+}
+```
+
+In the presented example, this will make sure only variants of the selected product in the first browser can be selected in the second one.

--- a/views/partials/form/_browser.blade.php
+++ b/views/partials/form/_browser.blade.php
@@ -22,6 +22,7 @@
     $buttonOnTop = $buttonOnTop ?? false;
     $browserNote = $browserNote ?? '';
     $disabled = $disabled ?? false;
+    $connectedBrowserField = $connectedBrowserField ?? false;
 @endphp
 
 <a17-inputframe label="{{ $label }}" name="browsers.{{ $name }}" note="{{ $fieldNote }}">
@@ -37,6 +38,9 @@
         browser-note="{{ $browserNote }}"
         @if($buttonOnTop) :button-on-top="true" @endif
         @if($disabled) disabled @endif
+        @if($renderForBlocks && $connectedBrowserField) :connected-browser-field="fieldName('{{ $connectedBrowserField }}')"
+        @elseif($connectedBrowserField) connected-browser-field="{{ $connectedBrowserField }}"
+        @endif
     >{{ $note }}</a17-browserfield>
 </a17-inputframe>
 


### PR DESCRIPTION
## Description

- The connected browser selected items IDs are added to the browser endpoint url
- When the connected browser is empty, the browser field is disabled
- When removing all items from the connected browser, the browser field is automatically emptied

