### PR TITLE
#1433: Allow max repeaters to be defined from the field.

### DIFF
--- a/docs/src/block-editor/adding-repeater-fields-to-a-block.md
+++ b/docs/src/block-editor/adding-repeater-fields-to-a-block.md
@@ -16,12 +16,12 @@ Inside a block, repeaters can be used too.
 ```
 You can add other fields before or after your repeater, or even multiple repeaters to the same block.
 
-- Create an *item* block, the one that will be reapeated inside the *container* block
+- Create an *item* block, the one that will be repeated inside the *container* block
 
 filename: ```views/admin/repeaters/accordion_item.blade.php```
 ```php
   @twillRepeaterTitle('Accordion item')
-  @twillRepeaterMax('10')
+  @twillRepeaterMax('10') // Optional
 
   @formField('input', [
       'name' => 'header',

--- a/docs/src/block-editor/creating-a-block-editor.md
+++ b/docs/src/block-editor/creating-a-block-editor.md
@@ -43,7 +43,8 @@ Available annotations:
   - Provide an icon with `@twillPropIcon` or `@twillBlockIcon` or `@twillRepeaterIcon`
   - Provide a group with `@twillPropGroup` or `@twillBlockGroup` or `@twillRepeaterGroup` (defaults to `app`)
   - Provide a repeater trigger label with `@twillPropTrigger` or `@twillRepeaterTrigger`
-  - Provide a repeater max items with `@twillPropMax` or `@twillRepeaterMax`
+  - Provide a repeater max items with `@twillPropMax` or `@twillRepeaterMax`, `@twillRepeaterMax` can also be defined from
+the formField. See [Repeater form field](/form-fields/repeater.html)
   - Define a block or repeater as compiled with `@twillPropCompiled` or `@twillBlockCompiled` or `@twillRepeaterCompiled`
   - Define a block or repeater component with `@twillPropComponent` or `@twillBlockComponent` or `@twillRepeaterComponent`
 

--- a/docs/src/form-fields/repeater.md
+++ b/docs/src/form-fields/repeater.md
@@ -10,11 +10,12 @@ pageClass: twill-doc
 @formField('repeater', ['type' => 'video'])
 ```
 
-| Option       | Description                                   | Type    | Default value  |
-| :----------- | :-------------------------------------------- | :-------| :------------- |
-| type         | Type of repeater items                        | string  |                |
-| name         | Name of the field                             | string  | same as `type` |
-| buttonAsLink | Displays the `Add` button as a centered link  | boolean | false          |
+| Option       | Description                                  | Type    | Default value    |
+|:-------------|:---------------------------------------------|:--------|:-----------------|
+| type         | Type of repeater items                       | string  |                  |
+| name         | Name of the field                            | string  | same as `type`   |
+| max          | Maximum amount that can be created           | number  | null (unlimited) |
+| buttonAsLink | Displays the `Add` button as a centered link | boolean | false            |
 
 <br/>
 

--- a/views/partials/form/_repeater.blade.php
+++ b/views/partials/form/_repeater.blade.php
@@ -1,10 +1,12 @@
 @php
     $name = $name ?? $type;
     $buttonAsLink = $buttonAsLink ?? false;
+    $max = $max ?? null;
 @endphp
 
 <a17-repeater
     type="{{ $type }}"
+    @if ($max) :max="{{$max}}" @endif
     @if ($renderForBlocks) :name="repeaterName('{{ $name }}')" @else name="{{ $name }}" @endif
     @if ($buttonAsLink) :button-as-link="true" @endif
 ></a17-repeater>


### PR DESCRIPTION
## Description

This will now allow max repeaters to be set from the field rather than the repeater itself.

Both still work, but field level takes priority.

## Related Issues

fixes #1433 
