### PR TITLE
Fix exception for missing repository in related browser

### DIFF
--- a/src/Repositories/Behaviors/HandleBlocks.php
+++ b/src/Repositories/Behaviors/HandleBlocks.php
@@ -306,8 +306,12 @@ trait HandleBlocks
                     }
                 }
             } else {
-                $relationRepository = $this->getModelRepository($relation);
-                $relatedItems = $relationRepository->get([], ['id' => $ids], [], -1);
+                try {
+                    $relationRepository = $this->getModelRepository($relation);
+                    $relatedItems = $relationRepository->get([], ['id' => $ids], [], -1);
+                } catch (\Throwable $th) {
+                    $relatedItems = collect();
+                }
                 $sortedRelatedItems = array_flip($ids);
 
                 foreach ($relatedItems as $item) {


### PR DESCRIPTION
## Description

Catch any errors for unfound model repositories in empty block browsers. Alternatively, one could disable the `$block->getRelated($relation)->isNotEmpty()` check — not sure what that does or why it's there.

## Related Issues

Fixes #1404