### PR TITLE
Bug fix for changing admin assets directory

### DIFF
--- a/src/Commands/Build.php
+++ b/src/Commands/Build.php
@@ -159,7 +159,9 @@ class Build extends Command
      */
     private function runProcessInTwill(array $command, $disableTimeout = false)
     {
-        $process = new Process($command, base_path(config('twill.vendor_path')));
+        $process = new Process($command, base_path(config('twill.vendor_path')), [
+            'TWILL_ASSETS_DIR' => config('twill.public_directory'),
+        ]);
         $process->setTty(Process::isTtySupported());
 
         if ($disableTimeout) {


### PR DESCRIPTION
## Description
When running `php artisan twill:build` there seems to be an issue with the config/env variables. 
The values are not being passed through from php -> node. Therefore it is impossible changing the admin assets location, however this seems to be configureable in the twill config, this PR enables that feature.

<!--

## Related Issues

  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
