### PR TITLE
[2.x] Add command to allow developers to flush only the twill-manifest.json from cache

### DIFF
--- a/src/Commands/TwillFlushManifest.php
+++ b/src/Commands/TwillFlushManifest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace A17\Twill\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Cache;
+
+class TwillFlushManifest extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'twill:flush-manifest';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Flush twill-manifest.json file from cache';
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        Cache::forget('twill-manifest');
+
+        $this->info('Twill manifest was flushed from cache.');
+
+        return 0;
+    }
+}

--- a/src/Commands/Update.php
+++ b/src/Commands/Update.php
@@ -16,7 +16,7 @@ class Update extends Command
     public function handle()
     {
         $this->publishAssets();
-        $this->call('cache:clear');
+        $this->call('twill:flush-manifest');
         $this->call('view:clear');
     }
 

--- a/src/TwillServiceProvider.php
+++ b/src/TwillServiceProvider.php
@@ -8,6 +8,7 @@ use A17\Twill\Commands\CapsuleInstall;
 use A17\Twill\Commands\CreateSuperAdmin;
 use A17\Twill\Commands\Dev;
 use A17\Twill\Commands\GenerateBlocks;
+use A17\Twill\Commands\TwillFlushManifest;
 use A17\Twill\Commands\GeneratePackageCommand;
 use A17\Twill\Commands\Install;
 use A17\Twill\Commands\ListBlocks;
@@ -327,6 +328,7 @@ class TwillServiceProvider extends ServiceProvider
             SyncLang::class,
             CapsuleInstall::class,
             GeneratePackageCommand::class,
+            TwillFlushManifest::class,
         ]);
     }
 


### PR DESCRIPTION
I'm trying to solve two problems here:

- While deploying to Vapor, we are running `php artisan twill:update` while building the image on CI, at this point we don't have access to the AWS Redis cache, so we needed a way to clear the twill-manifest.json during the vapor deploy stage, where we cannot run  `php artisan twill:update`, as no files are supposed to change anymore at this point of the deployment.
- `php artisan twill:update` is also clearing the whole application cache and this can be seen as a bad practice, as it's potentially clearing a lot of other application data from cache that developers may want to keep between deployments.

As far as I can tell, Twill is using the Laravel cache only to store the manifest, so that's why I created a separate command to clear this particular cache, and this is also something we can safely run during Vapor deploy stage.