### PR TITLE
[3.x] Compatibility/fix indexcolumns thumbnail

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,6 +54,7 @@
     "orchestra/testbench-dusk": "*",
     "phpunit/phpunit": "~5.0|~6.0|~7.0|~8.0|~9.0",
     "rector/rector": "^0.12.15",
+    "spatie/invade": "^1.1",
     "squizlabs/php_codesniffer": "*"
   },
   "autoload": {

--- a/src/Http/Controllers/Admin/ModuleController.php
+++ b/src/Http/Controllers/Admin/ModuleController.php
@@ -776,6 +776,16 @@ abstract class ModuleController extends Controller
                             );
                         })
                 );
+            } elseif ($indexColumn['thumb'] ?? false) {
+                $columns->add(
+                    Image::make()
+                        ->title($indexColumn['title'] ?? $key)
+                        ->role($indexColumn['variant']['role'] ?? null)
+                        ->crop($indexColumn['variant']['crop'] ?? null)
+                        ->field($indexColumn['field'] ?? $key)
+                        ->sortKey($indexColumn['sortKey'] ?? null)
+                        ->optional($indexColumn['optional'] ?? false)
+                );
             } elseif ($indexColumn['relatedBrowser'] ?? false) {
                 $columns->add(
                     Browser::make()

--- a/src/Services/Listings/Columns/Image.php
+++ b/src/Services/Listings/Columns/Image.php
@@ -28,7 +28,7 @@ class Image extends TableColumn
     /**
      * The image role that is defined in your model. Can be left out as it will take the first one available.
      */
-    public function role(string $role): self
+    public function role(?string $role): self
     {
         $this->role = $role;
         return $this;
@@ -37,7 +37,7 @@ class Image extends TableColumn
     /**
      * A specific crop to use for the image. Can be left out as it will take the first one available.
      */
-    public function crop(string $crop): self
+    public function crop(?string $crop): self
     {
         $this->crop = $crop;
         return $this;

--- a/tests/Browser/Fields/SelectFieldTest.php
+++ b/tests/Browser/Fields/SelectFieldTest.php
@@ -28,7 +28,8 @@ class SelectFieldTest extends BrowserTestCase
                             ->addOption(new Option('option2', 'option2')),
                     ])
                 )
-                ->boot();
+                ->boot()
+                ->getModelClassName();
         });
 
         $this->browse(function (Browser $browser) {

--- a/tests/Browser/FrontendDateConversionTest.php
+++ b/tests/Browser/FrontendDateConversionTest.php
@@ -32,7 +32,8 @@ class FrontendDateConversionTest extends BrowserTestCase
                             ->time24h($use24h),
                     ])
                 )
-                ->boot();
+                ->boot()
+                ->getModelClassName();
         });
 
         $this->assertEquals('UTC', config('app.timezone'));

--- a/tests/Browser/ScheduleDatesTest.php
+++ b/tests/Browser/ScheduleDatesTest.php
@@ -27,7 +27,8 @@ class ScheduleDatesTest extends BrowserTestCase
                         'type' => 'dateTime',
                     ],
                 ])
-                ->boot();
+                ->boot()
+                ->getModelClassName();
         });
 
         $this->assertEquals('UTC', config('app.timezone'));

--- a/tests/integration/AnonymousModulesTest.php
+++ b/tests/integration/AnonymousModulesTest.php
@@ -6,7 +6,6 @@ use A17\Twill\Tests\Integration\Anonymous\AnonymousModule;
 
 class AnonymousModulesTest extends TestCase
 {
-
     public function testCreateAndList(): void
     {
         AnonymousModule::make('servers', $this->app)->boot();

--- a/tests/integration/Controllers/Tables/FeaturedColumnTest.php
+++ b/tests/integration/Controllers/Tables/FeaturedColumnTest.php
@@ -31,7 +31,8 @@ class FeaturedColumnTest extends TestCase
                     FeaturedStatus::make(),
                 ])
             )
-            ->boot();
+            ->boot()
+            ->getModelClassName();
 
         $this->actingAs($this->superAdmin(), 'twill_users');
 

--- a/tests/integration/Controllers/Tables/TableBuilderBackwardsCompatibleTest.php
+++ b/tests/integration/Controllers/Tables/TableBuilderBackwardsCompatibleTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace A17\Twill\Tests\Integration\Controllers\Tables;
+
+use A17\Twill\Tests\Integration\Anonymous\AnonymousModule;
+use A17\Twill\Tests\Integration\ModulesTestBase;
+
+/**
+ * This test specifically tests the old $indexColumn implementation.
+ */
+class TableBuilderBackwardsCompatibleTest extends ModulesTestBase
+{
+    private AnonymousModule $serverModule;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->serverModule = AnonymousModule::make('servers', $this->app)
+            ->withAdditionalProp('indexColumns', [
+                'cover' => ['thumb' => true],
+                'title' => [],
+            ])
+            ->boot();
+    }
+
+    public function testCmsArray(): void
+    {
+        $controller = $this->serverModule->getModelController();
+
+        $indexData = invade($controller)->getIndexData();
+
+        $this->assertEquals([
+            [
+                'name' => 'published',
+                'label' => 'Published',
+                'visible' => false,
+                'optional' => true,
+                'sortable' => true,
+                'html' => false,
+                'specificType' => null,
+            ],
+            [
+                'name' => 'cover',
+                'label' => 'cover',
+                'visible' => true,
+                'optional' => false,
+                'sortable' => false,
+                'html' => false,
+                'specificType' => 'thumbnail',
+                'variation' => 'square',
+            ],
+            [
+                'name' => 'title',
+                'label' => 'Title',
+                'visible' => true,
+                'optional' => false,
+                'sortable' => false,
+                'html' => false,
+                'specificType' => null,
+            ],
+        ], $indexData['tableColumns']);
+    }
+}


### PR DESCRIPTION
Enables the following to automatically convert to the Table builder:

```php
    protected $indexColumns = [
        'cover' => [
            'thumb' => true,
        ],
        'title' => [
        ],
    ];
```