### PR TITLE
Only select enabled activities on the dashboard

### DIFF
--- a/src/Http/Controllers/Admin/DashboardController.php
+++ b/src/Http/Controllers/Admin/DashboardController.php
@@ -147,9 +147,25 @@ class DashboardController extends Controller
     /**
      * @return array
      */
+    private function getEnabledActivities()
+    {
+        $modules = $this->config->get('twill.dashboard.modules');
+        $listActivities = [];
+
+        foreach ($modules as $moduleClass => $moduleConfiguration) {
+            if (!empty($moduleConfiguration['activity'])) {
+                $listActivities[] = $moduleClass;
+            }
+        }
+        return $listActivities;
+    }
+    
+    /**
+     * @return array
+     */
     private function getAllActivities()
     {
-        return Activity::take(20)->latest()->get()->map(function ($activity) {
+        return Activity::whereIn('subject_type', $this->getEnabledActivities())->take(20)->latest()->get()->map(function ($activity) {
             return $this->formatActivity($activity);
         })->filter()->values();
     }
@@ -159,7 +175,7 @@ class DashboardController extends Controller
      */
     private function getLoggedInUserActivities()
     {
-        return Activity::where('causer_id', $this->authFactory->guard('twill_users')->user()->id)->take(20)->latest()->get()->map(function ($activity) {
+        return Activity::whereIn('subject_type', $this->getEnabledActivities())->where('causer_id', $this->authFactory->guard('twill_users')->user()->id)->take(20)->latest()->get()->map(function ($activity) {
             return $this->formatActivity($activity);
         })->filter()->values();
     }

--- a/src/Http/Controllers/Admin/DashboardController.php
+++ b/src/Http/Controllers/Admin/DashboardController.php
@@ -154,6 +154,9 @@ class DashboardController extends Controller
 
         foreach ($modules as $moduleClass => $moduleConfiguration) {
             if (!empty($moduleConfiguration['activity'])) {
+                if (!class_exists($moduleClass)) {
+                    throw new Exception("Class $moduleClass specified in twill.dashboard configuration does not exists.");
+                }
                 $listActivities[] = $moduleClass;
             }
         }

--- a/src/Http/Controllers/Admin/DashboardController.php
+++ b/src/Http/Controllers/Admin/DashboardController.php
@@ -15,6 +15,7 @@ use Psr\Log\LoggerInterface as Logger;
 use Spatie\Activitylog\Models\Activity;
 use Spatie\Analytics\Exceptions\InvalidConfiguration;
 use Spatie\Analytics\Period;
+use Illuminate\Database\Eloquent\Relations\Relation;
 
 class DashboardController extends Controller
 {
@@ -162,15 +163,45 @@ class DashboardController extends Controller
         }
         return $listActivities;
     }
-    
+
+    /**
+     * @return array
+     */
+    private function getEnabledActivities()
+    {
+        $modules = $this->config->get('twill.dashboard.modules');
+        $listActivities = [];
+
+        foreach ($modules as $moduleClass => $moduleConfiguration) {
+            $moduleClassToCheck = Relation::getMorphedModel($moduleClass) ?? $moduleClass;
+            if (! empty($moduleConfiguration['activity'])) {
+                if (! class_exists($moduleClassToCheck)) {
+                    //  Try to load it from the morph map.
+                    throw new \Exception(
+                        "Class $moduleClassToCheck specified in twill.dashboard configuration does not exists."
+                    );
+                }
+                $listActivities[] = $moduleClass;
+            }
+        }
+
+        return $listActivities;
+    }
+
     /**
      * @return array
      */
     private function getAllActivities()
     {
-        return Activity::whereIn('subject_type', $this->getEnabledActivities())->take(20)->latest()->get()->map(function ($activity) {
-            return $this->formatActivity($activity);
-        })->filter()->values();
+        return Activity::whereIn('subject_type', $this->getEnabledActivities())
+            ->take(20)
+            ->latest()
+            ->get()
+            ->map(function ($activity) {
+                return $this->formatActivity($activity);
+            })
+            ->filter()
+            ->values();
     }
 
     /**
@@ -178,9 +209,16 @@ class DashboardController extends Controller
      */
     private function getLoggedInUserActivities()
     {
-        return Activity::whereIn('subject_type', $this->getEnabledActivities())->where('causer_id', $this->authFactory->guard('twill_users')->user()->id)->take(20)->latest()->get()->map(function ($activity) {
-            return $this->formatActivity($activity);
-        })->filter()->values();
+        return Activity::whereIn('subject_type', $this->getEnabledActivities())
+            ->where('causer_id', $this->authFactory->guard('twill_users')->user()->id)
+            ->take(20)
+            ->latest()
+            ->get()
+            ->map(function ($activity) {
+                return $this->formatActivity($activity);
+            })
+            ->filter()
+            ->values();
     }
 
     /**
@@ -269,7 +307,6 @@ class DashboardController extends Controller
             'week',
             'month',
         ])->mapWithKeys(function ($period) use ($statsByDate, $dummyData) {
-
             if ($dummyData) {
                 return [$period => $dummyData];
             }

--- a/src/Http/Controllers/Admin/DashboardController.php
+++ b/src/Http/Controllers/Admin/DashboardController.php
@@ -154,25 +154,6 @@ class DashboardController extends Controller
         $listActivities = [];
 
         foreach ($modules as $moduleClass => $moduleConfiguration) {
-            if (!empty($moduleConfiguration['activity'])) {
-                if (!class_exists($moduleClass)) {
-                    throw new Exception("Class $moduleClass specified in twill.dashboard configuration does not exists.");
-                }
-                $listActivities[] = $moduleClass;
-            }
-        }
-        return $listActivities;
-    }
-
-    /**
-     * @return array
-     */
-    private function getEnabledActivities()
-    {
-        $modules = $this->config->get('twill.dashboard.modules');
-        $listActivities = [];
-
-        foreach ($modules as $moduleClass => $moduleConfiguration) {
             $moduleClassToCheck = Relation::getMorphedModel($moduleClass) ?? $moduleClass;
             if (! empty($moduleConfiguration['activity'])) {
                 if (! class_exists($moduleClassToCheck)) {


### PR DESCRIPTION
## Description

There is a problem sometimes with Models that are not configured or enabled in the twill.dashboard.modules config.

The activity is logged for every model regardless of whether or not this Model is displayed in the dashboard. And this is a good thing.

The problem is when the last 20 activities are from an not configured model. When that happens nothing is displayed in the activity section.

This PR changes how the activities are selected by only selecting those which are enabled.