### PR TITLE
Add word wrapping for long labels.

### DIFF
--- a/frontend/js/components/InputFrame.vue
+++ b/frontend/js/components/InputFrame.vue
@@ -65,6 +65,7 @@
     display:block;
     color:$color__text;
     margin-bottom:10px;
+    word-wrap:break-word;
     position:relative;
   }
 


### PR DESCRIPTION
## Description

<img width="932" alt="Screenshot 2022-04-05 at 10 22 42" src="https://user-images.githubusercontent.com/866743/161711039-a3e401a4-b2bd-4b9a-9078-b0b6b676cacb.png">

Just adds a wrapping for labels being too long.

## Related Issues

fixes #1527
