### PR TITLE
[3.x] Swappable roles without composer edit.

### DIFF
--- a/docs/src/user-management/index.md
+++ b/docs/src/user-management/index.md
@@ -35,85 +35,94 @@ Publishers have the same permissions as view only users plus:
 Admin users have the same permissions as publisher users plus:
 - full permissions on users
 
-There is also a super admin user that can impersonate other users at `/users/impersonate/{id}`. The super admin can be a useful tool for testing features with different user roles without having to logout/login manually, as well as for debugging issues reported by specific users. You can stop impersonating by going to `/users/impersonate/stop`.
+There is also a super admin user that can impersonate other users at `/users/impersonate/{id}`.
+The super admin can be a useful tool for testing features with different user roles without having to logout/login manually,
+as well as for debugging issues reported by specific users. You can stop impersonating by going to `/users/impersonate/stop`.
 
 ## Extending user roles and permissions
 
-You can create or modify new permissions for existing roles by using the Gate façade in your `AuthServiceProvider`. The `can` middleware, provided by default in Laravel, is very easy to use, either through route definition or controller constructor.
+You can create or modify new permissions for existing roles by using the Gate facade in your `AuthServiceProvider`.
+The `can` middleware, provided by default in Laravel, is very easy to use, either through route definition or controller constructor.
 
-To create new user roles, you could extend the default enum UserRole by overriding it using Composer autoloading. In `composer.json`:
 
-```json
-    "autoload": {
-        "classmap": [
-            "database/seeds",
-            "database/factories"
-        ],
-        "psr-4": {
-            "App\\": "app/"
-        },
-        "files": ["app/Models/Enums/UserRole.php"],
-        "exclude-from-classmap": ["vendor/area17/twill/src/Models/Enums/UserRole.php"]
-    }
-```
-
-In `app/Models/Enums/UserRole.php` (or anywhere else you'd like actually, only the namespace needs to be the same):
+In `app/Models/Enums/UserRole.php` (or another file) define your roles:
 
 ```php
-    <?php
+<?php
 
-    namespace A17\Twill\Models\Enums;
+namespace App\Models\Enums;
 
-    use MyCLabs\Enum\Enum;
+use MyCLabs\Enum\Enum;
 
-    class UserRole extends Enum
+class UserRole extends Enum
+{
+    const CUSTOM1 = 'Custom role 1';
+    const CUSTOM2 = 'Custom role 2';
+    const CUSTOM3 = 'Custom role 3';
+    const ADMIN = 'Admin';
+}
+```
+
+Then in your app service provider you can register it:
+
+```php
+<?php
+class AppServiceProvider extends ServiceProvider
+{
+    public function register(): void
     {
-        const CUSTOM1 = 'Custom role 1';
-        const CUSTOM2 = 'Custom role 2';
-        const CUSTOM3 = 'Custom role 3';
-        const ADMIN = 'Admin';
+        \A17\Twill\Facades\TwillPermissions::setRoleEnum(\App\Models\Enums\UserRole::class);
     }
+}
 ```
 
 Finally, in your `AuthServiceProvider` class, redefine [Twill's default permissions](https://github.com/area17/twill/blob/e8866e40b7df4a6919e0ddb368990d04caeb705a/src/AuthServiceProvider.php#L26-L48) if you need to, or add your own, for example:
 
 ```php
-    <?php
+<?php
 
-    namespace App\Providers;
+namespace App\Providers;
 
-    use A17\Twill\Models\Enums\UserRole;
-    use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
-    use Illuminate\Support\Facades\Gate;
+use App\Models\Enums\UserRole;
+use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
+use Illuminate\Support\Facades\Gate;
 
-    class AuthServiceProvider extends ServiceProvider
+class AuthServiceProvider extends ServiceProvider
+{
+    public function boot()
     {
-        public function boot()
-        {
-            Gate::define('list', function ($user) {
-                return in_array($user->role_value, [
-                    UserRole::CUSTOM1,
-                    UserRole::CUSTOM2,
-                    UserRole::ADMIN,
-                ]);
-            });
+        Gate::define('list', function ($user) {
+            return in_array($user->role_value, [
+                UserRole::CUSTOM1,
+                UserRole::CUSTOM2,
+                UserRole::ADMIN,
+            ]);
+        });
 
-            Gate::define('edit', function ($user) {
-                return in_array($user->role_value, [
-                    UserRole::CUSTOM3,
-                    UserRole::ADMIN,
-                ]);
-            });
+        Gate::define('edit', function ($user) {
+            return in_array($user->role_value, [
+                UserRole::CUSTOM3,
+                UserRole::ADMIN,
+            ]);
+        });
 
-            Gate::define('custom-permission', function ($user) {
-                return in_array($user->role_value, [
-                    UserRole::CUSTOM2,
-                    UserRole::ADMIN,
-                ]);
-            });
-        }
+        Gate::define('custom-permission', function ($user) {
+            return in_array($user->role_value, [
+                UserRole::CUSTOM2,
+                UserRole::ADMIN,
+            ]);
+        });
     }
+}
 ```
+
+If you need a more dynamic aproach you can also get the current permission enum using the facade:
+
+```php
+TwillAppSettings::roles()::PUBLISHER (or any role)
+```
+
+
 
 You can use your new permission and existing ones in many places like the `twill-navigation` configuration using `can`:
 

--- a/docs/src/user-management/index.md
+++ b/docs/src/user-management/index.md
@@ -119,7 +119,7 @@ class AuthServiceProvider extends ServiceProvider
 If you need a more dynamic aproach you can also get the current permission enum using the facade:
 
 ```php
-TwillAppSettings::roles()::PUBLISHER (or any role)
+TwillPermissons::roles()::PUBLISHER (or any role)
 ```
 
 

--- a/src/AuthServiceProvider.php
+++ b/src/AuthServiceProvider.php
@@ -2,7 +2,7 @@
 
 namespace A17\Twill;
 
-use A17\Twill\Facades\TwillAppSettings;
+use A17\Twill\Facades\TwillPermissions;
 use A17\Twill\Models\User;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 use Illuminate\Support\Facades\Gate;
@@ -72,9 +72,9 @@ class AuthServiceProvider extends ServiceProvider
         $this->define('list', function ($user, $item = null) {
             return $this->authorize($user, function ($user) {
                 return $this->userHasRole($user, [
-                    TwillAppSettings::roles()::VIEWONLY,
-                    TwillAppSettings::roles()::PUBLISHER,
-                    TwillAppSettings::roles()::ADMIN,
+                    TwillPermissions::roles()::VIEWONLY,
+                    TwillPermissions::roles()::PUBLISHER,
+                    TwillPermissions::roles()::ADMIN,
                 ]);
             });
         });
@@ -83,7 +83,7 @@ class AuthServiceProvider extends ServiceProvider
             return $this->authorize($user, function ($user) {
                 return $this->userHasRole(
                     $user,
-                    [TwillAppSettings::roles()::PUBLISHER, TwillAppSettings::roles()::ADMIN]
+                    [TwillPermissions::roles()::PUBLISHER, TwillPermissions::roles()::ADMIN]
                 );
             });
         });
