### PR TITLE
Fix unauthenticated user 500 error

### DIFF
--- a/src/Exceptions/Handler.php
+++ b/src/Exceptions/Handler.php
@@ -21,9 +21,11 @@ class Handler extends ExceptionHandler
      */
     protected function unauthenticated($request, AuthenticationException $exception)
     {
-        return $request->expectsJson()
-            ? response()->json(['message' => $exception->getMessage()], 401)
-            : redirect()->guest($exception->redirectTo() ?? route('admin.login', Route::current()->parameters()));
+        if ($request->expectsJson()) {
+            return response()->json(['message' => $exception->getMessage()], 401);
+        }
+
+        return parent::unauthenticated($request, $exception);
     }
 
     /**

--- a/src/Exceptions/Handler.php
+++ b/src/Exceptions/Handler.php
@@ -13,22 +13,6 @@ use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 class Handler extends ExceptionHandler
 {
     /**
-     * Convert an authentication exception into a response.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  \Illuminate\Auth\AuthenticationException  $exception
-     * @return \Symfony\Component\HttpFoundation\Response
-     */
-    protected function unauthenticated($request, AuthenticationException $exception)
-    {
-        if ($request->expectsJson()) {
-            return response()->json(['message' => $exception->getMessage()], 401);
-        }
-
-        return parent::unauthenticated($request, $exception);
-    }
-
-    /**
      * Get the view used to render HTTP exceptions.
      *
      * @param  \Symfony\Component\HttpKernel\Exception\HttpExceptionInterface  $e

--- a/src/Http/Middleware/Authenticate.php
+++ b/src/Http/Middleware/Authenticate.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace A17\Twill\Http\Middleware;
+
+use Illuminate\Auth\Middleware\Authenticate as Middleware;
+
+class Authenticate extends Middleware
+{
+    /**
+     * Get the path the user should be redirected to when they are not authenticated.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return string|null
+     */
+    protected function redirectTo($request)
+    {
+        return route('admin.login.form');
+    }
+}

--- a/src/RouteServiceProvider.php
+++ b/src/RouteServiceProvider.php
@@ -9,6 +9,7 @@ use A17\Twill\Http\Middleware\Localization;
 use A17\Twill\Http\Middleware\RedirectIfAuthenticated;
 use A17\Twill\Http\Middleware\SupportSubdomainRouting;
 use A17\Twill\Http\Middleware\ValidateBackHistory;
+use A17\Twill\Http\Middleware\Authenticate;
 use A17\Twill\Services\Routing\HasRoutes;
 use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;
 use Illuminate\Routing\Router;
@@ -191,10 +192,7 @@ class RouteServiceProvider extends ServiceProvider
             SupportSubdomainRouting::class
         );
         Route::aliasMiddleware('impersonate', Impersonate::class);
-        Route::aliasMiddleware(
-            'twill_auth',
-            \Illuminate\Auth\Middleware\Authenticate::class
-        );
+        Route::aliasMiddleware('twill_auth', Authenticate::class);
         Route::aliasMiddleware('twill_guest', RedirectIfAuthenticated::class);
         Route::aliasMiddleware(
             'validateBackHistory',


### PR DESCRIPTION
## Description

Currently, Twill aliases the \Illuminate\Auth\Middleware\Authenticate::class as 'twill_auth'.

The issue with this is that \Illuminate\Auth\Middleware\Authenticate's redirectTo function returns nothing, so it defaults to the Laravel default of the "login" named route as where it should redirect.

The issue with that, is that there is no login named route in Twill admin dashboard, instead there is 'admin.login.form'.

This PR creates a new Authenticate middleware in Twill that extends \Illuminate\Auth\Middleware\Authenticate and specifies the redirectTo function route correctly as 'admin.login.form'. This PR also modifies the routeserviceprovider so that it uses the new extended Authenticate class instead of the core Illuminate authenticate middleware.

## Related Issues

None I am aware of
