### PR TITLE
Fixed not all Translations were loaded within editInModal

### DIFF
--- a/src/Models/Behaviors/HasTranslation.php
+++ b/src/Models/Behaviors/HasTranslation.php
@@ -4,6 +4,7 @@ namespace A17\Twill\Models\Behaviors;
 
 use Astrotomic\Translatable\Translatable;
 use Illuminate\Database\Query\JoinClause;
+use Illuminate\Support\Collection;
 
 trait HasTranslation
 {
@@ -130,16 +131,15 @@ trait HasTranslation
      */
     public function getActiveLanguages()
     {
-        return $this->translations->map(function ($translation) {
+        return Collection::make(getLocales())->map(function ($locale) {
+            $translation = $this->translations->firstWhere('locale', $locale);
+
             return [
-                'shortlabel' => strtoupper($translation->locale),
-                'label' => getLanguageLabelFromLocaleCode($translation->locale),
-                'value' => $translation->locale,
+                'shortlabel' => strtoupper($locale),
+                'label' => getLanguageLabelFromLocaleCode($locale),
+                'value' => $locale,
                 'published' => $translation->active ?? false,
             ];
-        })->sortBy(function ($translation) {
-            $localesOrdered = getLocales();
-            return array_search($translation['value'], $localesOrdered);
         })->values();
     }
 


### PR DESCRIPTION
## Description

If you subsequently add a language to Twill, it is not displayed in the `editInModal` Modal  (only on items that were created before the new language was added).

![add_new_modal](https://user-images.githubusercontent.com/25499317/155498524-766d2823-2f7b-43fd-a7a2-d94a7658a096.png)
![edit_in_modal](https://user-images.githubusercontent.com/25499317/155498547-fa2e2443-45a4-4bdd-a04f-64ae4ec737ee.png)

With this pull-request the defined locales are used instead of the translations from database of this item.


