### PR TITLE
[2.x] Fix tests failure when using subdomain routing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        php: [8.1, 8.0, 7.4, 7.3, 7.2, 7.1]
+        php: [8.1, 8.0, 7.4, 7.3]
         laravel: [9.*, 8.*, 7.*, 6.*, 5.8.*]
         dbal: [^2.12, ^3.0]
         include:
@@ -32,28 +32,16 @@ jobs:
             php: 7.4
           - laravel: 9.*
             php: 7.3
-          - laravel: 9.*
-            php: 7.2
-          - laravel: 9.*
-            php: 7.1
           - laravel: 8.*
             php: 8.1
-          - laravel: 8.*
-            php: 7.2
-          - laravel : 8.*
-            php : 7.1
           - laravel: 7.*
             php: 8.1
           - laravel: 7.*
             php: 8.0
-          - laravel : 7.*
-            php : 7.1
           - laravel: 6.*
             php: 8.1
           - laravel: 6.*
             php: 8.0
-          - laravel : 6.*
-            php : 7.1
           - laravel: 5.8.*
             php: 8.1
           - laravel: 5.8.*

--- a/src/Http/Middleware/SupportSubdomainRouting.php
+++ b/src/Http/Middleware/SupportSubdomainRouting.php
@@ -4,11 +4,13 @@ namespace A17\Twill\Http\Middleware;
 
 use Closure;
 use Illuminate\Http\Request;
-use URL;
-use View;
+use Illuminate\Support\Facades\URL;
+use Illuminate\Support\Facades\View;
 
 class SupportSubdomainRouting
 {
+    public static array $routingOriginal = [];
+
     public function handle(Request $request, Closure $next)
     {
         $parameter = 'subdomain';
@@ -18,16 +20,29 @@ class SupportSubdomainRouting
             config(['twill.active_subdomain' => $subdomain]);
         }
 
+        if (self::$routingOriginal === []) {
+            // We store the original routing here so that every request we can start from the base config set.
+            self::$routingOriginal = [
+                'app.name' => config('twill.app_names'),
+                'twill-navigation' => config('twill-navigation'),
+                'twill.dashboard.modules' => config('twill.dashboard.modules'),
+            ];
+        }
+
         // Set subdomain as default URL parameter to not have
         // to add it manually when using route helpers
         URL::defaults([$parameter => $subdomain]);
 
         $blockLayout = View::exists($subdomain . '.layouts.block') ? ($subdomain . '.layouts.block') : 'site.layouts.blocks';
 
+        if (! isset(self::$routingOriginal['twill-navigation'][$subdomain])) {
+            throw new \Exception('Subdomain not found in SupportSubdomainRouting middleware: ' . $subdomain);
+        }
+
         config([
-            'app.name' => config('twill.app_names')[$subdomain] ?? config('app.name'),
-            'twill-navigation' => config('twill-navigation')[$subdomain] ?? config('twill-navigation'),
-            'twill.dashboard.modules' => config('twill.dashboard.modules')[$subdomain] ?? config('twill.dashboard.modules'),
+            'app.name' => self::$routingOriginal['app.name'][$subdomain] ?? config('app.name'),
+            'twill-navigation' => self::$routingOriginal['twill-navigation'][$subdomain],
+            'twill.dashboard.modules' => self::$routingOriginal['twill.dashboard.modules'][$subdomain] ?? config('twill.dashboard.modules'),
             'twill.block_editor.block_single_layout' => $blockLayout,
         ]);
 

--- a/src/Http/Middleware/SupportSubdomainRouting.php
+++ b/src/Http/Middleware/SupportSubdomainRouting.php
@@ -17,7 +17,7 @@ class SupportSubdomainRouting
         if (config('twill.active_subdomain') !== $subdomain) {
             config(['twill.active_subdomain' => $subdomain]);
         }
-        
+
         // Set subdomain as default URL parameter to not have
         // to add it manually when using route helpers
         URL::defaults([$parameter => $subdomain]);
@@ -26,8 +26,8 @@ class SupportSubdomainRouting
 
         config([
             'app.name' => config('twill.app_names')[$subdomain] ?? config('app.name'),
-            'twill-navigation' => config('twill-navigation')[$subdomain] ?? key(config('twill-navigation')),
-            'twill.dashboard.modules' => config('twill.dashboard.modules')[$subdomain] ?? key(config('twill.dashboard.modules')),
+            'twill-navigation' => config('twill-navigation')[$subdomain] ?? config('twill-navigation'),
+            'twill.dashboard.modules' => config('twill.dashboard.modules')[$subdomain] ?? config('twill.dashboard.modules'),
             'twill.block_editor.block_single_layout' => $blockLayout,
         ]);
 


### PR DESCRIPTION
## Description

Remove extracting `twill-navigation` and `twill.dashboard.modules` from the first key when the subdomain key doesn't exists. It will keep them as-is.

## Related Issues

#1778