### PR TITLE
[2.x] Add fallback path for nested directory models.

### DIFF
--- a/src/Models/Behaviors/HasSlug.php
+++ b/src/Models/Behaviors/HasSlug.php
@@ -51,12 +51,21 @@ trait HasSlug
      */
     public function getSlugModelClass()
     {
+        // First load it from the base directory.
+        $slug = config('twill.namespace') . "\\Models\\Slugs\\" . $this->getSlugClassName();
+
+        if (@class_exists($slug)) {
+            return $slug;
+        }
+
+        // Alternatively try to get it from the same directory as the model resides in (nested directory models).
         $slug = $this->getNamespace() . "\Slugs\\" . $this->getSlugClassName();
 
         if (@class_exists($slug)) {
             return $slug;
         }
 
+        // Finally try to get it from capsules.
         return TwillCapsules::getCapsuleForModel(class_basename($this))->getSlugModel();
     }
 


### PR DESCRIPTION
When a slug is not found in the base namespace, it is also checked now in the folder of the model.

Before this pr this behaviour only supported it to be in the same directory.