### PR TITLE
Update repeaters to work with active states.

### DIFF
--- a/src/Facades/TwillUtil.php
+++ b/src/Facades/TwillUtil.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace A17\Twill\Facades;
+
+use Illuminate\Support\Facades\Facade;
+
+class TwillUtil extends Facade
+{
+    protected static function getFacadeAccessor(): string
+    {
+        return 'twill_util';
+    }
+}

--- a/src/Repositories/Behaviors/HandleBlocks.php
+++ b/src/Repositories/Behaviors/HandleBlocks.php
@@ -2,10 +2,14 @@
 
 namespace A17\Twill\Repositories\Behaviors;
 
+use A17\Twill\Facades\TwillUtil;
 use A17\Twill\Models\Behaviors\HasMedias;
+use A17\Twill\Models\Block;
+use A17\Twill\Models\Model;
 use A17\Twill\Repositories\BlockRepository;
 use A17\Twill\Services\Blocks\BlockCollection;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Session;
 use Log;
 use Schema;
 use Symfony\Component\Routing\Exception\RouteNotFoundException;
@@ -19,11 +23,17 @@ trait HandleBlocks
      * @param int|null $parentId
      * @param \Illuminate\Support\Collection|null $blocksFromFields
      * @param \Illuminate\Support\Collection|null $mainCollection
-     * @param int|null $mainCollection|void
+     * @param int|null $mainCollection |void
      * @return \A17\Twill\Models\Model
      */
-    public function hydrateHandleBlocks($object, $fields, &$fakeBlockId = 0, $parentId = null, $blocksFromFields = null, $mainCollection = null)
-    {
+    public function hydrateHandleBlocks(
+        $object,
+        $fields,
+        &$fakeBlockId = 0,
+        $parentId = null,
+        $blocksFromFields = null,
+        $mainCollection = null
+    ) {
         if ($this->shouldIgnoreFieldBeforeSave('blocks')) {
             return;
         }
@@ -39,7 +49,13 @@ trait HandleBlocks
         }
 
         $blockRepository = app(BlockRepository::class);
-        $blocksCollection = $this->getChildrenBlocks($blocksFromFields, $blockRepository, $parentId, $fakeBlockId, $mainCollection);
+        $blocksCollection = $this->getChildrenBlocks(
+            $blocksFromFields,
+            $blockRepository,
+            $parentId,
+            $fakeBlockId,
+            $mainCollection
+        );
         $object->setRelation('blocks', $firstItem ? $mainCollection : $blocksCollection);
         return $object;
     }
@@ -57,7 +73,14 @@ trait HandleBlocks
             $fakeBlockId++;
             $newChildBlock->id = $fakeBlockId;
             if (!empty($childBlock['blocks'])) {
-                $childBlockHydrated = $this->hydrateHandleBlocks($newChildBlock, $childBlock, $fakeBlockId, $newChildBlock->id, $childBlock['blocks'], $mainCollection);
+                $childBlockHydrated = $this->hydrateHandleBlocks(
+                    $newChildBlock,
+                    $childBlock,
+                    $fakeBlockId,
+                    $newChildBlock->id,
+                    $childBlock['blocks'],
+                    $mainCollection
+                );
                 $newChildBlock->setRelation('children', $childBlockHydrated->blocks);
             }
 
@@ -67,12 +90,7 @@ trait HandleBlocks
         return $childBlocksCollection;
     }
 
