### PR TITLE
fix(repeaters): Expand new items when added or cloned

### DIFF
--- a/frontend/js/components/Repeater.vue
+++ b/frontend/js/components/Repeater.vue
@@ -140,12 +140,20 @@
     methods: {
       addBlock: function () {
         this.$store.commit(FORM.ADD_FORM_BLOCK, { type: this.type, name: this.name })
+
+        this.$nextTick(() => {
+          this.checkExpandBlocks()
+        })
       },
       duplicateBlock: function (index) {
         this.$store.commit(FORM.DUPLICATE_FORM_BLOCK, {
           type: this.type,
           name: this.name,
           index: index
+        })
+
+        this.$nextTick(() => {
+          this.checkExpandBlocks()
         })
       },
       deleteBlock: function (index) {
@@ -160,6 +168,11 @@
       },
       expandAllBlocks: function () {
         this.opened = true
+      },
+      checkExpandBlocks () {
+        if (this.$refs.blockList[this.$refs.blockList.length - 1] !== undefined) {
+          this.$refs.blockList[this.$refs.blockList.length - 1].toggleExpand()
+        }
       }
     },
     mounted: function () {


### PR DESCRIPTION
## Description

There's a small regression with repeaters that causes the new items to be collapsed by default : 

https://user-images.githubusercontent.com/7805679/176931296-c86058ff-7f9e-4a9c-98b0-54fbad226084.mp4

This borrows the `checkExpandBlocks()` method from `Blocks.vue` to ensure new items are expanded.

## Related 

https://github.com/area17/twill/commit/54c7ea2019ebb2b414ccf637ca6c160e3992258e
