### PR TITLE
[2.x] feat(form): Move default submit options to controller method

### DIFF
--- a/frontend/js/store/modules/publication.js
+++ b/frontend/js/store/modules/publication.js
@@ -27,6 +27,7 @@ const state = {
     }
   ],
   submitDisableMessage: window[process.env.VUE_APP_NAME].STORE.publication.submitDisableMessage || '',
+  // @todo(3.x): Remove 'submitOptions' default values as they are now defined in ModuleController.php
   submitOptions: window[process.env.VUE_APP_NAME].STORE.publication.submitOptions || {
     draft: [
       {

--- a/src/Http/Controllers/Admin/Concerns/FormSubmitOptions.php
+++ b/src/Http/Controllers/Admin/Concerns/FormSubmitOptions.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace A17\Twill\Http\Controllers\Admin\Concerns;
+
+use Illuminate\Database\Eloquent\Model;
+
+trait FormSubmitOptions
+{
+    public function getSubmitOptions(Model $item): ?array
+    {
+        if ($item->cmsRestoring ?? false) {
+            return [
+                'draft' => [
+                    [
+                        'name' => 'restore',
+                        'text' => twillTrans('twill::lang.publisher.restore-draft'),
+                    ],
+                    [
+                        'name' => 'restore-close',
+                        'text' => twillTrans('twill::lang.publisher.restore-draft-close'),
+                    ],
+                    [
+                        'name' => 'restore-new',
+                        'text' => twillTrans('twill::lang.publisher.restore-draft-new'),
+                    ],
+                    [
+                        'name' => 'cancel',
+                        'text' => twillTrans('twill::lang.publisher.cancel'),
+                    ],
+                ],
+                'live' => [
+                    [
+                        'name' => 'restore',
+                        'text' => twillTrans('twill::lang.publisher.restore-live'),
+                    ],
+                    [
+                        'name' => 'restore-close',
+                        'text' => twillTrans('twill::lang.publisher.restore-live-close'),
+                    ],
+                    [
+                        'name' => 'restore-new',
+                        'text' => twillTrans('twill::lang.publisher.restore-live-new'),
+                    ],
+                    [
+                        'name' => 'cancel',
+                        'text' => twillTrans('twill::lang.publisher.cancel'),
+                    ],
+                ],
+                'update' => [
+                    [
+                        'name' => 'restore',
+                        'text' => twillTrans('twill::lang.publisher.restore-live'),
+                    ],
+                    [
+                        'name' => 'restore-close',
+                        'text' => twillTrans('twill::lang.publisher.restore-live-close'),
+                    ],
+                    [
+                        'name' => 'restore-new',
+                        'text' => twillTrans('twill::lang.publisher.restore-live-new'),
+                    ],
+                    [
+                        'name' => 'cancel',
+                        'text' => twillTrans('twill::lang.publisher.cancel'),
+                    ],
+                ],
+            ];
+        }
+
+        return [
+            'draft' => [
+                [
+                    'name' => 'save',
+                    'text' => twillTrans('twill::lang.publisher.save'),
+                ],
+                [
+                    'name' => 'save-close',
+                    'text' => twillTrans('twill::lang.publisher.save-close'),
+                ],
+                [
+                    'name' => 'save-new',
+                    'text' => twillTrans('twill::lang.publisher.save-new'),
+                ],
+                [
+                    'name' => 'cancel',
+                    'text' => twillTrans('twill::lang.publisher.cancel'),
+                ],
+            ],
+            'live' => [
+                [
+                    'name' => 'publish',
+                    'text' => twillTrans('twill::lang.publisher.publish'),
+                ],
+                [
+                    'name' => 'publish-close',
+                    'text' => twillTrans('twill::lang.publisher.publish-close'),
+                ],
+                [
+                    'name' => 'publish-new',
+                    'text' => twillTrans('twill::lang.publisher.publish-new'),
+                ],
+                [
+                    'name' => 'cancel',
+                    'text' => twillTrans('twill::lang.publisher.cancel'),
+                ],
+            ],
+            'update' => [
+                [
+                    'name' => 'update',
+                    'text' => twillTrans('twill::lang.publisher.update'),
+                ],
+                [
+                    'name' => 'update-close',
+                    'text' => twillTrans('twill::lang.publisher.update-close'),
+                ],
+                [
+                    'name' => 'update-new',
+                    'text' => twillTrans('twill::lang.publisher.update-new'),
+                ],
+                [
+                    'name' => 'cancel',
+                    'text' => twillTrans('twill::lang.publisher.cancel'),
+                ],
+            ],
+        ];
+    }
+}

--- a/src/Http/Controllers/Admin/ModuleController.php
+++ b/src/Http/Controllers/Admin/ModuleController.php
@@ -26,6 +26,8 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 abstract class ModuleController extends Controller
 {
+    use Concerns\FormSubmitOptions;
+
     /**
      * @var Application
      */
@@ -1558,6 +1560,7 @@ abstract class ModuleController extends Controller
             'blockPreviewUrl' => Route::has('admin.blocks.preview') ? URL::route('admin.blocks.preview') : '#',
             'availableRepeaters' => $this->getRepeaterList()->toJson(),
             'revisions' => $this->moduleHas('revisions') ? $item->revisionsArray() : null,
+            'submitOptions' => $this->getSubmitOptions($item),
         ] + (Route::has($previewRouteName) && $itemId ? [
             'previewUrl' => moduleRoute($this->moduleName, $this->routePrefix, 'preview', [$itemId]),
         ] : [])

--- a/src/Http/Controllers/Admin/SettingController.php
+++ b/src/Http/Controllers/Admin/SettingController.php
@@ -4,6 +4,7 @@ namespace A17\Twill\Http\Controllers\Admin;
 
 use A17\Twill\Repositories\SettingRepository;
 use Illuminate\Config\Repository as Config;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Redirector;
 use Illuminate\Routing\UrlGenerator;
@@ -87,5 +88,11 @@ class SettingController extends Controller
         fireCmsEvent('cms-settings.saved');
 
         return $this->redirector->back();
+    }
+
+    public function getSubmitOptions(Model $item): ?array
+    {
+        // Use options from form template
+        return null;
     }
 }

--- a/src/Http/Controllers/Admin/SingletonModuleController.php
+++ b/src/Http/Controllers/Admin/SingletonModuleController.php
@@ -3,6 +3,7 @@
 namespace A17\Twill\Http\Controllers\Admin;
 
 use A17\Twill\Facades\TwillCapsules;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Session;
 
 abstract class SingletonModuleController extends ModuleController
@@ -45,5 +46,76 @@ abstract class SingletonModuleController extends ModuleController
         }
         $seeder = new $seederName();
         $seeder->run();