-    /**
-     * @param \A17\Twill\Models\Model $object
-     * @param array $fields
-     * @return void
-     */
-    public function afterSaveHandleBlocks($object, $fields)
+    public function afterSaveHandleBlocks(Model $object, array $fields): void
     {
         if ($this->shouldIgnoreFieldBeforeSave('blocks')) {
             return;
@@ -80,30 +98,98 @@ trait HandleBlocks
 
         $blockRepository = app(BlockRepository::class);
 
-        $blockRepository->bulkDelete($object->blocks()->pluck('id')->toArray());
-        $this->getBlocks($object, $fields)->each(function ($block) use ($object, $blockRepository) {
-            $this->createBlock($blockRepository, $block);
-        });
+        $existingBlockIds = $object->blocks()->pluck('id')->toArray();
+
+        $usedBlockIds = [];
+
+        foreach ($this->getBlocks($object, $fields) as $blockData) {
+            $this->updateOrCreateBlock($blockRepository, $blockData, $existingBlockIds, $usedBlockIds);
+        }
+
+        // Delete the unused existing blocks.
+        $unusedBlockIds = array_diff($existingBlockIds, $usedBlockIds);
+        $blockRepository->bulkDelete($unusedBlockIds);
+    }
+
+    private function updateOrCreateBlock(
+        BlockRepository $blockRepository,
+        array $blockData,
+        array $existingBlockIds,
+        array &$usedBlockIds
+    ): void {
+        // Find an existing block id based on the frontend id.
+        if (
+            !in_array($blockData['id'] ?? null, $existingBlockIds, false) &&
+            $id = TwillUtil::hasBlockIdFor($blockData['id'])
+        ) {
+            $originalBlockId = $blockData['id'];
+            $blockData['id'] = $id;
+        }
+        // Check if the block already exists.
+        if (in_array($blockData['id'] ?? null, $existingBlockIds, false)) {
+            $blockObject = $this->updateBlock($blockRepository, $blockData, $existingBlockIds, $usedBlockIds);
+        } else {
+            $blockObject = $this->createBlock($blockRepository, $blockData, $existingBlockIds, $usedBlockIds);
+            TwillUtil::registerBlockId($originalBlockId ?? $blockData['id'], $blockObject->id);
+        }
+
+        $usedBlockIds[] = $blockObject->id;
+    }
+
+    private function updateBlock(
+        BlockRepository $blockRepository,
+        array $blockData,
+        array $existingBlockIds,
+        array &$usedBlockIds
+    ): Block {
+        $blockRepository->update($blockData['id'], $blockData);
+        $blockCreated = $blockRepository->findOrFail($blockData['id']);
+
+        $this->updateOrCreateChildBlocks(
+            $blockCreated,
+            $blockRepository,
+            $blockData,
+            $existingBlockIds,
+            $usedBlockIds
+        );
+
+        return $blockCreated;
     }
 
     /**
      * Create a block from formFields, and recursively create it's child blocks
-     *
-     * @param  \A17\Twill\Repositories\BlockRepository $blockRepository
-     * @param  array $blockFields
-     * @return \A17\Twill\Models\Block $blockCreated
      */
-    private function createBlock(BlockRepository $blockRepository, $blockFields)
-    {
-        $blockCreated = $blockRepository->create($blockFields);
+    private function createBlock(
+        BlockRepository $blockRepository,
+        array $blockData,
+        array $existingBlockIds,
+        array &$usedBlockIds
+    ): Block {
+        $blockCreated = $blockRepository->create($blockData);
 
-        // Handle child blocks
-        $blockFields['blocks']->each(function ($childBlock) use ($blockCreated, $blockRepository) {
-            $childBlock['parent_id'] = $blockCreated->id;
-            $this->createBlock($blockRepository, $childBlock);
-        });
+        $this->updateOrCreateChildBlocks(
+            $blockCreated,
+            $blockRepository,
+            $blockData,
+            $existingBlockIds,
+            $usedBlockIds
+        );
 
         return $blockCreated;
+    }
+
+    private function updateOrCreateChildBlocks(
+        Block $parentBlock,
+        BlockRepository $blockRepository,
+        array $blockData,
+        array $existingBlockIds,
+        array &$usedBlockIds
+    ): void {
+        foreach ($blockData['blocks'] as $childBlock) {
+            $childBlock['parent_id'] = $parentBlock->id;
+
+            $this->updateOrCreateBlock($blockRepository, $childBlock, $existingBlockIds, $usedBlockIds);
+        }
     }
 
     /**
@@ -129,8 +215,8 @@ trait HandleBlocks
     /**
      * Recursively generate child blocks from the fields of a block
      *
-     * @param  \A17\Twill\Models\Model $object
-     * @param  array $parentBlockFields
+     * @param \A17\Twill\Models\Model $object
+     * @param array $parentBlockFields
      * @return \Illuminate\Support\Collection
      */
     private function getChildBlocks($object, $parentBlockFields)
@@ -199,14 +285,14 @@ trait HandleBlocks
 
                 if ($isInRepeater) {
                     $fields['blocksRepeaters']["blocks-{$block->parent_id}_{$block->child_key}"][] = $blockItem + [
-                        'trigger' => $blockTypeConfig['trigger'],
-                    ] + (isset($blockTypeConfig['max']) ? [
-                        'max' => $blockTypeConfig['max'],
-                    ] : []);
+                            'trigger' => $blockTypeConfig['trigger'],
+                        ] + (isset($blockTypeConfig['max']) ? [
+                            'max' => $blockTypeConfig['max'],
+                        ] : []);
                 } else {
                     $fields['blocks'][$blockItem['name']][] = $blockItem + [
-                        'icon' => $blockTypeConfig['icon'],
-                    ];
+                            'icon' => $blockTypeConfig['icon'],
+                        ];
                 }
 
                 $fields['blocksFields'][] = Collection::make($block['content'])->filter(function ($value, $key) {
@@ -224,19 +310,25 @@ trait HandleBlocks
 
                 if ($medias) {
                     if (config('twill.media_library.translated_form_fields', false)) {
-                        $fields['blocksMedias'][] = Collection::make($medias)->mapWithKeys(function ($mediasByLocale, $locale) use ($block) {
-                            return Collection::make($mediasByLocale)->mapWithKeys(function ($value, $key) use ($block, $locale) {
-                                return [
-                                    "blocks[$block->id][$key][$locale]" => $value,
-                                ];
-                            });
-                        })->filter()->toArray();
+                        $fields['blocksMedias'][] = Collection::make($medias)->mapWithKeys(
+                            function ($mediasByLocale, $locale) use ($block) {
+                                return Collection::make($mediasByLocale)->mapWithKeys(
+                                    function ($value, $key) use ($block, $locale) {
+                                        return [
+                                            "blocks[$block->id][$key][$locale]" => $value,
+                                        ];
+                                    }
+                                );
+                            }
+                        )->filter()->toArray();
                     } else {
-                        $fields['blocksMedias'][] = Collection::make($medias)->mapWithKeys(function ($value, $key) use ($block) {
-                            return [
-                                "blocks[$block->id][$key]" => $value,
-                            ];
-                        })->filter()->toArray();
+                        $fields['blocksMedias'][] = Collection::make($medias)->mapWithKeys(
+                            function ($value, $key) use ($block) {
+                                return [
+                                    "blocks[$block->id][$key]" => $value,
+                                ];
+                            }
+                        )->filter()->toArray();
                     }
                 }
 
@@ -244,11 +336,13 @@ trait HandleBlocks
 
                 if ($files) {
                     Collection::make($files)->each(function ($rolesWithFiles, $locale) use (&$fields, $block) {
-                        $fields['blocksFiles'][] = Collection::make($rolesWithFiles)->mapWithKeys(function ($files, $role) use ($locale, $block) {
-                            return [
-                                "blocks[$block->id][$role][$locale]" => $files,
-                            ];
-                        })->toArray();
+                        $fields['blocksFiles'][] = Collection::make($rolesWithFiles)->mapWithKeys(
+                            function ($files, $role) use ($locale, $block) {
+                                return [
+                                    "blocks[$block->id][$role][$locale]" => $files,
+                                ];
+                            }
+                        )->toArray();
                     });
                 }
 
@@ -284,7 +378,8 @@ trait HandleBlocks
     protected function getBlockBrowsers($block)
     {
         return Collection::make($block['content']['browsers'])->mapWithKeys(function ($ids, $relation) use ($block) {
-            if (Schema::hasTable(config('twill.related_table', 'twill_related')) && $block->getRelated($relation)->isNotEmpty()) {
+            if (Schema::hasTable(config('twill.related_table', 'twill_related')) && $block->getRelated($relation)
+                    ->isNotEmpty()) {
                 $items = $this->getFormFieldsForRelatedBrowser($block, $relation);
                 foreach ($items as &$item) {
                     if (!isset($item['edit'])) {
@@ -318,12 +413,17 @@ trait HandleBlocks
                     return is_object($value);
                 })->map(function ($relatedElement) use ($relation) {
                     return [
-                        'id' => $relatedElement->id,
-                        'name' => $relatedElement->titleInBrowser ?? $relatedElement->title,
-                        'edit' => moduleRoute($relation, config('twill.block_editor.browser_route_prefixes.' . $relation), 'edit', $relatedElement->id),
-                    ] + (classHasTrait($relatedElement, HasMedias::class) ? [
-                        'thumbnail' => $relatedElement->defaultCmsImage(['w' => 100, 'h' => 100]),
-                    ] : []);
+                            'id' => $relatedElement->id,
+                            'name' => $relatedElement->titleInBrowser ?? $relatedElement->title,
+                            'edit' => moduleRoute(
+                                $relation,
+                                config('twill.block_editor.browser_route_prefixes.' . $relation),
+                                'edit',
+                                $relatedElement->id
+                            ),
+                        ] + (classHasTrait($relatedElement, HasMedias::class) ? [
+                            'thumbnail' => $relatedElement->defaultCmsImage(['w' => 100, 'h' => 100]),
+                        ] : []);
                 })->toArray();
             }
             return [

--- a/src/Repositories/Behaviors/HandleBlocks.php
+++ b/src/Repositories/Behaviors/HandleBlocks.php
@@ -9,7 +9,6 @@ use A17\Twill\Models\Model;
 use A17\Twill\Repositories\BlockRepository;
 use A17\Twill\Services\Blocks\BlockCollection;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\Session;
 use Log;
 use Schema;
 use Symfony\Component\Routing\Exception\RouteNotFoundException;

--- a/src/Repositories/Behaviors/HandleRepeaters.php
+++ b/src/Repositories/Behaviors/HandleRepeaters.php
@@ -2,6 +2,7 @@
 
 namespace A17\Twill\Repositories\Behaviors;
 
+use A17\Twill\Facades\TwillUtil;
 use A17\Twill\Services\Blocks\BlockCollection;
 use Carbon\Carbon;
 use Illuminate\Support\Arr;
@@ -39,7 +40,13 @@ trait HandleRepeaters
     public function afterSaveHandleRepeaters($object, $fields)
     {
         foreach ($this->getRepeaters() as $repeater) {
-            $this->updateRepeater($object, $fields, $repeater['relation'], $repeater['model'], $repeater['repeaterName']);
+            $this->updateRepeater(
+                $object,
+                $fields,
+                $repeater['relation'],
+                $repeater['model'],
+                $repeater['repeaterName']
+            );
         }
     }
 
@@ -51,7 +58,13 @@ trait HandleRepeaters
     public function getFormFieldsHandleRepeaters($object, $fields)
     {
         foreach ($this->getRepeaters() as $repeater) {
-            $fields = $this->getFormFieldsForRepeater($object, $fields, $repeater['relation'], $repeater['model'], $repeater['repeaterName']);
+            $fields = $this->getFormFieldsForRepeater(
+                $object,
+                $fields,
+                $repeater['relation'],
+                $repeater['model'],
+                $repeater['repeaterName']
+            );
         }
 
         return $fields;
@@ -91,8 +104,14 @@ trait HandleRepeaters
      * @param string|null $repeaterName
      * @return void
      */
-    public function updateRepeaterMorphMany($object, $fields, $relation, $morph = null, $model = null, $repeaterName = null)
-    {
+    public function updateRepeaterMorphMany(
+        $object,
+        $fields,
+        $relation,
+        $morph = null,
+        $model = null,
+        $repeaterName = null
+    ) {
         if (!$repeaterName) {
             $repeaterName = $relation;
         }
@@ -177,8 +196,29 @@ trait HandleRepeaters
         // keep a list of updated and new rows to delete (soft delete?) old rows that were deleted from the frontend
         $currentIdList = [];
 
+
         foreach ($relationFields as $index => $relationField) {
             $relationField['position'] = $index + 1;
+            // If the relation is not an "existing" one try to match it with our session.
+            if (
+                !Str::startsWith($relationField['id'], $relation) &&
+                $id = TwillUtil::hasRepeaterIdFor($relationField['id'])
+            ) {
+                $relationField['id'] = $relation . '-' . $id;
+            }
+
+            // Set the active data based on the parent.
+            if (!isset($relationField['languages'])) {
+                foreach ($relationField['active'] as $langCode => $active) {
+                    // Add the languages field.
+                    $relationField['languages'][] = [
+                        'value' => $langCode,
+                        'published' => $fields[$langCode]['active']
+                    ];
+                }
+            }
+
+            // Finally store the data.
             if (isset($relationField['id']) && Str::startsWith($relationField['id'], $relation)) {
                 // row already exists, let's update
                 $id = str_replace($relation . '-', '', $relationField['id']);
@@ -187,9 +227,12 @@ trait HandleRepeaters
             } else {
                 // new row, let's attach to our object and create
                 $relationField[$this->model->getForeignKey()] = $object->id;
+                $frontEndId = $relationField['id'];
                 unset($relationField['id']);
                 $newRelation = $relationRepository->create($relationField);
                 $currentIdList[] = $newRelation['id'];
+
+                TwillUtil::registerRepeaterId($frontEndId, $newRelation->id);
             }
         }
 
@@ -214,8 +257,13 @@ trait HandleRepeaters
      * @param string|null $repeaterName
      * @return array
      */
-    public function getFormFieldsForRepeater($object, $fields, $relation, $modelOrRepository = null, $repeaterName = null)
-    {
+    public function getFormFieldsForRepeater(
+        $object,
+        $fields,
+        $relation,
+        $modelOrRepository = null,
+        $repeaterName = null
+    ) {
         if (!$repeaterName) {
             $repeaterName = $relation;
         }
@@ -253,13 +301,17 @@ trait HandleRepeaters
 
             if (isset($relatedItemFormFields['medias'])) {
                 if (config('twill.media_library.translated_form_fields', false)) {
-                    Collection::make($relatedItemFormFields['medias'])->each(function ($rolesWithMedias, $locale) use (&$repeatersMedias, $relation, $relationItem) {
-                        $repeatersMedias[] = Collection::make($rolesWithMedias)->mapWithKeys(function ($medias, $role) use ($locale, $relation, $relationItem) {
-                            return [
-                                "blocks[$relation-$relationItem->id][$role][$locale]" => $medias,
-                            ];
-                        })->toArray();
-                    });
+                    Collection::make($relatedItemFormFields['medias'])->each(
+                        function ($rolesWithMedias, $locale) use (&$repeatersMedias, $relation, $relationItem) {
+                            $repeatersMedias[] = Collection::make($rolesWithMedias)->mapWithKeys(
+                                function ($medias, $role) use ($locale, $relation, $relationItem) {
+                                    return [
+                                        "blocks[$relation-$relationItem->id][$role][$locale]" => $medias,
+                                    ];
+                                }
+                            )->toArray();
+                        }
+                    );
                 } else {
                     foreach ($relatedItemFormFields['medias'] as $key => $values) {
                         $repeatersMedias["blocks[$relation-$relationItem->id][$key]"] = $values;
@@ -268,13 +320,17 @@ trait HandleRepeaters
             }
 
             if (isset($relatedItemFormFields['files'])) {
-                Collection::make($relatedItemFormFields['files'])->each(function ($rolesWithFiles, $locale) use (&$repeatersFiles, $relation, $relationItem) {
-                    $repeatersFiles[] = Collection::make($rolesWithFiles)->mapWithKeys(function ($files, $role) use ($locale, $relation, $relationItem) {
-                        return [
-                            "blocks[$relation-$relationItem->id][$role][$locale]" => $files,
-                        ];
-                    })->toArray();
-                });
+                Collection::make($relatedItemFormFields['files'])->each(
+                    function ($rolesWithFiles, $locale) use (&$repeatersFiles, $relation, $relationItem) {
+                        $repeatersFiles[] = Collection::make($rolesWithFiles)->mapWithKeys(
+                            function ($files, $role) use ($locale, $relation, $relationItem) {
+                                return [
+                                    "blocks[$relation-$relationItem->id][$role][$locale]" => $files,
+                                ];
+                            }
+                        )->toArray();
+                    }
+                );
             }
 
             if (isset($relatedItemFormFields['browsers'])) {
@@ -283,7 +339,8 @@ trait HandleRepeaters
                 }
             }
 
-            $itemFields = method_exists($relationItem, 'toRepeaterArray') ? $relationItem->toRepeaterArray() : Arr::except($relationItem->attributesToArray(), $translatedFields);
+            $itemFields = method_exists($relationItem, 'toRepeaterArray') ? $relationItem->toRepeaterArray(
+            ) : Arr::except($relationItem->attributesToArray(), $translatedFields);
 
             foreach ($itemFields as $key => $value) {
                 $repeatersFields[] = [
@@ -295,10 +352,22 @@ trait HandleRepeaters
             if (isset($relatedItemFormFields['repeaters'])) {
                 foreach ($relatedItemFormFields['repeaters'] as $childRepeaterName => $childRepeaterItems) {
                     $fields['repeaters']["blocks-$relation-{$relationItem->id}_$childRepeaterName"] = $childRepeaterItems;
-                    $repeatersFields = array_merge($repeatersFields, $relatedItemFormFields['repeaterFields'][$childRepeaterName]);
-                    $repeatersMedias = array_merge($repeatersMedias, $relatedItemFormFields['repeaterMedias'][$childRepeaterName]);
-                    $repeatersFiles = array_merge($repeatersFiles, $relatedItemFormFields['repeaterFiles'][$childRepeaterName]);
-                    $repeatersBrowsers = array_merge($repeatersBrowsers, $relatedItemFormFields['repeaterBrowsers'][$childRepeaterName]);
+                    $repeatersFields = array_merge(
+                        $repeatersFields,
+                        $relatedItemFormFields['repeaterFields'][$childRepeaterName]
+                    );
+                    $repeatersMedias = array_merge(
+                        $repeatersMedias,
+                        $relatedItemFormFields['repeaterMedias'][$childRepeaterName]
+                    );
+                    $repeatersFiles = array_merge(
+                        $repeatersFiles,
+                        $relatedItemFormFields['repeaterFiles'][$childRepeaterName]
+                    );
+                    $repeatersBrowsers = array_merge(
+                        $repeatersBrowsers,
+                        $relatedItemFormFields['repeaterBrowsers'][$childRepeaterName]
+                    );
                 }
             }
         }
@@ -331,8 +400,12 @@ trait HandleRepeaters
         return collect($this->repeaters)->map(function ($repeater, $key) {
             $repeaterName = is_string($repeater) ? $repeater : $key;
             return [
-                'relation' => !empty($repeater['relation']) ? $repeater['relation'] : $this->inferRelationFromRepeaterName($repeaterName),
-                'model' => !empty($repeater['model']) ? $repeater['model'] : $this->inferModelFromRepeaterName($repeaterName),
+                'relation' => !empty($repeater['relation']) ? $repeater['relation'] : $this->inferRelationFromRepeaterName(
+                    $repeaterName
+                ),
+                'model' => !empty($repeater['model']) ? $repeater['model'] : $this->inferModelFromRepeaterName(
+                    $repeaterName
+                ),
                 'repeaterName' => $repeaterName,
             ];
         })->values();

--- a/src/Repositories/Behaviors/HandleRepeaters.php
+++ b/src/Repositories/Behaviors/HandleRepeaters.php
@@ -196,7 +196,6 @@ trait HandleRepeaters
         // keep a list of updated and new rows to delete (soft delete?) old rows that were deleted from the frontend
         $currentIdList = [];
 
-
         foreach ($relationFields as $index => $relationField) {
             $relationField['position'] = $index + 1;
             // If the relation is not an "existing" one try to match it with our session.
@@ -208,7 +207,7 @@ trait HandleRepeaters
             }
 
             // Set the active data based on the parent.
-            if (!isset($relationField['languages'])) {
+            if (!isset($relationField['languages']) && isset($relationField['active'])) {
                 foreach ($relationField['active'] as $langCode => $active) {
                     // Add the languages field.
                     $relationField['languages'][] = [

--- a/src/Repositories/ModuleRepository.php
+++ b/src/Repositories/ModuleRepository.php
@@ -60,7 +60,7 @@ abstract class ModuleRepository
      * @param array $orders
      * @param int $perPage
      * @param bool $forcePagination
-     * @return \Illuminate\Database\Eloquent\Collection
+     * @return \Illuminate\Support\Collection|\Illuminate\Contracts\Pagination\LengthAwarePaginator
      */
     public function get($with = [], $scopes = [], $orders = [], $perPage = 20, $forcePagination = false)
     {
@@ -259,7 +259,7 @@ abstract class ModuleRepository
     /**
      * @param array $attributes
      * @param array $fields
-     * @return \A17\Twill\Models\Model
+     * @return \A17\Twill\Models\Model|void
      */
     public function updateOrCreate($attributes, $fields)
     {

--- a/src/TwillServiceProvider.php
+++ b/src/TwillServiceProvider.php
@@ -109,15 +109,14 @@ class TwillServiceProvider extends ServiceProvider
 
     /**
      * Registers the package services.
-     *
-     * @return void
      */
-    public function register()
+    public function register(): void
     {
         $this->mergeConfigs();
 
         $this->registerProviders();
         $this->registerAliases();
+        $this->registerFacades();
 
         Relation::morphMap([
             'users' => User::class,
@@ -129,12 +128,16 @@ class TwillServiceProvider extends ServiceProvider
         config(['twill.version' => $this->version()]);
     }
 
+    private function registerFacades(): void {
+        $this->app->bind('twill_util', function() {
+            return new TwillUtil();
+        });
+    }
+
     /**
      * Registers the package service providers.
-     *
-     * @return void
      */
-    private function registerProviders()
+    private function registerProviders(): void
     {
         foreach ($this->providers as $provider) {
             $this->app->register($provider);

--- a/src/TwillUtil.php
+++ b/src/TwillUtil.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace A17\Twill;
+
+use Illuminate\Support\Facades\Session;
+
+/**
+ * @todo: This could "pile up" over time. Maybe we can clear it when a new form is being built.
+ */
+class TwillUtil
+{
+    private const SESSION_FIELD = 'twill_util';
+    private const REPEATER_ID_INDEX = 'repeater_ids';
+
+    public function hasRepeaterIdFor(int $frontEndId): ?int {
+        return $this->getFromTempStore(self::REPEATER_ID_INDEX, $frontEndId);
+    }
+
+    public function registerRepeaterId(int $frontEndId, int $dbId): self
+    {
+        $this->pushToTempStore(self::REPEATER_ID_INDEX, $frontEndId, $dbId);
+
+        return $this;
+    }
+
+    private function getFromTempStore(string $key, int $frontendId): ?int {
+        $data = Session::get(self::SESSION_FIELD . '.' . $key, []);
+
+        return $data[$frontendId] ?? null;
+    }
+
+    private function pushToTempStore(string $key, int $frontendId, int $dbId): void
+    {
+        $sessionData = Session::get(self::SESSION_FIELD . '.' . $key, []);
+
+        $keyData = $sessionData[$key] ?? [];
+        $keyData[$frontendId] = $dbId;
+
+        $sessionData[$key] = $keyData;
+
+        Session::put(self::SESSION_FIELD, $sessionData);
+    }
+}

--- a/src/TwillUtil.php
+++ b/src/TwillUtil.php
@@ -10,7 +10,9 @@ use Illuminate\Support\Facades\Session;
 class TwillUtil
 {
     private const SESSION_FIELD = 'twill_util';
+
     private const REPEATER_ID_INDEX = 'repeater_ids';
+    private const BLOCK_ID_INDEX = 'block_ids';
 
     public function hasRepeaterIdFor(int $frontEndId): ?int {
         return $this->getFromTempStore(self::REPEATER_ID_INDEX, $frontEndId);
@@ -23,15 +25,26 @@ class TwillUtil
         return $this;
     }
 
-    private function getFromTempStore(string $key, int $frontendId): ?int {
-        $data = Session::get(self::SESSION_FIELD . '.' . $key, []);
+    public function hasBlockIdFor(int $frontEndId): ?int {
+        return $this->getFromTempStore(self::BLOCK_ID_INDEX, $frontEndId);
+    }
 
-        return $data[$frontendId] ?? null;
+    public function registerBlockId(int $frontEndId, int $dbId): self
+    {
+        $this->pushToTempStore(self::BLOCK_ID_INDEX, $frontEndId, $dbId);
+
+        return $this;
+    }
+
+    private function getFromTempStore(string $key, int $frontendId): ?int {
+        $data = Session::get(self::SESSION_FIELD, []);
+
+        return $data[$key][$frontendId] ?? null;
     }
 
     private function pushToTempStore(string $key, int $frontendId, int $dbId): void
     {
-        $sessionData = Session::get(self::SESSION_FIELD . '.' . $key, []);
+        $sessionData = Session::get(self::SESSION_FIELD, []);
 
         $keyData = $sessionData[$key] ?? [];
         $keyData[$frontendId] = $dbId;


### PR DESCRIPTION
## Description

This pr introduces some changes:

- When a new repeater is saved multiple times, we keep track of frontend/backend ids to not delete/resave so the IDs do no longer pile up.
- The active state is taken from the parent model, this also automatically publishes/unpublishes the slugs
- Blocks and childblocks are now updating instead of removing/creating.

Repeaters will not work nicely if it would be a module itself. As the active/inactive state of a translation might "desync"
Repeater activates the translation, while it might be disabled from the module's page itself.

There is no easy fix for this but to have the active flag (like in the sidebar) on the repeater itself.

(this problem is not new with this pr but has always existed)

Below is something I found out as well, but not really an issue.

When you remove the repeater field from the model and save, the values are erased in the database. -> I guess we can fix this to leave them untouched.