### PR TITLE
enh: Add language publication control to TitleEditor and LangManager

### DIFF
--- a/frontend/js/components/LangManager.vue
+++ b/frontend/js/components/LangManager.vue
@@ -1,12 +1,14 @@
 <template>
   <div class="languageManager" v-if="languages.length > 1">
     <div class="languageManager__switcher">
-      <a17-langswitcher :in-modal="true"/>
+      <a17-langswitcher :in-modal="true" :all-published="!controlPublication" />
     </div>
     <a17-dropdown class="languageManager__dropdown"
                   ref="languageManagerDropdown"
                   position="bottom-right"
-                  :clickable="true">
+                  :clickable="true"
+                  v-if="controlPublication"
+    >
       <button class="languageManager__button"
               type="button"
               @click="$refs.languageManagerDropdown.toggle()">
@@ -38,6 +40,10 @@
       'a17-langswitcher': a17LangSwitcher
     },
     props: {
+      controlPublication: {
+        type: Boolean,
+        default: true
+      },
       value: {
         default: function () { return [] }
       }

--- a/frontend/js/components/TitleEditor.vue
+++ b/frontend/js/components/TitleEditor.vue
@@ -14,7 +14,7 @@
 
       <!-- Editing modal -->
       <a17-modal class="modal--form" ref="editModal" :title="modalTitle" :forceLock="disabled">
-        <a17-langmanager></a17-langmanager>
+        <a17-langmanager :control-publication="controlLanguagesPublication"></a17-langmanager>
         <form action="#" @submit.prevent="update" ref="modalForm">
           <slot name="modal-form"></slot>
           <a17-modal-validation :mode="mode" @disable="lockModal"></a17-modal-validation>
@@ -60,6 +60,10 @@
         default: 'title'
       },
       editableTitle: {
+        type: Boolean,
+        default: true
+      },
+      controlLanguagesPublication: {
         type: Boolean,
         default: true
       },

--- a/views/layouts/form.blade.php
+++ b/views/layouts/form.blade.php
@@ -45,6 +45,7 @@
                 <a17-title-editor
                     name="{{ $titleFormKey }}"
                     :editable-title="{{ json_encode($editableTitle ?? true) }}"
+                    :control-languages-publication="{{ json_encode($controlLanguagesPublication) }}"
                     custom-title="{{ $customTitle ?? '' }}"
                     custom-permalink="{{ $customPermalink ?? '' }}"
                     localized-permalinkbase="{{ json_encode($localizedPermalinkBase ?? '') }}"

--- a/views/layouts/listing.blade.php
+++ b/views/layouts/listing.blade.php
@@ -10,6 +10,7 @@
     $bulkEdit = $bulkEdit ?? true;
     $create = $create ?? false;
     $skipCreateModal = $skipCreateModal ?? false;
+    $controlLanguagesPublication = $controlLanguagesPublication ?? true;
 
     $requestFilter = json_decode(request()->get('filter'), true) ?? [];
 @endphp
@@ -144,7 +145,9 @@
                 @if ($customPublishedLabel ?? false) published-label="{{ $customPublishedLabel }}" @endif
                 @if ($customDraftLabel ?? false) draft-label="{{ $customDraftLabel }}" @endif
             >
-                <a17-langmanager></a17-langmanager>
+                <a17-langmanager
+                    :control-publication="{{ json_encode($controlLanguagesPublication) }}"
+                ></a17-langmanager>
                 @partialView(($moduleName ?? null), 'create', ['renderForModal' => true])
             </a17-modal-create>
         @endif


### PR DESCRIPTION
## Description

In the `form` layout, it's possible to set a `$controlLanguagesPublication` variable in order to control a user's ability to mark languages as active.

This PR:
- makes it possible to set `$controlLanguagesPublication` in the `listing` layout to control this ability in the create modal
- follows this setting in the form's title editor modal

**`$controlLanguagesPublication = true` (default)** :

![01-language-publication](https://user-images.githubusercontent.com/7805679/155407023-aeb22df9-ee46-435d-b29e-9df0e83adee3.png)

**`$controlLanguagesPublication = false`** : 

![02-no-language-publication](https://user-images.githubusercontent.com/7805679/155407036-4839e10a-0d26-4a62-a392-094f7bff4902.png)

## Related Issues

—
