### PR TITLE
Search input length trigger change

### DIFF
--- a/frontend/js/components/Search.vue
+++ b/frontend/js/components/Search.vue
@@ -170,7 +170,7 @@
       },
       onSearchInput: debounce(function (event) {
         this.searchValue = event.target.value
-        if (this.searchValue && this.searchValue.length > 2) {
+        if (this.searchValue && this.searchValue.length > 0) {
           if (this.type === 'dashboard') {
             htmlSearchClasses.forEach((klass) => {
               html.classList.add(klass)


### PR DESCRIPTION
## Description

On Discord user, Gvido Blue Fox#3566 noticed that search won't be activated for 2 or fewer string lengths.
This creates problems for search fields that are shorter or equal to 2.

I have changed the limit to 0, which triggers a search on the first input change event with 300 delays from `debounce`.

## Related Issues
