### PR TITLE
Fix function name in definition check

### DIFF
--- a/src/Helpers/migrations_helpers.php
+++ b/src/Helpers/migrations_helpers.php
@@ -26,7 +26,7 @@ if (!function_exists('twillIntegerMethod')) {
     }
 }
 
-if (!function_exists('createDefaultFields')) {
+if (!function_exists('createDefaultTableFields')) {
     /**
      * @param \Illuminate\Database\Schema\Blueprint $table
      * @param bool $softDeletes


### PR DESCRIPTION
In migration helpers, function name definition check was performed for a different name than the actual name of the function.