### PR TITLE
[3.x] #1778 subdomain routing issues

### DIFF
--- a/examples/tests-subdomain-routing/app/Http/Controllers/Twill/PageController.php
+++ b/examples/tests-subdomain-routing/app/Http/Controllers/Twill/PageController.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use A17\Twill\Http\Controllers\Admin\ModuleController as BaseModuleController;
+
+class PageController extends BaseModuleController
+{
+    protected $moduleName = 'pages';
+
+    protected $indexOptions = [
+    ];
+}

--- a/examples/tests-subdomain-routing/app/Http/Requests/Twill/PageRequest.php
+++ b/examples/tests-subdomain-routing/app/Http/Requests/Twill/PageRequest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Requests\Admin;
+
+use A17\Twill\Http\Requests\Admin\Request;
+
+class PageRequest extends Request
+{
+    public function rulesForCreate()
+    {
+        return [];
+    }
+
+    public function rulesForUpdate()
+    {
+        return [];
+    }
+}

--- a/examples/tests-subdomain-routing/app/Models/Page.php
+++ b/examples/tests-subdomain-routing/app/Models/Page.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Models;
+
+use A17\Twill\Models\Behaviors\HasBlocks;
+use A17\Twill\Models\Behaviors\HasTranslation;
+use A17\Twill\Models\Behaviors\HasSlug;
+use A17\Twill\Models\Behaviors\HasMedias;
+use A17\Twill\Models\Behaviors\HasFiles;
+use A17\Twill\Models\Behaviors\HasRevisions;
+use A17\Twill\Models\Behaviors\HasPosition;
+use A17\Twill\Models\Behaviors\Sortable;
+use A17\Twill\Models\Model;
+
+class Page extends Model implements Sortable
+{
+    use HasBlocks, HasTranslation, HasSlug, HasMedias, HasFiles, HasRevisions, HasPosition;
+
+    protected $fillable = [
+        'published',
+        'title',
+        'description',
+        'position',
+    ];
+    
+    public $translatedAttributes = [
+        'title',
+        'description',
+        'active',
+    ];
+    
+    public $slugAttributes = [
+        'title',
+    ];
+    
+    public $mediasParams = [
+        'cover' => [
+            'default' => [
+                [
+                    'name' => 'default',
+                    'ratio' => 16 / 9,
+                ],
+            ],
+            'mobile' => [
+                [
+                    'name' => 'mobile',
+                    'ratio' => 1,
+                ],
+            ],
+            'flexible' => [
+                [
+                    'name' => 'free',
+                    'ratio' => 0,
+                ],
+                [
+                    'name' => 'landscape',
+                    'ratio' => 16 / 9,
+                ],
+                [
+                    'name' => 'portrait',
+                    'ratio' => 3 / 5,
+                ],
+            ],
+        ],
+    ];
+}

--- a/examples/tests-subdomain-routing/app/Models/Revisions/PageRevision.php
+++ b/examples/tests-subdomain-routing/app/Models/Revisions/PageRevision.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Models\Revisions;
+
+use A17\Twill\Models\Revision;
+
+class PageRevision extends Revision
+{
+    protected $table = "page_revisions";
+}

--- a/examples/tests-subdomain-routing/app/Models/Slugs/PageSlug.php
+++ b/examples/tests-subdomain-routing/app/Models/Slugs/PageSlug.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Models\Slugs;
+
+use A17\Twill\Models\Model;
+
+class PageSlug extends Model
+{
+    protected $table = "page_slugs";
+}

--- a/examples/tests-subdomain-routing/app/Models/Translations/PageTranslation.php
+++ b/examples/tests-subdomain-routing/app/Models/Translations/PageTranslation.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Models\Translations;
+
+use A17\Twill\Models\Model;
+use App\Models\Page;
+
+class PageTranslation extends Model
+{
+    protected $baseModuleModel = Page::class;
+}

