### PR TITLE
#1520 translate indexColumns labels

### DIFF
--- a/src/Http/Controllers/Admin/ModuleController.php
+++ b/src/Http/Controllers/Admin/ModuleController.php
@@ -1188,7 +1188,7 @@ abstract class ModuleController extends Controller
 
             $tableColumns[] = [
                 'name' => $columnName,
-                'label' => $column['title'],
+                'label' => twillTrans($column['title']),
                 'visible' => $visibleColumns ? in_array($columnName, $visibleColumns) : ($column['visible'] ?? true),
                 'optional' => $column['optional'] ?? true,
                 'sortable' => $this->getIndexOption('reorder') ? false : ($column['sort'] ?? false),


### PR DESCRIPTION
<!--
  Thanks for opening a PR! Your contribution is much appreciated.
  Do you have any questions? Check out the contributing docs at https://github.com/area17/twill/blob/2.x/CONTRIBUTING.md, 
  or ask in this Pull Request and a Twill maintainer will be happy to help :)
-->

## Description

This will enable the possibility to just add a translation key in the $indexColumns

e.g. 
    protected $indexColumns = [
        'mycolumname' => [
            'title' => 'admin.mycolumname',

## Related Issues
#1520 
suggestion for https://github.com/area17/twill/issues/1520