### PR TITLE
[2.x] Fix $parameter not being an array on legacy applications

### DIFF
--- a/src/Helpers/routes_helpers.php
+++ b/src/Helpers/routes_helpers.php
@@ -19,7 +19,7 @@ if (!function_exists('moduleRoute')) {
 
         // Nested module, pass in current parameters for deeply nested modules
         if (Str::contains($moduleName, '.')) {
-            $parameters = array_merge(Route::current()->parameters(), $parameters);
+            $parameters = array_merge(Route::current()->parameters(), (array) $parameters);
         }
 
         // Create base route name


### PR DESCRIPTION
## Description

As `$parameters` may not be an array [sometimes](https://github.com/area17/twill/blob/2.x/src/Repositories/Behaviors/HandleBrowsers.php#L159). 