### PR TITLE
fix duplicate feature nested module

### DIFF
--- a/src/Http/Controllers/Admin/ModuleController.php
+++ b/src/Http/Controllers/Admin/ModuleController.php
@@ -661,6 +661,14 @@ abstract class ModuleController extends Controller
     }
 
     /**
+     * @return array
+    */
+    protected function duplicateItemData()
+    {
+        return [];
+    }
+
+    /**
      * @param int $id
      * @param int|null $submoduleId
      * @return \Illuminate\Http\JsonResponse
@@ -668,6 +676,7 @@ abstract class ModuleController extends Controller
     public function duplicate($id, $submoduleId = null)
     {
 
+        $submoduleId = $submoduleId ?? key($this->request->input());
         $item = $this->repository->getById($submoduleId ?? $id);
         if ($newItem = $this->repository->duplicate($submoduleId ?? $id, $this->titleColumnKey)) {
             $this->fireEvent();
@@ -680,7 +689,7 @@ abstract class ModuleController extends Controller
                     $this->moduleName,
                     $this->routePrefix,
                     'edit',
-                    array_filter([Str::singular($this->moduleName) => $newItem->id])
+                    array_filter([Str::singular($this->moduleName) => $newItem->id] + $this->duplicateItemData())
                 ),
             ]);
         }
@@ -953,7 +962,7 @@ abstract class ModuleController extends Controller
             $itemIsTrashed = method_exists($item, 'trashed') && $item->trashed();
             $itemCanDelete = $this->getIndexOption('delete') && ($item->canDelete ?? true);
             $canEdit = $this->getIndexOption('edit');
-            $canDuplicate = $this->getIndexOption('duplicate');
+            $canDuplicate = $this->getIndexOption('duplicate', $item);
 
             return array_replace([
                 'id' => $item->id,

--- a/src/Repositories/ModuleRepository.php
+++ b/src/Repositories/ModuleRepository.php
@@ -343,6 +343,15 @@ abstract class ModuleRepository
     }
 
     /**
+     * @return array
+     */
+    protected function duplicateItemData()
+    {
+        return [];
+    }
+
+
+    /**
      * @param mixed $id
      * @return mixed
      */
@@ -364,7 +373,7 @@ abstract class ModuleRepository
             'languages'
         ])->filter()->toArray();
 
-        $newObject = $this->create($baseInput);
+        $newObject = $this->create($baseInput + $this->duplicateItemData());
 
         $this->update($newObject->id, $revisionInput);
 


### PR DESCRIPTION
## Description

<!-- Write a description of the changes introduced by this PR -->
This PR introduces a new hook that allows the developer to add extra data for duplicating a nested module item. 
For example, if the nested module is `genericDetail` and the main module is `page`, the following error is triggered 

<img width="1227" alt="Screenshot 2022-10-10 at 11 01 27" src="https://user-images.githubusercontent.com/26021934/194842144-06f08bf5-7dc5-49a9-83da-4a7a85a05760.png">

The `page` route parameter is missing above, and this PR helps us fix it by allowing us add it as an extra parameter in the controller:

```
class PageGenericDetailController extends ModuleController
{
    protected $moduleName = 'genericDetails';
    protected $modelName = 'GenericDetail';
    ...
   
    protected function duplicateItemData()
    {
        return [
            'page' => request()->id,
        ];
    }

    ...
}

```

And if we need to add any extra data in the repository, we can do that like so:

```
class GenericDetailRepository extends ModuleRepository
{
   ....

   protected function duplicateItemData()
    {
        return [
            'page_id' => request()->id
        ];
    }

  ...
}

```



## Related Issues
This PR fixes this issue https://github.com/area17/twill/issues/1730

