### PR TITLE
feat: Allow custom revision label from revisionsArray()

### DIFF
--- a/frontend/js/components/Previewer.vue
+++ b/frontend/js/components/Previewer.vue
@@ -18,9 +18,9 @@
                 </template>
               </a17-button>
               <div slot="dropdown__content">
-                <button type="button" class="previewerRevision" :class="{ 'previewerRevision--active' : currentRevision.id === revision.id }" @click="toggleRevision(revision.id)" v-for="(revision, index) in revisions"  :key="revision.id">
+                <button type="button" class="previewerRevision" :class="{ 'previewerRevision--active' : currentRevision.id === revision.id }" @click="toggleRevision(revision.id)" v-for="revision in revisions"  :key="revision.id">
                   <span class="previewerRevision__author">{{ revision.author }}</span>
-                  <span class="previewerRevision__datetime"><span class="tag" v-if="index === 0">{{ $trans('previewer.current-revision') }}</span> {{ revision.datetime | formatDate }}</span>
+                  <span class="previewerRevision__datetime"><span class="tag" v-if="revision.label">{{ revision.label }}</span> {{ revision.datetime | formatDate }}</span>
                 </button>
               </div>
             </a17-dropdown>

--- a/frontend/js/components/RevisionAccordion.vue
+++ b/frontend/js/components/RevisionAccordion.vue
@@ -4,10 +4,13 @@
     <div slot="accordion__value">{{ $trans('publisher.last-edit') }} <timeago :auto-update="1" :datetime="new Date(revisions[0].datetime)"></timeago></div>
     <div class="revaccordion__scroller">
       <ul class="revaccordion__list">
-        <li class="revaccordion__item" v-for="(revision, index) in revisions" :key="revision.id">
+        <li class="revaccordion__item" v-for="revision in revisions" :key="revision.id">
           <a href="#" @click.prevent="openPreview(revision.id)">
             <span class="revaccordion__author">{{ revision.author }}</span>
-            <span class="revaccordion__datetime"><span class="tag" v-if="index === 0">{{ $trans('publisher.current') }}</span> {{ revision.datetime | formatDate }}</span>
+            <span class="revaccordion__datetime">
+              <span class="tag" v-if="revision.label">{{  revision.label }}</span>
+              {{ revision.datetime | formatDate }}
+            </span>
           </a>
         </li>
       </ul>

--- a/src/Models/Behaviors/HasRevisions.php
+++ b/src/Models/Behaviors/HasRevisions.php
@@ -34,11 +34,12 @@ trait HasRevisions
      */
     public function revisionsArray()
     {
-        return $this->revisions->map(function ($revision) {
+        return $this->revisions->map(function ($revision, $index) {
             return [
                 'id' => $revision->id,
                 'author' => $revision->user->name ?? 'Unknown',
                 'datetime' => $revision->created_at->toIso8601String(),
+                'label' => $index === 0 ? twillTrans('twill::lang.publisher.current') : '',
             ];
         })->toArray();
     }


### PR DESCRIPTION
## Description

This moves the revision label logic from the frontend components back to the `HasRevisions` trait. By overriding the `revisionsArray()` method on a model, this can be the basis of a customized workflow around the revision history:

![revision-label](https://user-images.githubusercontent.com/7805679/155405944-9897db97-5ed6-4bee-8857-1fab2780515a.png)

## Related Issues

—