### PR TITLE
[3.x] fix: Hide nav item if user is not authorized (legacy config)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -111,7 +111,7 @@ jobs:
         run: ./vendor/bin/testbench twill:build --forTesting
 
       - name: Upgrade Chrome Driver
-        run: ./vendor/bin/testbench dusk:chrome-driver
+        run: ./vendor/bin/testbench dusk:chrome-driver --detect
 
       - name: Execute tests
         run: vendor/bin/testbench package:test

--- a/src/TwillNavigation.php
+++ b/src/TwillNavigation.php
@@ -115,11 +115,11 @@ class TwillNavigation
             $link = NavigationLink::make()->forModule($key);
         }
 
-        if ($link && ($legacy['title'] ?? false)) {
+        if ($legacy['title'] ?? false) {
             $link->title($legacy['title']);
         }
 
-        if ($link && ($legacy['can'] ?? false)) {
+        if ($legacy['can'] ?? false) {
             $link->onlyWhen(fn () => (bool) Auth::user()?->can($legacy['can']));
         }
 

--- a/src/TwillNavigation.php
+++ b/src/TwillNavigation.php
@@ -119,6 +119,10 @@ class TwillNavigation
             $link->title($legacy['title']);
         }
 
+        if ($link && ($legacy['can'] ?? false)) {
+            $link->onlyWhen(fn () => (bool) Auth::user()?->can($legacy['can']));
+        }
+
         return $link;
     }
 

--- a/tests/integration/Navigation/LegacyNavigationTest.php
+++ b/tests/integration/Navigation/LegacyNavigationTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace A17\Twill\Tests\Integration\Navigation;
+
+use A17\Twill\Facades\TwillNavigation;
+use A17\Twill\Tests\Integration\TestCase;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Auth;
+
+class LegacyNavigationTest extends TestCase
+{
+    public function testNavItemIsNotVisibleIfNotAuthorized(): void
+    {
+        config()->set('twill-navigation', [
+            'pages' => [
+                'module' => true,
+                'can' => 'see-nav-item',
+            ]
+        ]);
+
+        $this->login();
+
+        $navigation = TwillNavigation::buildNavigationTree();
+
+        $this->assertFalse(Auth::user()->can('see-nav-item'));
+        $this->assertEmpty($navigation['left']);
+    }
+
+    public function testNavItemIsVisibleIfAuthorized(): void
+    {
+        config()->set('twill-navigation', [
+            'pages' => [
+                'module' => true,
+                'can' => 'see-nav-item',
+            ]
+        ]);
+
+        Gate::define('see-nav-item', function () {
+            return true;
+        });
+
+        $this->login();
+
+        $navigation = TwillNavigation::buildNavigationTree();
+
+        $this->assertTrue(Auth::user()->can('see-nav-item'));
+        $this->assertNotEmpty($navigation['left']);
+        $this->assertEquals('Pages', $navigation['left'][0]->getTitle());
+    }
+}


### PR DESCRIPTION
Small fix to ensure that the `can` key in still supported in legacy `config/twill-navigation.php`:

```php
    'pages' => [
        'title' => 'Pages',
        'route' => 'admin.pages.index',
        'can' => 'access-pages',
    ],
```
