### PR TITLE
[2.x] Allow create without modal.

### DIFF
--- a/views/layouts/listing.blade.php
+++ b/views/layouts/listing.blade.php
@@ -137,7 +137,7 @@
             </a17-datatable>
         @endif
 
-        @if($create)
+        @if($create || (isset($tableData[0]['editInModal']) &&!empty($tableData[0]['editInModal'])))
             <a17-modal-create
                 ref="editionModal"
                 form-create="{{ $storeUrl }}"


### PR DESCRIPTION
Fixes an issue where the create modal is not available when no create option is there. However, that create modal is used for editing as well