--- a/examples/tests-subdomain-routing/app/Repositories/PageRepository.php
+++ b/examples/tests-subdomain-routing/app/Repositories/PageRepository.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Repositories;
+
+use A17\Twill\Repositories\Behaviors\HandleBlocks;
+use A17\Twill\Repositories\Behaviors\HandleTranslations;
+use A17\Twill\Repositories\Behaviors\HandleSlugs;
+use A17\Twill\Repositories\Behaviors\HandleMedias;
+use A17\Twill\Repositories\Behaviors\HandleFiles;
+use A17\Twill\Repositories\Behaviors\HandleRevisions;
+use A17\Twill\Repositories\ModuleRepository;
+use App\Models\Page;
+
+class PageRepository extends ModuleRepository
+{
+    use HandleBlocks, HandleTranslations, HandleSlugs, HandleMedias, HandleFiles, HandleRevisions;
+
+    public function __construct(Page $model)
+    {
+        $this->model = $model;
+    }
+}

--- a/examples/tests-subdomain-routing/config/twill-navigation.php
+++ b/examples/tests-subdomain-routing/config/twill-navigation.php
@@ -1,0 +1,16 @@
+<?php
+
+return [
+    'subdomain1' => [
+        'pages' => [
+            'title' => 'Pages subdomain 1',
+            'module' => true,
+        ],
+    ],
+    'subdomain2' => [
+        'pages' => [
+            'title' => 'Pages subdomain 2',
+            'module' => true,
+        ],
+    ],
+];

--- a/examples/tests-subdomain-routing/config/twill.php
+++ b/examples/tests-subdomain-routing/config/twill.php
@@ -1,0 +1,24 @@
+<?php
+
+return [
+    'support_subdomain_admin_routing' => true,
+    'admin_app_subdomain' => 'admin',
+    'active_subdomain' => null,
+    'app_names' => [
+        'subdomain1' => 'App 1 name',
+        'subdomain2' => 'App 2 name',
+    ],
+
+    /**
+     * If this is not present, the middleware src/Http/Middleware/SupportSubdomainRouting.php,
+     * throws an exception.
+     *
+     * TypeError: key(): Argument #1 ($array) must be of type array, null given in /var/www/html/vendor/area17/twill/src/Http/Middleware/SupportSubdomainRouting.php:30
+     */
+    'dashboard' => [
+        'modules' => [
+            'subdomain1' => [],
+            'subdomain2' => [],
+        ]
+    ]
+];

