### PR TITLE
Add index options reference for searchability

### DIFF
--- a/docs/src/crud-modules/controllers.md
+++ b/docs/src/crud-modules/controllers.md
@@ -226,13 +226,11 @@ For example, to disable the user's ability to permanently delete an article, you
 
 File: `app/Http/Controllers/Admin/ArticleController`
 ```php
-	...
-	
+
 	protected $indexOptions = [
 		'forceDelete' => false // This is the opposite of the default
 		];
 
-	...
 ```
 
 With this, all index options apart from `Destroy` and the synonymous bulk action will be available on the listing view for articles.

--- a/docs/src/crud-modules/controllers.md
+++ b/docs/src/crud-modules/controllers.md
@@ -218,6 +218,25 @@ File: `app/Models/Play.php`
     }
 ```
 
+#### Index Options
+
+You can change the available actions within the listing view for any particular module by altering the `$indexOptions` array in the module's controller. The full list at the start of this chapter demonstrates the available options with their default settings. Should you wish to change one, include it in the controller's array with the desired overriding value.
+
+For example, to disable the user's ability to permanently delete an article, you include the following:
+
+File: `app/Http/Controllers/Admin/ArticleController`
+```php
+	...
+	
+	protected $indexOptions = [
+		'forceDelete' => false // This is the opposite of the default
+		];
+
+	...
+```
+
+With this, all index options apart from `Destroy` and the synonymous bulk action will be available on the listing view for articles.
+
 #### Additional table actions
 
 You can override the `additionalTableActions()` method to add custom actions in your module's listing view:


### PR DESCRIPTION
<!--
  Thanks for opening a PR! Your contribution is much appreciated.
  Do you have any questions? Check out the contributing docs at https://github.com/area17/twill/blob/2.x/CONTRIBUTING.md, 
  or ask in this Pull Request and a Twill maintainer will be happy to help :)
-->

## Description

<!-- Write a description of the changes introduced by this PR -->
I failed to find information regarding the `$indexOptions` when using the search bar on the docs when I needed to figure out where they could be altered. I did eventually find them, but if there was a small reference to them within `CRUDModules/Controllers` then I would have found them a little quicker.

Just wanted to help out anyone in my the same situation as me in the future.
<!-- If this is introducing a new feature, it would be great if you can create a stub for documentation including bullet points for how to use the feature, code snippets, etc. -->

## Related Issues
N/A

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
