### PR TITLE
[2.x] Fix moduleRoute() double dots

### DIFF
--- a/src/Helpers/routes_helpers.php
+++ b/src/Helpers/routes_helpers.php
@@ -34,8 +34,10 @@ if (!function_exists('moduleRoute')) {
             $routeName .= "{$moduleName}";
         }
 
+        $glue = Str::endsWith($routeName, '.') ? '' : '.';
+
         //  Add the action name
-        $routeName .= $action ? ".{$action}" : '';
+        $routeName .= $action ? "{$glue}{$action}" : '';
 
         // Build the route
         return route($routeName, $parameters, $absolute);


### PR DESCRIPTION
## Description

While migrating a Twill 2.2 app, I found it was not able to generate some of our routes properly, adding a second dot before the action:

```
Route [admin.visit.openingHours.openingHoursExtended..update] not defined.
```

This is the call that generated this error:

``` php
moduleRoute(
  "openingHoursExtended",
  "visit.openingHours.openingHoursExtended",
  "",
  [],
  true,
);
```