--- a/examples/tests-subdomain-routing/database/migrations/2022_08_17_112843_create_pages_tables.php
+++ b/examples/tests-subdomain-routing/database/migrations/2022_08_17_112843_create_pages_tables.php
@@ -1,0 +1,44 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreatePagesTables extends Migration
+{
+    public function up()
+    {
+        Schema::create('pages', function (Blueprint $table) {
+            // this will create an id, a "published" column, and soft delete and timestamps columns
+            createDefaultTableFields($table);
+            
+            $table->integer('position')->unsigned()->nullable();
+            
+            // add those 2 columns to enable publication timeframe fields (you can use publish_start_date only if you don't need to provide the ability to specify an end date)
+            // $table->timestamp('publish_start_date')->nullable();
+            // $table->timestamp('publish_end_date')->nullable();
+        });
+
+        Schema::create('page_translations', function (Blueprint $table) {
+            createDefaultTranslationsTableFields($table, 'page');
+            $table->string('title', 200)->nullable();
+            $table->text('description')->nullable();
+        });
+
+        Schema::create('page_slugs', function (Blueprint $table) {
+            createDefaultSlugsTableFields($table, 'page');
+        });
+
+        Schema::create('page_revisions', function (Blueprint $table) {
+            createDefaultRevisionsTableFields($table, 'page');
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('page_revisions');
+        Schema::dropIfExists('page_translations');
+        Schema::dropIfExists('page_slugs');
+        Schema::dropIfExists('pages');
+    }
+}

--- a/examples/tests-subdomain-routing/resources/views/twill/pages/form.blade.php
+++ b/examples/tests-subdomain-routing/resources/views/twill/pages/form.blade.php
@@ -1,0 +1,10 @@
+@extends('twill::layouts.form')
+
+@section('contentFields')
+    @formField('input', [
+        'name' => 'description',
+        'label' => 'Description',
+        'translated' => true,
+        'maxlength' => 100
+    ])
+@stop

--- a/examples/tests-subdomain-routing/routes/twill.php
+++ b/examples/tests-subdomain-routing/routes/twill.php
@@ -1,0 +1,8 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+
+// Register Twill routes here eg.
+// Route::module('posts');
+
+Route::module('pages');

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -29,7 +29,7 @@
     <php>
         <env name="APP_KEY" value="base64:DV8kQN5a+4MwAIQ5uk1WNafxO+/Efab0K20uVMDJ2UE="/>
         <env name="APP_ENV" value="testing"/>
-        <env name="APP_URL" value="http://twill.test"/>
+        <env name="APP_URL" value="twill.test"/>
         <env name="APP_DEBUG" value="true"/>
         <env name="TELESCOPE_ENABLED" value="false"/>
         <env name="BCRYPT_ROUNDS" value="4"/>

--- a/src/Http/Middleware/SupportSubdomainRouting.php
+++ b/src/Http/Middleware/SupportSubdomainRouting.php
@@ -9,6 +9,8 @@ use Illuminate\Support\Facades\View;
 
 class SupportSubdomainRouting
 {
+    public static array $routingOriginal = [];
+
     public function handle(Request $request, Closure $next)
     {
         $parameter = 'subdomain';
@@ -18,6 +20,15 @@ class SupportSubdomainRouting
             config(['twill.active_subdomain' => $subdomain]);
         }
 
+        if (self::$routingOriginal === []) {
+            // We store the original routing here so that every request we can start from the base config set.
+            self::$routingOriginal = [
+                'app.name' => config('twill.app_names'),
+                'twill-navigation' => config('twill-navigation'),
+                'twill.dashboard.modules' => config('twill.dashboard.modules'),
+            ];
+        }
+
         // Set subdomain as default URL parameter to not have
         // to add it manually when using route helpers
         URL::defaults([$parameter => $subdomain]);
@@ -25,9 +36,9 @@ class SupportSubdomainRouting
         $blockLayout = View::exists($subdomain . '.layouts.block') ? ($subdomain . '.layouts.block') : 'site.layouts.blocks';
 
         config([
-            'app.name' => config('twill.app_names')[$subdomain] ?? config('app.name'),
-            'twill-navigation' => config('twill-navigation')[$subdomain] ?? key(config('twill-navigation')),
-            'twill.dashboard.modules' => config('twill.dashboard.modules')[$subdomain] ?? key(config('twill.dashboard.modules')),
+            'app.name' => self::$routingOriginal['app.name'][$subdomain] ?? config('app.name'),
+            'twill-navigation' => self::$routingOriginal['twill-navigation'][$subdomain] ?? key(config('twill-navigation')),
+            'twill.dashboard.modules' => self::$routingOriginal['twill.dashboard.modules'][$subdomain] ?? key(config('twill.dashboard.modules')),
             'twill.block_editor.block_single_layout' => $blockLayout,
         ]);
 

--- a/src/RouteServiceProvider.php
+++ b/src/RouteServiceProvider.php
@@ -13,7 +13,6 @@ use A17\Twill\Http\Middleware\ValidateBackHistory;
 use A17\Twill\Services\MediaLibrary\Glide;
 use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;
 use Illuminate\Routing\Router;
-use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Str;
 
@@ -115,19 +114,19 @@ class RouteServiceProvider extends ServiceProvider
                 'namespace' => $this->namespace . '\Admin',
             ],
             function ($router) use ($internalRoutes, $supportSubdomainRouting) {
-                $router->group(
-                    [
-                        'domain' => config('twill.admin_app_url'),
-                    ],
-                    $internalRoutes
-                );
-
                 if ($supportSubdomainRouting) {
                     $router->group(
                         [
                             'domain' => config('twill.admin_app_subdomain', 'admin') .
                                 '.{subdomain}.' .
                                 config('app.url'),
+                        ],
+                        $internalRoutes
+                    );
+                } else {
+                    $router->group(
+                        [
+                            'domain' => config('twill.admin_app_url'),
                         ],
                         $internalRoutes
                     );
@@ -271,9 +270,9 @@ class RouteServiceProvider extends ServiceProvider
 
     public static function shouldPrefixRouteName($groupPrefix, $lastRouteGroupName)
     {
-        return !empty($groupPrefix) && (blank($lastRouteGroupName) ||
+        return ! empty($groupPrefix) && (blank($lastRouteGroupName) ||
                 config('twill.allow_duplicates_on_route_names', true) ||
-                (!Str::endsWith($lastRouteGroupName, ".{$groupPrefix}.")));
+                (! Str::endsWith($lastRouteGroupName, ".{$groupPrefix}.")));
     }
 
     public static function getLastRouteGroupName()
@@ -292,7 +291,7 @@ class RouteServiceProvider extends ServiceProvider
             '.'
         );
 
-        if (!empty(config('twill.admin_app_path'))) {
+        if (! empty(config('twill.admin_app_path'))) {
             $groupPrefix = ltrim(
                 str_replace(
                     config('twill.admin_app_path'),

--- a/src/TwillRoutes.php
+++ b/src/TwillRoutes.php
@@ -64,12 +64,12 @@ class TwillRoutes
         if (isset($options['only'])) {
             $customRoutes = array_intersect(
                 $defaults,
-                (array)$options['only']
+                (array) $options['only']
             );
         } elseif (isset($options['except'])) {
             $customRoutes = array_diff(
                 $defaults,
-                (array)$options['except']
+                (array) $options['except']
             );
         }
 
@@ -180,19 +180,19 @@ class TwillRoutes
                     );
                 };
 
-                $router->group(
-                    $groupOptions + [
-                        'domain' => config('twill.admin_app_url'),
-                    ],
-                    $hostRoutes
-                );
-
                 if ($supportSubdomainRouting) {
                     $router->group(
                         $groupOptions + [
                             'domain' => config('twill.admin_app_subdomain', 'admin') .
                                 '.{subdomain}.' .
                                 config('app.url'),
+                        ],
+                        $hostRoutes
+                    );
+                } else {
+                    $router->group(
+                        $groupOptions + [
+                            'domain' => config('twill.admin_app_url'),
                         ],
                         $hostRoutes
                     );
@@ -264,7 +264,7 @@ class TwillRoutes
                 $capsule->getControllersNamespace(),
                 $routesFile,
                 // When it is not a package capsule we can register it immediately.
-                !$capsule->packageCapsule
+                ! $capsule->packageCapsule
             );
         }
     }

--- a/tests/integration/SubdomainRoutingTest.php
+++ b/tests/integration/SubdomainRoutingTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace A17\Twill\Tests\Integration;
+
+class SubdomainRoutingTest extends TestCase
+{
+    public $example = 'tests-subdomain-routing';
+
+    public function testSubdomainRouting(): void
+    {
+        $this->assertEquals(
+            [
+                'subdomain1' => [
+                    'pages' => [
+                        'title' => 'Pages subdomain 1',
+                        'module' => true,
+                    ],
+                ],
+                'subdomain2' => [
+                    'pages' => [
+                        'title' => 'Pages subdomain 2',
+                        'module' => true,
+                    ],
+                ],
+            ],
+            config('twill-navigation')
+        );
+
+        $this->actingAs($this->superAdmin(), 'twill_users')
+            ->get(route('twill.dashboard', ['subdomain' => 'subdomain1']))
+            ->assertSee('App 1 name')
+            ->assertStatus(200);
+
+        // The second request it would fail because of the config mismatch.
+        $this->actingAs($this->superAdmin(), 'twill_users')
+            ->get(route('twill.dashboard', ['subdomain' => 'subdomain1']))
+            ->assertSee('App 1 name')
+            ->assertStatus(200);
+
+        // Check that we can also request subdomain2 within the same runtime.
+        $this->actingAs($this->superAdmin(), 'twill_users')
+            ->get(route('twill.dashboard', ['subdomain' => 'subdomain2']))
+            ->assertSee('App 2 name')
+            ->assertStatus(200);
+    }
+}


### PR DESCRIPTION
Different approach to https://github.com/area17/twill/pull/1779

My main concern is the overwriting of config. I have not dived too deep into it but I made a solution (I think) where it is irrelevant where the request comes from.

My main concern was that with overwriting config, in memory adaptions can cause conflicts (like the tests) but also Laravel octane.

One breaking change here, is that when subdomain routing is enabled, base domain routes are no longer created. I might need to revise this based on input.

Fixes https://github.com/area17/twill/issues/1778

