### PR TITLE
fix: Ignore deleted records when loading related items

### DIFF
--- a/src/Models/Behaviors/HasRelated.php
+++ b/src/Models/Behaviors/HasRelated.php
@@ -51,12 +51,13 @@ trait HasRelated
             ->where('browser_name', $browser_name)
             ->map(function ($item) {
                 /** @var \A17\Twill\Models\Model $model */
-                $model = $item->related;
+                if ($model = $item->related) {
+                    $model->setRelation('pivot', $item);
+                    return $model;
+                }
 
-                $model->setRelation('pivot', $item);
-
-                return $model;
-            });
+                return null;
+            })->filter();
     }
 
     /**


### PR DESCRIPTION
## Description

This is a quick fix to ignore deleted items when eager loading the `relatedItems` relationship.

There might be a better way to handle this from the application layer but I think this can be a nice fallback to prevent errors on the frontend, as well as on the edit form. This omits the deleted items from the browser field when the form is loaded and the "broken" relationship is fixed when the record is saved.

## Related Issues

—
