### PR TITLE
[2.x] Fix displayed language name in admin panel

### DIFF
--- a/src/Helpers/i18n_helpers.php
+++ b/src/Helpers/i18n_helpers.php
@@ -83,9 +83,9 @@ if (!function_exists('getLanguageLabelFromLocaleCode')) {
     {
         if (class_exists(Locale::class)) {
             if ($native) {
-                return ucfirst(Locale::getDisplayLanguage($code, $code));
+                return ucfirst(Locale::getDisplayName($code, $code));
             } else {
-                return ucfirst(Locale::getDisplayLanguage($code, config('twill.locale', config('twill.fallback_locale', 'en'))));
+                return ucfirst(Locale::getDisplayName($code, config('twill.locale', config('twill.fallback_locale', 'en'))));
             }
         }
 

--- a/src/Helpers/i18n_helpers.php
+++ b/src/Helpers/i18n_helpers.php
@@ -84,9 +84,9 @@ if (!function_exists('getLanguageLabelFromLocaleCode')) {
         if (class_exists(Locale::class)) {
             if ($native) {
                 return Locale::getDisplayName($code, $code);
-            } else {
-                return Locale::getDisplayName($code, config('twill.locale', config('twill.fallback_locale', 'en')));
             }
+
+            return Locale::getDisplayName($code, config('twill.locale', config('twill.fallback_locale', 'en')));
         }
 
         $codeToLanguageMappings = getCodeToLanguageMappings();

--- a/src/Helpers/i18n_helpers.php
+++ b/src/Helpers/i18n_helpers.php
@@ -83,9 +83,9 @@ if (!function_exists('getLanguageLabelFromLocaleCode')) {
     {
         if (class_exists(Locale::class)) {
             if ($native) {
-                return ucfirst(Locale::getDisplayName($code, $code));
+                return Locale::getDisplayName($code, $code);
             } else {
-                return ucfirst(Locale::getDisplayName($code, config('twill.locale', config('twill.fallback_locale', 'en'))));
+                return Locale::getDisplayName($code, config('twill.locale', config('twill.fallback_locale', 'en')));
             }
         }
 


### PR DESCRIPTION


## Description

When add to language list pt-BR and pt he displayed in language list same. 
https://monosnap.com/file/fXBhpEkkcIOUgL45iHK8lbPn25FYPl
If change function from getDisplayLanguage to getDisplayName. Language list be more correct. 
https://monosnap.com/file/e2ohyGD3ZU0ZmvLsrHaFab2c5Aw2xM
It's work for all language modifie, like Chines Simply and Chines Tradition

## Related Issues

No issue, just find and fix :-)
