### PR TITLE
Remove 'with' from orderByTranslation scopes

### DIFF
--- a/src/Models/Behaviors/HasTranslation.php
+++ b/src/Models/Behaviors/HasTranslation.php
@@ -79,8 +79,7 @@ trait HasTranslation
             })
             ->where($translationTable.'.'.$this->getLocaleKey(), $locale)
             ->orderBy($translationTable.'.'.$orderField, $orderType)
-            ->select($table.'.*')
-            ->with('translations');
+            ->select($table.'.*');
     }
 
     /**

--- a/src/Models/Behaviors/HasTranslation.php
+++ b/src/Models/Behaviors/HasTranslation.php
@@ -101,8 +101,7 @@ trait HasTranslation
             ->groupBy("{$table}.id")
             ->groupBy("t.{$groupByField}")
             ->select("{$table}.*")
-            ->orderByRaw($orderRawString)
-            ->with('translations');
+            ->orderByRaw($orderRawString);
     }
 
     /**


### PR DESCRIPTION
## Description

When using the scope function `withActiveTranslations()` in combination with `orderByTranslation()` or `orderByRawByTranslation`, the orderBy functions was overwriting the with-query from `withActiveTranslations()`. This results in all languages being delivered instead of just the current one.