@@ -92,7 +92,7 @@ class AuthServiceProvider extends ServiceProvider
             return $this->authorize($user, function ($user) {
                 return $this->userHasRole(
                     $user,
-                    [TwillAppSettings::roles()::PUBLISHER, TwillAppSettings::roles()::ADMIN]
+                    [TwillPermissions::roles()::PUBLISHER, TwillPermissions::roles()::ADMIN]
                 );
             });
         });
@@ -101,7 +101,7 @@ class AuthServiceProvider extends ServiceProvider
             return $this->authorize($user, function ($user) {
                 return $this->userHasRole(
                     $user,
-                    [TwillAppSettings::roles()::PUBLISHER, TwillAppSettings::roles()::ADMIN]
+                    [TwillPermissions::roles()::PUBLISHER, TwillPermissions::roles()::ADMIN]
                 );
             });
         });
@@ -110,7 +110,7 @@ class AuthServiceProvider extends ServiceProvider
             return $this->authorize($user, function ($user) {
                 return $this->userHasRole(
                     $user,
-                    [TwillAppSettings::roles()::PUBLISHER, TwillAppSettings::roles()::ADMIN]
+                    [TwillPermissions::roles()::PUBLISHER, TwillPermissions::roles()::ADMIN]
                 );
             });
         });
@@ -119,7 +119,7 @@ class AuthServiceProvider extends ServiceProvider
             return $this->authorize($user, function ($user) {
                 return $this->userHasRole(
                     $user,
-                    [TwillAppSettings::roles()::PUBLISHER, TwillAppSettings::roles()::ADMIN]
+                    [TwillPermissions::roles()::PUBLISHER, TwillPermissions::roles()::ADMIN]
                 );
             });
         });
