### PR TITLE
Refactored translatable rules functionality

### DIFF
--- a/src/Http/Requests/Admin/Request.php
+++ b/src/Http/Requests/Admin/Request.php
@@ -47,7 +47,7 @@ abstract class Request extends FormRequest
         if ($this->request->has('languages')) {
             foreach ($locales as $locale) {
                 $language = Collection::make($this->request->get('languages'))->where('value', $locale)->first();
-                $currentLocaleActive = $language['published'];
+                $currentLocaleActive = $language['published'] ?? false;
                 $rules = $this->updateRules($rules, $fields, $locale, $currentLocaleActive);
 
                 if ($currentLocaleActive) {

--- a/src/Http/Requests/Admin/Request.php
+++ b/src/Http/Requests/Admin/Request.php
@@ -43,17 +43,20 @@ abstract class Request extends FormRequest
     {
         $locales = getLocales();
         $localeActive = false;
-        foreach ($locales as $locale) {
-            if ($this->request->has('languages')) {
-                $languageFromRequest = Collection::make($this->request->get('languages'))->where('value', $locale)->first();
-                if ($languageFromRequest['published']) {
+
+        if ($this->request->has('languages')) {
+            foreach ($locales as $locale) {
+                $language = Collection::make($this->request->get('languages'))->where('value', $locale)->first();
+                $currentLocaleActive = $language['published'];
+                $rules = $this->updateRules($rules, $fields, $locale, $currentLocaleActive);
+
+                if ($currentLocaleActive) {
                     $localeActive = true;
-                    $rules = $this->updateRules($rules, $fields, $locale);
                 }
             }
         }
 
-        if (!$localeActive) {
+        if (! $localeActive) {
             $rules = $this->updateRules($rules, $fields, reset($locales));
         }
 
@@ -64,24 +67,59 @@ abstract class Request extends FormRequest
      * @param array $rules
      * @param array $fields
      * @param string $locale
+     * @param bool $localeActive
      * @return array
      */
-    private function updateRules($rules, $fields, $locale)
+    private function updateRules($rules, $fields, $locale, $localeActive = true)
     {
-        foreach ($fields as $field => $field_rules) {
-            // allows using validation rule that references other fields even for translated fields
-            if (Str::contains($field_rules, $fields)) {
-                foreach ($fields as $fieldName => $fieldRules) {
-                    if (Str::contains($field_rules, $fieldName) && Str::startsWith('required_', $field_rules)) {
-                        $field_rules = str_replace($fieldName, "{$fieldName}.{$locale}", $field_rules);
-                    }
+        $fieldNames = array_keys($fields);
+
+        foreach ($fields as $field => $fieldRules) {
+            if (is_string($fieldRules)) {
+                $fieldRules = explode('|', $fieldRules);
+            }
+
+            $fieldRules = Collection::make($fieldRules);
+
+            // Remove required rules, when locale is not active
+            if (! $localeActive) {
+                $hasRequiredRule = $fieldRules->contains(function ($rule) {
+                    return $this->ruleStartsWith($rule, 'required');
+                });
+
+                $fieldRules = $fieldRules->reject(function ($rule) {
+                    return $this->ruleStartsWith($rule, 'required');
+                });
+
+                if ($hasRequiredRule && $fieldRules->doesntContain('nullable')) {
+                    $fieldRules->add('nullable');
                 }
             }
 
-            $rules["{$field}.{$locale}"] = $field_rules;
+            $rules["{$field}.{$locale}"] = $fieldRules->map(function ($rule) use ($locale, $fieldNames) {
+                // allows using validation rule that references other fields even for translated fields
+                if ($this->ruleStartsWith($rule, 'required_') && Str::contains($rule, $fieldNames)) {
+                    foreach ($fieldNames as $fieldName) {
+                        $rule = str_replace($fieldName, "{$fieldName}.{$locale}", $rule);
+                    }
+                }
+
+                return $rule;
+            })->toArray();
         }
 
         return $rules;
+    }
+
+    /**
+     * @param mixed $rule
+     * @param string $needle
+     *
+     * @return bool
+     */
+    private function ruleStartsWith($rule, $needle)
+    {
+        return is_string($rule) && Str::startsWith($rule, $needle);
     }
 
     /**


### PR DESCRIPTION
## Description

I have refactored the translatable rules functionality to add some features and fix a bug.

- Not published locales now getting validated (required rules will be disabled)
- Now supports defining rules for fields as Array (like [Laravel](https://laravel.com/docs/8.x/validation#quick-writing-the-validation-logic) it does)
- Fixed bug in the If-Condition where it checks for `'required_'` (haystack and needle were interchanged)

We came across this when we received a database error because it tried to save a text that was too long. Unfortunately, the validation was not performed because the language was not (yet) published. 
