### PR TITLE
[2.x] fix media library upload replace accents

### DIFF
--- a/src/Helpers/media_library_helpers.php
+++ b/src/Helpers/media_library_helpers.php
@@ -63,6 +63,9 @@ if (!function_exists('replaceAccents')) {
      */
     function replaceAccents($str)
     {
+        if (function_exists('mb_convert_encoding')) {
+            return mb_convert_encoding($str, 'ASCII', 'UTF-8');
+        }
         return iconv('UTF-8', 'ASCII//TRANSLIT', $str);
     }
 }


### PR DESCRIPTION
## Description

Uses mb_convert_encoding if available, otherwise fallback to iconv.

## Related Issues

Fixes [Media Library upload fails when iconv does not support transliteration #78](https://github.com/area17/twill/issues/78)
kudos to @pboivin

