### PR TITLE
Allows slugs to be empty

### DIFF
--- a/frontend/js/components/TitleEditor.vue
+++ b/frontend/js/components/TitleEditor.vue
@@ -7,7 +7,7 @@
         </a>
         <span v-else>{{ customTitle ? customTitle : title }}</span>
       </h2>
-      <a v-if="(permalink || customPermalink) && !showModal" :href="fullUrl" target="_blank" class="titleEditor__permalink f--small">
+      <a v-if="(typeof permalink !== 'undefined' || typeof customPermalink !== 'undefined') && !showModal" :href="fullUrl" target="_blank" class="titleEditor__permalink f--small">
         <span class="f--note f--external f--underlined--o">{{ visibleUrl | prettierUrl }}</span>
       </a>
       <span v-if="showModal" class="titleEditor__permalink f--small f--note f--external f--underlined--o">{{ visibleUrl | prettierUrl }}</span>
@@ -73,7 +73,7 @@
       },
       customPermalink: {
         type: String,
-        default: ''
+        default: undefined
       },
       localizedPermalinkbase: {
         type: String,

--- a/src/Repositories/Behaviors/HandleSlugs.php
+++ b/src/Repositories/Behaviors/HandleSlugs.php
@@ -13,7 +13,7 @@ trait HandleSlugs
     {
         if (property_exists($this->model, 'slugAttributes')) {
             foreach (getLocales() as $locale) {
-                if (isset($fields['slug']) && isset($fields['slug'][$locale]) && !empty($fields['slug'][$locale])) {
+                if (isset($fields['slug']) && isset($fields['slug'][$locale]) && $fields['slug'][$locale] !== null) {
                     $object->disableLocaleSlugs($locale);
                     $currentSlug = [];
                     $currentSlug['slug'] = $fields['slug'][$locale];

--- a/views/layouts/form.blade.php
+++ b/views/layouts/form.blade.php
@@ -47,9 +47,13 @@
                     :editable-title="{{ json_encode($editableTitle ?? true) }}"
                     :control-languages-publication="{{ json_encode($controlLanguagesPublication) }}"
                     custom-title="{{ $customTitle ?? '' }}"
-                    custom-permalink="{{ $customPermalink ?? '' }}"
+                    @isset($customPermalink)
+                        custom-permalink="{{ $customPermalink }}"
+                    @endisset
                     localized-permalinkbase="{{ json_encode($localizedPermalinkBase ?? '') }}"
-                    localized-custom-permalink="{{ json_encode($localizedCustomPermalink ?? '') }}"
+                    @isset($localizedCustomPermalink)
+                        localized-custom-permalink="{{ json_encode($localizedCustomPermalink) }}"
+                    @endisset
                     slot="title"
                     @if($createWithoutModal ?? false) :show-modal="true" @endif
                     @if(isset($editModalTitle)) modal-title="{{ $editModalTitle }}" @endif


### PR DESCRIPTION
<!--
  Thanks for opening a PR! Your contribution is much appreciated.
  Do you have any questions? Check out the contributing docs at https://github.com/area17/twill/blob/2.x/CONTRIBUTING.md, 
  or ask in this Pull Request and a Twill maintainer will be happy to help :)
-->

## Description

This PR allows slugs to be empty. The use case being entities like a homepage.

I'm pretty new to the Twill Vue setup so not sure if the changes are how you would want to go about this.

I've marked this as a draft because I was unable to generate the dist assets. When I ran `yarn build` I got a large number of `Syntax Error: TypeError: token.type.endsWith is not a function` in files I haven't changed, what am I doing wrong?
