### PR TITLE
Fix: repeater inside a block has wrong expanding behavior

### DIFF
--- a/frontend/js/components/Repeater.vue
+++ b/frontend/js/components/Repeater.vue
@@ -4,14 +4,15 @@
       <transition-group name="draggable_list" tag='div'>
         <div class="content__item" v-for="(block, index) in blocks" :key="block.id">
           <a17-blockeditor-item
-              ref="blockList"
-              :block="block"
-              :index="index"
-              :size="blockSize"
-              :opened="opened"
-              @expand="setOpened">
-            <a17-button slot="block-actions" variant="icon" data-action @click="duplicateBlock(index)"
-                        v-if="hasRemainingBlocks"><span v-svg symbol="add"></span></a17-button>
+            ref="blockList"
+            :block="block"
+            :index="index"
+            :size="blockSize"
+            :opened="opened"
+          >
+            <a17-button slot="block-actions" variant="icon" data-action @click="duplicateBlock(index)" v-if="hasRemainingBlocks">
+              <span v-svg symbol="add"></span>
+            </a17-button>
             <div slot="dropdown-action">
               <button type="button" @click="collapseAllBlocks()" v-if="opened">
                 {{ $trans('fields.block-editor.collapse-all', 'Collapse all') }}
@@ -32,10 +33,11 @@
     </draggable>
     <div class="content__trigger">
       <a17-button
-          v-if="hasRemainingBlocks && blockType.trigger"
-          :class="triggerClass"
-          :variant="triggerVariant"
-          @click="addBlock()">
+        v-if="hasRemainingBlocks && blockType.trigger"
+        :class="triggerClass"
+        :variant="triggerVariant"
+        @click="addBlock()"
+      >
         {{ blockType.trigger }}
       </a17-button>
       <div class="content__note f--note f--small">
@@ -135,11 +137,7 @@
       })
     },
     methods: {
-      setOpened: function () {
-        this.opened = true
-      },
       addBlock: function () {
-        this.opened = true
         this.$store.commit(FORM.ADD_FORM_BLOCK, { type: this.type, name: this.name })
       },
       duplicateBlock: function (index) {

--- a/frontend/js/components/blocks/BlockEditorItem.vue
+++ b/frontend/js/components/blocks/BlockEditorItem.vue
@@ -3,8 +3,7 @@
     <div class="block__header" @dblclick.prevent="toggleExpand()">
       <span class="block__handle"></span>
       <div class="block__toggle">
-        <a17-dropdown :ref="moveDropdown" class="f--small" position="bottom-left" v-if="withMoveDropdown"
-                      :maxHeight="270">
+        <a17-dropdown :ref="moveDropdown" class="f--small" position="bottom-left" v-if="withMoveDropdown" :maxHeight="270">
           <span class="block__counter f--tiny" @click="$refs[moveDropdown].toggle()">{{ index + 1 }}</span>
           <div slot="dropdown__content">
             <slot name="dropdown-numbers"/>
@@ -15,8 +14,7 @@
       </div>
       <div class="block__actions">
         <slot name="block-actions"/>
-        <a17-dropdown :ref="addDropdown" position="bottom-right" @open="hover = true" @close="hover = false"
-                      v-if="withAddDropdown">
+        <a17-dropdown :ref="addDropdown" position="bottom-right" @open="hover = true" @close="hover = false" v-if="withAddDropdown">
           <a17-button variant="icon" data-action @click="$refs[addDropdown].toggle()"><span v-svg symbol="add"></span>
           </a17-button>
           <div slot="dropdown__content">
@@ -37,8 +35,9 @@
       </div>
     </div>
     <div class="block__content" :aria-hidden="!visible ? true : null">
-      <component v-bind:is="`${block.type}`" :name="componentName(block.id)" v-bind="block.attributes"
-                 :key="`form_${block.type}_${block.id}`"><!-- dynamic components --></component>
+      <component v-bind:is="`${block.type}`" :name="componentName(block.id)" v-bind="block.attributes" :key="`form_${block.type}_${block.id}`">
+        <!-- dynamic components -->
+      </component>
       <!-- Block validation input frame, to display errors -->
       <a17-inputframe size="small" label="" :name="`block.${block.id}`"></a17-inputframe>
     </div>
@@ -130,7 +129,6 @@
     methods: {
       toggleExpand () {
         this.visible = !this.visible
-        this.$emit('expand', this.visible)
       },
       componentName (id) {
         return 'blocks[' + id + ']'


### PR DESCRIPTION
fixed the bug that when the add item button or the expand item button is clicked, all the items are expanded, this is especially uncomfortable in repeaters with a lot of items since the end user has to scroll down to get to the item that was just added, this also caused lag for a brief moment 
