### PR TITLE
ancestors sort by position desc to ensure the slug is following the tree

### DIFF
--- a/src/Models/Behaviors/HasNesting.php
+++ b/src/Models/Behaviors/HasNesting.php
@@ -2,8 +2,8 @@
 
 namespace A17\Twill\Models\Behaviors;
 
-use Kalnoy\Nestedset\NodeTrait;
 use A17\Twill\Models\NestedsetCollection;
+use Kalnoy\Nestedset\NodeTrait;
 
 trait HasNesting
 {
@@ -38,7 +38,7 @@ trait HasNesting
      */
     public function getAncestorsSlug($locale = null)
     {
-        return collect($this->ancestors ?? [])
+        return collect($this->ancestors->sortByDesc('position') ?? [])
             ->map(function ($i) use ($locale) { return $i->getSlug($locale); })
             ->implode('/');
     }

--- a/tests/integration/NestedModuleTest.php
+++ b/tests/integration/NestedModuleTest.php
@@ -105,7 +105,6 @@ class NestedModuleTest extends TestCase
         $parents = $this->createNodes(['One', 'Two', 'Three']);
         $children = $this->createNodes(['A', 'B', 'C']);
         $data = $this->arrangeNodes($parents, $children);
-        dd($data);
         $this->httpRequestAssert('/twill/nodes/reorder', 'POST', ['ids' => $data]);
 
         // When queried through the `browser` endpoint

--- a/tests/stubs/nested_module/Node.php
+++ b/tests/stubs/nested_module/Node.php
@@ -2,14 +2,17 @@
 
 namespace App\Models;
 
-use A17\Twill\Models\Behaviors\HasPosition;
 use A17\Twill\Models\Behaviors\HasNesting;
+use A17\Twill\Models\Behaviors\HasPosition;
+use A17\Twill\Models\Behaviors\HasSlug;
 use A17\Twill\Models\Behaviors\Sortable;
 use A17\Twill\Models\Model;
+use Illuminate\Support\Str;
 
 class Node extends Model implements Sortable
 {
-    use HasPosition, HasNesting;
+    use HasPosition;
+    use HasNesting;
 
     protected $fillable = [
         'published',
@@ -17,4 +20,9 @@ class Node extends Model implements Sortable
         'description',
         'position',
     ];
+
+    public function getSlug()
+    {
+        return Str::slug($this->title);
+    }
 }


### PR DESCRIPTION
## Description

This pr fixes the getAncestorsSlug() return slug in wrong order if the child item is created before the parent item.