### PR TITLE
Update Refresh Crops command to take in consideration the MorphMap.

### DIFF
--- a/src/Commands/RefreshCrops.php
+++ b/src/Commands/RefreshCrops.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use A17\Twill\Models\Media;
+use Illuminate\Database\Eloquent\Relations\Relation;
 
 class RefreshCrops extends Command
 {
@@ -120,6 +121,16 @@ class RefreshCrops extends Command
         $mediables = $this->db
             ->table(config('twill.mediables_table', 'twill_mediables'))
             ->where(['mediable_type' => $this->modelName, 'role' => $this->roleName]);
+
+        // If the model exists in the Morphmap, we loop for the morphed name instead.
+        $mediableType = $this->modelName;
+        if ($morphedModelName = array_search($this->modelName, Relation::morphMap())) {
+            $mediableType = $morphedModelName;
+        }
+
+        $mediables = $this->db
+            ->table(config('twill.mediables_table', 'twill_mediables'))
+            ->where(['mediable_type' => $mediableType, 'role' => $this->roleName]);
 
         if ($mediables->count() === 0) {
             $this->warn("No mediables found for model `$this->modelName` and role `$this->roleName`");

--- a/src/Commands/RefreshCrops.php
+++ b/src/Commands/RefreshCrops.php
@@ -118,10 +118,6 @@ class RefreshCrops extends Command
 
         $this->crops = collect($mediasParams[$this->roleName]);
 
-        $mediables = $this->db
-            ->table(config('twill.mediables_table', 'twill_mediables'))
-            ->where(['mediable_type' => $this->modelName, 'role' => $this->roleName]);
-
         // If the model exists in the Morphmap, we loop for the morphed name instead.
         $mediableType = $this->modelName;
         if ($morphedModelName = array_search($this->modelName, Relation::morphMap())) {


### PR DESCRIPTION
## Description

Right now the RefreshCrop command only takes the Full Model name and namespace to create/process the new crops.
If a MorphMap is set, it will not find any new crop to process.

## Solution
Added dependency for the Eloquent Relation.
Add logic for verifying the existence of the provided ModelName in the definition of the MorphMap