+    }
+
+    public function getSubmitOptions(Model $item): ?array
+    {
+        if ($item->cmsRestoring ?? false) {
+            return [
+                'draft' => [
+                    [
+                        'name' => 'restore',
+                        'text' => twillTrans('twill::lang.publisher.restore-draft'),
+                    ],
+                    [
+                        'name' => 'cancel',
+                        'text' => twillTrans('twill::lang.publisher.cancel'),
+                    ],
+                ],
+                'live' => [
+                    [
+                        'name' => 'restore',
+                        'text' => twillTrans('twill::lang.publisher.restore-live'),
+                    ],
+                    [
+                        'name' => 'cancel',
+                        'text' => twillTrans('twill::lang.publisher.cancel'),
+                    ],
+                ],
+                'update' => [
+                    [
+                        'name' => 'restore',
+                        'text' => twillTrans('twill::lang.publisher.restore-live'),
+                    ],
+                    [
+                        'name' => 'cancel',
+                        'text' => twillTrans('twill::lang.publisher.cancel'),
+                    ],
+                ],
+            ];
+        }
+
+        return [
+            'draft' => [
+                [
+                    'name' => 'save',
+                    'text' => twillTrans('twill::lang.publisher.save'),
+                ],
+                [
+                    'name' => 'cancel',
+                    'text' => twillTrans('twill::lang.publisher.cancel'),
+                ],
+            ],
+            'live' => [
+                [
+                    'name' => 'publish',
+                    'text' => twillTrans('twill::lang.publisher.publish'),
+                ],
+                [
+                    'name' => 'cancel',
+                    'text' => twillTrans('twill::lang.publisher.cancel'),
+                ],
+            ],
+            'update' => [
+                [
+                    'name' => 'update',
+                    'text' => twillTrans('twill::lang.publisher.update'),
+                ],
+                [
+                    'name' => 'cancel',
+                    'text' => twillTrans('twill::lang.publisher.cancel'),
+                ],
+            ],
+        ];
     }
 }

