### PR TITLE
#1673: Fix cleanup of related if left empty in blocks.

### DIFF
--- a/src/Models/Behaviors/HasRelated.php
+++ b/src/Models/Behaviors/HasRelated.php
@@ -64,11 +64,7 @@ trait HasRelated
      */
     public function saveRelated($items, $browser_name)
     {
-        RelatedItem::where([
-            'browser_name' => $browser_name,
-            'subject_id' => $this->getKey(),
-            'subject_type' => $this->getMorphClass(),
-        ])->delete();
+        $this->clearRelated($browser_name);
 
         $position = 1;
 
@@ -85,5 +81,17 @@ trait HasRelated
             ]);
             $position++;
         });
+    }
+
+    public function clearRelated($browserName): void {
+        RelatedItem::where([
+            'browser_name' => $browserName,
+            'subject_id' => $this->getKey(),
+            'subject_type' => $this->getMorphClass(),
+        ])->delete();
+    }
+
+    public function clearAllRelated(): void {
+        $this->relatedItems()->delete();
     }
 }

--- a/src/Models/Behaviors/HasRelated.php
+++ b/src/Models/Behaviors/HasRelated.php
@@ -83,7 +83,8 @@ trait HasRelated
         });
     }
 
-    public function clearRelated($browserName): void {
+    public function clearRelated($browserName): void
+    {
         RelatedItem::where([
             'browser_name' => $browserName,
             'subject_id' => $this->getKey(),
@@ -91,7 +92,8 @@ trait HasRelated
         ])->delete();
     }
 
-    public function clearAllRelated(): void {
+    public function clearAllRelated(): void
+    {
         $this->relatedItems()->delete();
     }
 }

--- a/src/Repositories/BlockRepository.php
+++ b/src/Repositories/BlockRepository.php
@@ -5,6 +5,7 @@ namespace A17\Twill\Repositories;
 use A17\Twill\Models\Behaviors\HasFiles;
 use A17\Twill\Models\Behaviors\HasMedias;
 use A17\Twill\Models\Block;
+use A17\Twill\Models\RelatedItem;
 use A17\Twill\Repositories\Behaviors\HandleFiles;
 use A17\Twill\Repositories\Behaviors\HandleMedias;
 use A17\Twill\Services\Blocks\Block as BlockConfig;
@@ -78,6 +79,8 @@ class BlockRepository extends ModuleRepository
                 Collection::make($fields['browsers'])->each(function ($items, $browserName) use ($object) {
                     $object->saveRelated($items, $browserName);
                 });
+            } else {
+                $object->clearAllRelated();
             }
         }
 
@@ -90,7 +93,7 @@ class BlockRepository extends ModuleRepository
         $object->files()->sync([]);
 
         if (Schema::hasTable(config('twill.related_table', 'twill_related'))) {
-            $object->relatedItems()->delete();
+            $object->clearAllRelated();
         }
     }
 


### PR DESCRIPTION
## Description

Fixes issue that when related data is empty it is not cleaned up.

## Related Issues

Fixes #1763
