### PR TITLE
#766: Add fallback + handle null.

### DIFF
--- a/frontend/js/components/Search.vue
+++ b/frontend/js/components/Search.vue
@@ -22,7 +22,7 @@
               </div>
               <div class="search__cell">
                 <span class="search__title">{{ item.title }}</span>
-                <p class="f--note">
+                <p class="f--note" v-if="item.date">
                   {{ item.activity }} <timeago :auto-update="1" :datetime="new Date(item.date)"></timeago> by {{ item.author }}
                   <span class="search__type">{{ item.type }}</span>
                 </p>

--- a/src/Http/Controllers/Admin/DashboardController.php
+++ b/src/Http/Controllers/Admin/DashboardController.php
@@ -122,13 +122,21 @@ class DashboardController extends Controller
                     $author = 'Admin';
                 }
 
+                $date = null;
+                if ($item->updated_at) {
+                    $date = $item->updated_at->toIso8601String();
+                }
+                elseif ($item->created_at) {
+                    $date = $item->created_at->toIso8601String();
+                }
+
                 return [
                     'id' => $item->id,
                     'href' => moduleRoute($module['name'], $module['routePrefix'] ?? null, 'edit', $item->id),
                     'thumbnail' => method_exists($item, 'defaultCmsImage') ? $item->defaultCmsImage(['w' => 100, 'h' => 100]) : null,
                     'published' => $item->published,
                     'activity' => twillTrans('twill::lang.dashboard.search.last-edit'),
-                    'date' => $item->updated_at->toIso8601String(),
+                    'date' => $date,
                     'title' => $item->titleInDashboard ?? $item->title,
                     'author' => $author,
                     'type' => ucfirst($module['label_singular'] ?? Str::singular($module['name'])),


### PR DESCRIPTION
## Description

If updated_at is empty, we now fall back to the created_at field.

If both are empty, we send back "null" and hide the metadata on the Vue side.

## Related Issues

Fixes #766
