### PR TITLE
Fixed meta title typo "Documenation" -> "Documentation" on docs landing

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,6 +1,6 @@
 ---
 pageClass: twill-doc
-title: Documenation
+title: Documentation
 next: "/preface/"
 ---
 


### PR DESCRIPTION
## Description

Fixed typo in the front-matter title for the Docs homepage.

## Related Issues

None
