### PR TITLE
#1610: Fix for error in rulesForTranslatedFields helper method

### DIFF
--- a/src/Http/Requests/Admin/Request.php
+++ b/src/Http/Requests/Admin/Request.php
@@ -46,7 +46,7 @@ abstract class Request extends FormRequest
 
         if ($this->request->has('languages')) {
             foreach ($locales as $locale) {
-                $language = Collection::make($this->request->get('languages'))->where('value', $locale)->first();
+                $language = Collection::make($this->request->all('languages'))->where('value', $locale)->first();
                 $currentLocaleActive = $language['published'] ?? false;
                 $rules = $this->updateRules($rules, $fields, $locale, $currentLocaleActive);
 


### PR DESCRIPTION
<!--
  Thanks for opening a PR! Your contribution is much appreciated.
  Do you have any questions? Check out the contributing docs at https://github.com/area17/twill/blob/2.x/CONTRIBUTING.md, 
  or ask in this Pull Request and a Twill maintainer will be happy to help :)
-->

## Description

<!-- Write a description of the changes introduced by this PR -->
<!-- If this is introducing a new feature, it would be great if you can create a stub for documentation including bullet points for how to use the feature, code snippets, etc. -->
Fixes the error when generating validation rules using the `rulesForTranslatedFields` helper.
## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
Fixes #1610 