### PR TITLE
[2.x] User auth activity 

### DIFF
--- a/config/dashboard.php
+++ b/config/dashboard.php
@@ -13,4 +13,16 @@ return [
     'modules' => [],
     'analytics' => ['enabled' => false],
     'search_endpoint' => 'admin.search',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Twill Auth activity related configuration
+    |--------------------------------------------------------------------------
+    |
+     */
+    'auth_activity_log' => [
+        'login' => true,
+        'logout' => true,
+    ],
+    'auth_activity_causer' => 'users',
 ];

--- a/config/dashboard.php
+++ b/config/dashboard.php
@@ -21,8 +21,8 @@ return [
     |
      */
     'auth_activity_log' => [
-        'login' => true,
-        'logout' => true,
+        'login' => false,
+        'logout' => false,
     ],
     'auth_activity_causer' => 'users',
 ];

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -26,6 +26,7 @@ return [
         'reset-password' => 'Reset password',
         'reset-send' => 'Send password reset link',
         'verify-login' => 'Verify login',
+        'auth-causer' => 'Authentication'
     ],
     'buckets' => [
         'intro' => 'What would you like to feature today?',
@@ -56,6 +57,8 @@ return [
             'unfeatured' => 'Unfeatured',
             'restored' => 'Restored',
             'deleted' => 'Deleted',
+            'login' => 'Login action',
+            'logout' => 'Logout action'
         ],
         'activity-row' => [
             'edit' => 'Edit',

--- a/src/Http/Controllers/Admin/DashboardController.php
+++ b/src/Http/Controllers/Admin/DashboardController.php
@@ -166,6 +166,9 @@ class DashboardController extends Controller
             }
         }
 
+        config('twill.dashboard.auth_activity_log.login', false) && array_push($listActivities, config('twill.dashboard.auth_activity_causer', 'users')) ||
+        config('twill.dashboard.auth_activity_log.logout', false) && array_push($listActivities, config('twill.dashboard.auth_activity_causer', 'users'));
+
         return $listActivities;
     }
 
@@ -208,6 +211,10 @@ class DashboardController extends Controller
      */
     private function formatActivity($activity)
     {
+        if($activity->subject_type === config('twill.auth_activity_causer', 'users')){
+            return $this->formatAuthActivity($activity);
+        }
+
         $dashboardModule = $this->config->get('twill.dashboard.modules.' . $activity->subject_type);
 
         if (!$dashboardModule || !$dashboardModule['activity'] ?? false) {
@@ -224,13 +231,31 @@ class DashboardController extends Controller
             'date' => $activity->created_at->toIso8601String(),
             'author' => $activity->causer->name ?? twillTrans('twill::lang.dashboard.unknown-author'),
             'name' => $activity->subject->titleInDashboard ?? $activity->subject->title,
-            'activity' => twillTrans('twill::lang.dashboard.activities.' . $activity->description),
+            'activity' => twillTrans('twill::lang.dashboard.activities.' . $activity->description, $activity->properties->toArray()),
         ] + (classHasTrait($activity->subject, HasMedias::class) ? [
             'thumbnail' => $activity->subject->defaultCmsImage(['w' => 100, 'h' => 100]),
         ] : []) + (!$activity->subject->trashed() ? [
             'edit' => moduleRoute($dashboardModule['name'], $dashboardModule['routePrefix'] ?? null, 'edit', $activity->subject_id),
         ] : []) + (!is_null($activity->subject->published) ? [
             'published' => $activity->description === 'published' ? true : ($activity->description === 'unpublished' ? false : $activity->subject->published),
+        ] : []);
+    }
+
+    /**
+     * @param \Spatie\Activitylog\Models\Activity $activity
+     * @return array|null
+     */
+    private function formatAuthActivity($activity)
+    {
+        return [
+            'id' => $activity->id,
+            'type' => twillTrans('twill::lang.auth.auth-causer'),
+            'date' => $activity->created_at->toIso8601String(),
+            'author' => $activity->causer->name ?? twillTrans('twill::lang.dashboard.unknown-author'),
+            'name' => ucfirst($activity->description) ?? '',
+            'activity' => twillTrans('twill::lang.dashboard.activities.' . $activity->description, $activity->properties->toArray()),
+        ] + (classHasTrait($activity->subject, HasMedias::class) ? [
+            'thumbnail' => $activity->subject->defaultCmsImage(['w' => 100, 'h' => 100]),
         ] : []);
     }
 

--- a/src/Http/Controllers/Admin/LoginController.php
+++ b/src/Http/Controllers/Admin/LoginController.php
@@ -112,6 +112,10 @@ class LoginController extends Controller
      */
     public function logout(Request $request)
     {
+        config('twill.dashboard.auth_activity_log.logout', false) && activity()
+                                                            ->performedOn($this->user())
+                                                            ->causedBy($this->user())
+                                                            ->log('logout');
         $this->guard()->logout();
 
         $request->session()->invalidate();
@@ -140,6 +144,11 @@ class LoginController extends Controller
 
             return $this->redirector->to(route('admin.login-2fa.form'));
         }
+
+        config('twill.dashboard.auth_activity_log.login', false) && activity()
+                                                            ->performedOn($this->user())
+                                                            ->causedBy($this->user())
+                                                            ->log('login');
 
         return $this->redirector->intended($this->redirectTo);
     }
@@ -286,5 +295,13 @@ class LoginController extends Controller
     protected function credentials($request)
     {
         return array_merge($request->only($this->username(), 'password'), ['published' => 1]);
+    }
+
+    /**
+     * @return \A17\Twill\Models\User|null
+     */
+    protected function user()
+    {
+        return $this->guard()->user();
     }
 }


### PR DESCRIPTION
Currently, no auth activity is logged in the CMS. 
This PR implements `login` and `logout` auth actions.

Per default, this is off.

TODO:
*    docs
*    document new possible parsing via analytics arguments on the lang.
*    Implement admin area activity.

![dc](https://user-images.githubusercontent.com/30219259/203185442-a1f76db9-8b79-4984-a90d-02f69609f343.jpg)