@@ -128,7 +128,7 @@ class AuthServiceProvider extends ServiceProvider
             return $this->authorize($user, function ($user) {
                 return $this->userHasRole(
                     $user,
-                    [TwillAppSettings::roles()::PUBLISHER, TwillAppSettings::roles()::ADMIN]
+                    [TwillPermissions::roles()::PUBLISHER, TwillPermissions::roles()::ADMIN]
                 );
             });
         });
@@ -137,14 +137,14 @@ class AuthServiceProvider extends ServiceProvider
             return $this->authorize($user, function ($user) {
                 return $this->userHasRole(
                     $user,
-                    [TwillAppSettings::roles()::PUBLISHER, TwillAppSettings::roles()::ADMIN]
+                    [TwillPermissions::roles()::PUBLISHER, TwillPermissions::roles()::ADMIN]
                 );
             });
         });
 
         $this->define('manage-users', function ($user) {
             return $this->authorize($user, function ($user) {
-                return $this->userHasRole($user, [TwillAppSettings::roles()::ADMIN]);
+                return $this->userHasRole($user, [TwillPermissions::roles()::ADMIN]);
             });
         });
 
@@ -152,7 +152,7 @@ class AuthServiceProvider extends ServiceProvider
         // As a non-admin, I can edit myself only
         $this->define('edit-user', function ($user, $editedUser = null) {
             return $this->authorize($user, function ($user) use ($editedUser) {
-                return ($this->userHasRole($user, [TwillAppSettings::roles()::ADMIN]) || $user->id == $editedUser->id)
+                return ($this->userHasRole($user, [TwillPermissions::roles()::ADMIN]) || $user->id == $editedUser->id)
                     && ($editedUser ? $editedUser->role !== self::SUPERADMIN : true);
             });
         });
