### PR TITLE
fix(blocks): Show 'Expand all' if block list is initially collapsed

### DIFF
--- a/frontend/js/components/blocks/Blocks.vue
+++ b/frontend/js/components/blocks/Blocks.vue
@@ -273,6 +273,8 @@
         if (this.blocks(this.editorName) && this.blocks(this.editorName).length < 4 && this.$refs.blockList) {
           this.$refs.blockList.forEach((block) => block.toggleExpand())
         }
+
+        this.setOpened()
       })
     }
   }


### PR DESCRIPTION
## Description

There's a small regression that initializes a collapsed block list with the `Collapse all` option visible in the dropdown : 

![collapse-all](https://user-images.githubusercontent.com/7805679/176930709-198c4a29-a375-40ed-bbc9-6f28ff0e4553.png)

This ensures that `Expand all` is visible instead.

## Related

https://github.com/area17/twill/commit/015cd0015a93baa0203b022213da52b58ee1d14f
