### PR TITLE
Fix locale if intl extension is missing.

### DIFF
--- a/src/Helpers/i18n_helpers.php
+++ b/src/Helpers/i18n_helpers.php
@@ -96,6 +96,11 @@ if (!function_exists('getLanguageLabelFromLocaleCode')) {
             if (is_array($lang) && isset($lang[1]) && $native) {
                 return $lang[1];
             }
+
+            if (is_array($lang) && isset($lang[0])) {
+                return $lang[0];
+            }
+
             return $lang;
         }
         return $code;


### PR DESCRIPTION
When there is no intl extension, we make sure a value is returned and not an array.