@@ -162,7 +162,7 @@ class AuthServiceProvider extends ServiceProvider
                 $editedUserObject = User::find(request('id'));
                 return $this->userHasRole(
                         $user,
-                        [TwillAppSettings::roles()::ADMIN]
+                        [TwillPermissions::roles()::ADMIN]
                     ) && (
                         $editedUserObject && $user->id !== $editedUserObject->id &&
                         $editedUserObject->role !== self::SUPERADMIN

--- a/src/AuthServiceProvider.php
+++ b/src/AuthServiceProvider.php
@@ -2,7 +2,7 @@
 
 namespace A17\Twill;
 
-use A17\Twill\Models\Enums\UserRole;
+use A17\Twill\Facades\TwillAppSettings;
 use A17\Twill\Models\User;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 use Illuminate\Support\Facades\Gate;
@@ -19,8 +19,14 @@ class AuthServiceProvider extends ServiceProvider
     const ABILITY_ALIASES = [
         'list' => ['access-module-list', 'access-media-library'],
         'edit' => [
-            'view-item', 'view-module', 'edit-item', 'edit-module', 'edit-settings',
-            'manage-item', 'manage-module', 'manage-modules'
+            'view-item',
+            'view-module',
+            'edit-item',
+            'edit-module',
+            'edit-settings',
+            'manage-item',
+            'manage-module',
+            'manage-modules',
         ],
         'reorder' => [],
         'publish' => [],
@@ -63,57 +69,82 @@ class AuthServiceProvider extends ServiceProvider
 
     public function boot()
     {
-        $this->define('list', function ($user, $item=null) {
+        $this->define('list', function ($user, $item = null) {
             return $this->authorize($user, function ($user) {
-                return $this->userHasRole($user, [UserRole::VIEWONLY, UserRole::PUBLISHER, UserRole::ADMIN]);
+                return $this->userHasRole($user, [
+                    TwillAppSettings::roles()::VIEWONLY,
+                    TwillAppSettings::roles()::PUBLISHER,
+                    TwillAppSettings::roles()::ADMIN,
+                ]);
             });
         });
 
-        $this->define('edit', function ($user, $item=null) {
+        $this->define('edit', function ($user, $item = null) {
             return $this->authorize($user, function ($user) {
-                return $this->userHasRole($user, [UserRole::PUBLISHER, UserRole::ADMIN]);
+                return $this->userHasRole(
+                    $user,
+                    [TwillAppSettings::roles()::PUBLISHER, TwillAppSettings::roles()::ADMIN]
+                );
             });
         });
 
         $this->define('reorder', function ($user) {
             return $this->authorize($user, function ($user) {
-                return $this->userHasRole($user, [UserRole::PUBLISHER, UserRole::ADMIN]);
+                return $this->userHasRole(
+                    $user,
+                    [TwillAppSettings::roles()::PUBLISHER, TwillAppSettings::roles()::ADMIN]
+                );
             });
         });
 
         $this->define('publish', function ($user) {
             return $this->authorize($user, function ($user) {
-                return $this->userHasRole($user, [UserRole::PUBLISHER, UserRole::ADMIN]);
+                return $this->userHasRole(
+                    $user,
+                    [TwillAppSettings::roles()::PUBLISHER, TwillAppSettings::roles()::ADMIN]
+                );
             });
         });
 
         $this->define('feature', function ($user) {
             return $this->authorize($user, function ($user) {
-                return $this->userHasRole($user, [UserRole::PUBLISHER, UserRole::ADMIN]);
+                return $this->userHasRole(
+                    $user,
+                    [TwillAppSettings::roles()::PUBLISHER, TwillAppSettings::roles()::ADMIN]
+                );
             });
         });
 
         $this->define('delete', function ($user) {
             return $this->authorize($user, function ($user) {
-                return $this->userHasRole($user, [UserRole::PUBLISHER, UserRole::ADMIN]);
+                return $this->userHasRole(
+                    $user,
+                    [TwillAppSettings::roles()::PUBLISHER, TwillAppSettings::roles()::ADMIN]
+                );
             });
         });
 
         $this->define('duplicate', function ($user) {
             return $this->authorize($user, function ($user) {
-                return $this->userHasRole($user, [UserRole::PUBLISHER, UserRole::ADMIN]);
+                return $this->userHasRole(
+                    $user,
+                    [TwillAppSettings::roles()::PUBLISHER, TwillAppSettings::roles()::ADMIN]
+                );
             });
         });
 
         $this->define('upload', function ($user) {
             return $this->authorize($user, function ($user) {
-                return $this->userHasRole($user, [UserRole::PUBLISHER, UserRole::ADMIN]);
+                return $this->userHasRole(
+                    $user,
+                    [TwillAppSettings::roles()::PUBLISHER, TwillAppSettings::roles()::ADMIN]
+                );
             });
         });
 
         $this->define('manage-users', function ($user) {
             return $this->authorize($user, function ($user) {
-                return $this->userHasRole($user, [UserRole::ADMIN]);
+                return $this->userHasRole($user, [TwillAppSettings::roles()::ADMIN]);
             });
         });
 
@@ -121,7 +152,7 @@ class AuthServiceProvider extends ServiceProvider
         // As a non-admin, I can edit myself only
         $this->define('edit-user', function ($user, $editedUser = null) {
             return $this->authorize($user, function ($user) use ($editedUser) {
-                return ($this->userHasRole($user, [UserRole::ADMIN]) || $user->id == $editedUser->id)
+                return ($this->userHasRole($user, [TwillAppSettings::roles()::ADMIN]) || $user->id == $editedUser->id)
                     && ($editedUser ? $editedUser->role !== self::SUPERADMIN : true);
             });
         });
@@ -129,7 +160,13 @@ class AuthServiceProvider extends ServiceProvider
         $this->define('publish-user', function ($user) {
             return $this->authorize($user, function ($user) {
                 $editedUserObject = User::find(request('id'));
-                return $this->userHasRole($user, [UserRole::ADMIN]) && ($editedUserObject ? $user->id !== $editedUserObject->id && $editedUserObject->role !== self::SUPERADMIN : false);
+                return $this->userHasRole(
+                        $user,
+                        [TwillAppSettings::roles()::ADMIN]
+                    ) && (
+                        $editedUserObject && $user->id !== $editedUserObject->id &&
+                        $editedUserObject->role !== self::SUPERADMIN
+                    );
             });
         });
 

--- a/src/Http/Controllers/Admin/UserController.php
+++ b/src/Http/Controllers/Admin/UserController.php
@@ -4,7 +4,6 @@ namespace A17\Twill\Http\Controllers\Admin;
 
 use A17\Twill\Facades\TwillPermissions;
 use A17\Twill\Models\Contracts\TwillModelContract;
-use A17\Twill\Models\Enums\UserRole;
 use A17\Twill\Models\Group;
 use A17\Twill\Models\Permission;
 use A17\Twill\Models\Role;
@@ -384,7 +383,7 @@ class UserController extends ModuleController
             })->toArray();
         }
 
-        return collect(UserRole::toArray())->map(function ($item, $key) {
+        return collect(TwillPermissions::roles()::toArray())->map(function ($item, $key) {
             return ['value' => $key, 'label' => $item];
         })->values()->toArray();
     }

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -2,13 +2,13 @@
 
 namespace A17\Twill\Models;
 
+use A17\Twill\Facades\TwillPermissions;
 use A17\Twill\Models\Behaviors\HasMedias;
 use A17\Twill\Models\Behaviors\HasOauth;
 use A17\Twill\Models\Behaviors\HasPermissions;
 use A17\Twill\Models\Behaviors\HasPresenter;
 use A17\Twill\Models\Behaviors\IsTranslatable;
 use A17\Twill\Models\Contracts\TwillModelContract;
-use A17\Twill\Models\Enums\UserRole;
 use A17\Twill\Notifications\PasswordResetByAdmin as PasswordResetByAdminNotification;
 use A17\Twill\Notifications\Reset as ResetNotification;
 use A17\Twill\Notifications\TemporaryPassword as TemporaryPasswordNotification;
@@ -16,7 +16,6 @@ use A17\Twill\Notifications\Welcome as WelcomeNotification;
 use Illuminate\Auth\Authenticatable;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\SoftDeletes;
-use Illuminate\Database\Eloquent\SoftDeletingScope;
 use Illuminate\Foundation\Auth\Access\Authorizable;
 use Illuminate\Foundation\Auth\User as AuthenticatableContract;
 use Illuminate\Notifications\Notifiable;
@@ -120,16 +119,16 @@ class User extends AuthenticatableContract implements TwillModelContract
 
     public function getRoleValueAttribute()
     {
-        if ($this->is_superadmin || $this->role == 'SUPERADMIN') {
+        if ($this->is_superadmin || $this->role === 'SUPERADMIN') {
             return 'SUPERADMIN';
         }
 
         if (config('twill.enabled.permissions-management')) {
-            return $this->role ? $this->role->name : null;
+            return $this->role->name ?? null;
         }
 
         if (! empty($this->role)) {
-            return UserRole::{$this->role}()->getValue();
+            return TwillPermissions::roles()::{$this->role}()->getValue();
         }
 
         return null;

--- a/src/TwillPermissions.php
+++ b/src/TwillPermissions.php
@@ -3,13 +3,34 @@
 namespace A17\Twill;
 
 use A17\Twill\Enums\PermissionLevel;
+use A17\Twill\Models\Enums\UserRole;
 use A17\Twill\Models\Permission;
+use MyCLabs\Enum\Enum;
 
 class TwillPermissions
 {
+    public string $roleEnum = UserRole::class;
+
     public function enabled(): bool
     {
         return config('twill.enabled.permissions-management');
+    }
+
+    /**
+     * @return Enum
+     */
+    public function roles(): string
+    {
+        return $this->roleEnum;
+    }
+
+    /**
+     * The role enumeration class. Must extend MyCLabs\Enum\Enum.
+     * See A17\Twill\Models\Enums\UserRole for an example.
+     */
+    public function setRoleEnum(string $roleEnum): void
+    {
+        $this->roleEnum = $roleEnum;
     }
 
     /**

--- a/tests/integration/SwappableRolesTest.php
+++ b/tests/integration/SwappableRolesTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace A17\Twill\Tests\Integration;
+
+use A17\Twill\Facades\TwillPermissions;
+use MyCLabs\Enum\Enum;
+
+class SwappableRolesTest extends PermissionsTestBase
+{
+    public function testDefaultRoles(): void
+    {
+        $this->assertEquals(
+            ['VIEWONLY' => 'View only', 'PUBLISHER' => 'Publisher', 'ADMIN' => 'Admin'],
+            TwillPermissions::roles()::toArray()
+        );
+    }
+
+    public function testCustomRoles(): void {
+        $rolesEnum = new class('Custom only') extends Enum {
+            public const CUSTOMONLY = 'Custom only';
+        };
+
+        TwillPermissions::setRoleEnum($rolesEnum::class);
+        
+        $this->assertEquals(
+            ['CUSTOMONLY' => 'Custom only'],
+            TwillPermissions::roles()::toArray()
+        );
+    }
+}


### PR DESCRIPTION
When using basic permissions, roles can now be swapped without having to edit composer.json.

It is backwards compatible with the old approach so no migration is needed.

```php
class AppServiceProvider extends ServiceProvider
{
    public function register(): void
    {
        TwillPermissions::setRoleEnum(\App\Models\Enums\UserRole::class);
    }
}
```