### PR TITLE
[2.x] enh: Add Twill Route facade to preserve `singleton()` method

### DIFF
--- a/src/Facades/Route.php
+++ b/src/Facades/Route.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace A17\Twill\Facades;
+
+use Illuminate\Support\Facades\Facade;
+
+class Route extends Facade
+{
+    protected static function getFacadeAccessor(): string
+    {
+        return 'router';
+    }
+
+    public static function singleton($moduleName)
+    {
+        return app(static::getFacadeAccessor())->twillSingleton($moduleName);
+    }
+}


### PR DESCRIPTION
This PR adds a `Route` facade in Twill. The facade is equivalent to `Illuminate\Support\Facades\Route`, and adds a `singleton()` static method as an alias for the `twillSingleton()` macro (renamed in 2.12.0). 

This offers an alternative migration path on `2.x`, which is to use `A17\Twill\Facades\Route` within `routes/admin.php`.

ref: https://github.com/area17/twill/issues/1961