### PR TITLE
[3.x] #436 allow empty allowed extensions

### DIFF
--- a/frontend/js/components/media-library/Uploader.vue
+++ b/frontend/js/components/media-library/Uploader.vue
@@ -34,9 +34,13 @@
       },
       uploaderValidation: function () {
         const extensions = this.uploaderConfig.allowedExtensions
+        let acceptFiles = '*/*'
+        if (extensions.length > 0) {
+          acceptFiles = '.' + extensions.join(', .')
+        }
         return {
           allowedExtensions: extensions,
-          acceptFiles: '.' + extensions.join(', .'),
+          acceptFiles: acceptFiles,
           stopOnFirstInvalidFile: false
         }
       }


### PR DESCRIPTION
## Description

This will default to the supported `*/*` when allowed_extensions is empty

## Related Issues

fixes #436 