--- a/src/Http/Controllers/Admin/UserController.php
+++ b/src/Http/Controllers/Admin/UserController.php
@@ -6,6 +6,7 @@ use A17\Twill\Models\Enums\UserRole;
 use Illuminate\Config\Repository as Config;
 use Illuminate\Contracts\Auth\Factory as AuthFactory;
 use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
 use PragmaRX\Google2FAQRCode\Google2FA;
@@ -240,5 +241,11 @@ class UserController extends ModuleController
         return [
             'edit' => $canEdit ? $this->getModuleRoute($item->id, 'edit') : null,
         ];
+    }
+
+    public function getSubmitOptions(Model $item): ?array
+    {
+        // Use options from form template
+        return null;
     }
 }

--- a/views/layouts/form.blade.php
+++ b/views/layouts/form.blade.php
@@ -153,62 +153,7 @@
         endDate: '{{ $item->publish_end_date ?? '' }}',
         visibility: '{{ isset($item) && $item->isFillable('public') ? ($item->public ? 'public' : 'private') : false }}',
         reviewProcess: {!! isset($reviewProcess) ? json_encode($reviewProcess) : '[]' !!},
-        submitOptions: @if(isset($item) && $item->cmsRestoring) {
-            draft: [
-                {
-                    name: 'restore',
-                    text: '{{ twillTrans('twill::lang.publisher.restore-draft') }}'
-                },
-                {
-                    name: 'restore-close',
-                    text: '{{ twillTrans('twill::lang.publisher.restore-draft-close') }}'
-                },
-                {
-                    name: 'restore-new',
-                    text: '{{ twillTrans('twill::lang.publisher.restore-draft-new') }}'
-                },
-                {
-                    name: 'cancel',
-                    text: '{{ twillTrans('twill::lang.publisher.cancel') }}'
-                }
-            ],
-            live: [
-                {
-                    name: 'restore',
-                    text: '{{ twillTrans('twill::lang.publisher.restore-live') }}'
-                },
-                {
-                    name: 'restore-close',
-                    text: '{{ twillTrans('twill::lang.publisher.restore-live-close') }}'
-                },
-                {
-                    name: 'restore-new',
-                    text: '{{ twillTrans('twill::lang.publisher.restore-live-new') }}'
-                },
-                {
-                    name: 'cancel',
-                    text: '{{ twillTrans('twill::lang.publisher.cancel') }}'
-                }
-            ],
-            update: [
-                {
-                    name: 'restore',
-                    text: '{{ twillTrans('twill::lang.publisher.restore-live') }}'
-                },
-                {
-                    name: 'restore-close',
-                    text: '{{ twillTrans('twill::lang.publisher.restore-live-close') }}'
-                },
-                {
-                    name: 'restore-new',
-                    text: '{{ twillTrans('twill::lang.publisher.restore-live-new') }}'
-                },
-                {
-                    name: 'cancel',
-                    text: '{{ twillTrans('twill::lang.publisher.cancel') }}'
-                }
-            ]
-        } @else null @endif
+        submitOptions: {!! isset($submitOptions) ? json_encode($submitOptions) : 'null' !!}
     }
 
     window['{{ config('twill.js_namespace') }}'].STORE.revisions = {!! json_encode($revisions ?? []) !!}


### PR DESCRIPTION
## Description

This consolidates the form's default submit options into a `getSubmitOptions()` controller method. This method can more easily be extended to further customize the options based on the current `$item` and other information from the current request.

This also includes a small fix to `SingletonModuleController` to adjust the submit options, as `Save and close` and `Save and create new` are not really supported in the context of a singleton module.

## Related 

Follows https://github.com/area17/twill/pull/1467 in the spirit of adding more flexibility to the publishing workflow.
