### PR TITLE
[3.x] Use TwillRoutes instead of macro's

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -18,6 +18,7 @@ We provide an automated upgrade path using the commands explaned below. This wil
 - Moving the twill views to the new namespace
 - Moving the twill routes to the new location
 - Fixing (most) compatibility issues.
+- Using the new TwillRoutes facade for ::module and ::singleton instead of a Route macro.
 
 ### Run the upgrade:
 

--- a/docs/content/1_documentation/2_getting-started/4_navigation.md
+++ b/docs/content/1_documentation/2_getting-started/4_navigation.md
@@ -39,16 +39,18 @@ public function boot(): void
 ```php
 <?php
 
-Route::module('pages');
+use A17\Twill\Facades\TwillRoutes;
+
+TwillRoutes::module('pages');
 
 Route::group(['prefix' => 'work'], function () {
     Route::group(['prefix' => 'projects'], function () {
-        Route::module('projectCustomers');
+        TwillRoutes::module('projectCustomers');
     });
-    Route::module('projects');
-    Route::module('clients');
-    Route::module('industries');
-    Route::module('studios');
+    TwillRoutes::module('projects');
+    TwillRoutes::module('clients');
+    TwillRoutes::module('industries');
+    TwillRoutes::module('studios');
 });
 ```
 

--- a/docs/content/1_documentation/3_modules/cli-generator.md
+++ b/docs/content/1_documentation/3_modules/cli-generator.md
@@ -24,7 +24,9 @@ Once you ran the command a new entry will be added to `routes/twill.php`.
 ```php
 <?php
 
-Route::module('moduleName');
+use A17\Twill\Facades\TwillRoutes;
+
+TwillRoutes::module('moduleName');
 ```
 
 And a navigation entry will be added in `config/twill-navigation.php`.
@@ -74,8 +76,9 @@ Once you ran the command a new entry will be added to `routes/twill.php`.
 
 ```php
 <?php
+use A17\Twill\Facades\TwillRoutes;
 
-Route::singleton('moduleName');
+TwillRoutes::singleton('moduleName');
 ```
 
 And a navigation entry will be added in `config/twill-navigation.php`.

--- a/docs/content/1_documentation/3_modules/nested-modules.md
+++ b/docs/content/1_documentation/3_modules/nested-modules.md
@@ -206,8 +206,12 @@ class IssueController extends BaseModuleController
 Add both modules to `routes/twill.php`:
 
 ```php
-Route::module('issues');
-Route::module('issues.articles');
+<?php
+
+use A17\Twill\Facades\TwillRoutes;
+
+TwillRoutes::module('issues');
+TwillRoutes::module('issues.articles');
 ```
 
 Add the parent module to `AppServiceProvider.php`:

--- a/docs/content/1_documentation/3_modules/routes.md
+++ b/docs/content/1_documentation/3_modules/routes.md
@@ -1,19 +1,21 @@
 # Routes
 
-A router macro is available to create module routes quicker:
+A router facade is available to create module routes quicker:
 ```php
 <?php
 
-Route::module('yourModulePluralName');
+use A17\Twill\Facades\TwillRoutes;
+
+TwillRoutes::module('yourModulePluralName');
 
 // You can add an array of only/except action names as a second parameter
 // By default, the following routes are created : 'reorder', 'publish', 'browser', 'bucket', 'feature', 'restore', 'bulkFeature', 'bulkPublish', 'bulkDelete', 'bulkRestore'
-Route::module('yourModulePluralName', ['except' => ['reorder', 'feature', 'bucket', 'browser']]);
+TwillRoutes::module('yourModulePluralName', ['except' => ['reorder', 'feature', 'bucket', 'browser']]);
 
 // You can add an array of only/except action names for the resource controller as a third parameter
 // By default, the following routes are created : 'index', 'store', 'show', 'edit', 'update', 'destroy'
-Route::module('yourModulePluralName', [], ['only' => ['index', 'edit', 'store', 'destroy']]);
+TwillRoutes::module('yourModulePluralName', [], ['only' => ['index', 'edit', 'store', 'destroy']]);
 
 // The last optional parameter disable the resource controller actions on the module
-Route::module('yourPluralModuleName', [], [], false);
+TwillRoutes::module('yourPluralModuleName', [], [], false);
 ```

--- a/docs/content/2_guides/1_page-builder-with-blade/4_creating-the-page-module.md
+++ b/docs/content/2_guides/1_page-builder-with-blade/4_creating-the-page-module.md
@@ -105,9 +105,10 @@ Once the command is complete you will be prompted with some instructions:
 
 ```shell
 The following snippet has been added to routes/twill.php:
-┌─────────────────────────┐
-│ Route::module('pages'); │
-└─────────────────────────┘
+┌──────────────────────────────────┐
+│ use A17\Twill\Facades\TwillRoutes│
+│ TwillRoutes::module('pages');    │
+└──────────────────────────────────┘
 To add a navigation entry add the following to your AppServiceProvider BOOT method.
 **************************
 use A17\Twill\Facades\TwillNavigation;

--- a/docs/content/2_guides/adding-custom-roles-and-permissions.md
+++ b/docs/content/2_guides/adding-custom-roles-and-permissions.md
@@ -33,13 +33,15 @@ php artisan migrate
 Add the modules to our admin routes:
 
 :::filename:::
-`routes/admin.hpp`
+`routes/twill.php`
 :::#filename:::
 
 ```php
-Route::module('pages');
+use A17\Twill\Facades\TwillRoutes;
 
-Route::module('posts');
+TwillRoutes::module('pages');
+
+TwillRoutes::module('posts');
 ```
 
 ... and to our navigation:
@@ -265,16 +267,18 @@ class PostController extends ModuleController
 Then, add the route groups and middleware in the admin routes configuration:
 
 :::filename:::
-`routes/admin.php`
+`routes/twill.php`
 :::#filename:::
 
 ```php
+use A17\Twill\Facades\TwillRoutes;
+
 Route::group(['middleware' => 'can:edit-pages'], function () {
-    Route::module('pages');
+    TwillRoutes::module('pages');
 });
 
 Route::group(['middleware' => 'can:edit-posts'], function () {
-    Route::module('posts');
+    TwillRoutes::module('posts');
 });
 
 // ...

--- a/examples/basic-page-builder/routes/twill.php
+++ b/examples/basic-page-builder/routes/twill.php
@@ -1,10 +1,6 @@
 <?php
 
-use Illuminate\Support\Facades\Route;
+use A17\Twill\Facades\TwillRoutes;
 
-// Register Twill routes here eg.
-// Route::module('posts');
-
-Route::module('pages');
-Route::module('menuLinks');
-Route::module('menuLinks');
+TwillRoutes::module('pages');
+TwillRoutes::module('menuLinks');

--- a/examples/portfolio/routes/twill.php
+++ b/examples/portfolio/routes/twill.php
@@ -1,5 +1,7 @@
 <?php
 
-Route::module('projects');
-Route::module('partners');
-Route::module('comments');
+use A17\Twill\Facades\TwillRoutes;
+
+TwillRoutes::module('projects');
+TwillRoutes::module('partners');
+TwillRoutes::module('comments');

--- a/examples/tests-browsers/routes/twill.php
+++ b/examples/tests-browsers/routes/twill.php
@@ -1,10 +1,10 @@
 <?php
 
-use Illuminate\Support\Facades\Route;
+use A17\Twill\Facades\TwillRoutes;
 
 // Register Twill routes here eg.
 
-Route::module('writers');
-Route::module('letters');
-Route::module('bios');
-Route::module('books');
+TwillRoutes::module('writers');
+TwillRoutes::module('letters');
+TwillRoutes::module('bios');
+TwillRoutes::module('books');

--- a/examples/tests-capsules/app/Twill/Capsules/Posts/routes/twill.php
+++ b/examples/tests-capsules/app/Twill/Capsules/Posts/routes/twill.php
@@ -1,3 +1,5 @@
 <?php
 
-Route::module('posts');
+use A17\Twill\Facades\TwillRoutes;
+
+TwillRoutes::module('posts');

--- a/examples/tests-modules/routes/twill.php
+++ b/examples/tests-modules/routes/twill.php
@@ -1,7 +1,9 @@
 <?php
 
+use A17\Twill\Facades\TwillRoutes;
+
 Route::group(['prefix' => 'personnel'], function () {
-    Route::module('authors');
+    TwillRoutes::module('authors');
 });
 
-Route::module('categories');
+TwillRoutes::module('categories');

--- a/examples/tests-nestedmodules/routes/twill.php
+++ b/examples/tests-nestedmodules/routes/twill.php
@@ -1,5 +1,5 @@
 <?php
 
-use Illuminate\Support\Facades\Route;
+use A17\Twill\Facades\TwillRoutes;
 
-Route::module('nodes');
+TwillRoutes::module('nodes');

--- a/examples/tests-permissions/routes/twill.php
+++ b/examples/tests-permissions/routes/twill.php
@@ -1,3 +1,5 @@
 <?php
 
-Route::module('postings');
+use A17\Twill\Facades\TwillRoutes;
+
+TwillRoutes::module('postings');

--- a/examples/tests-singleton/routes/twill.php
+++ b/examples/tests-singleton/routes/twill.php
@@ -1,5 +1,5 @@
 <?php
 
-use Illuminate\Support\Facades\Route;
+use A17\Twill\Facades\TwillRoutes;
 
-Route::singleton('contactPage');
+TwillRoutes::singleton('contactPage');

--- a/examples/tests-subdomain-routing/routes/twill.php
+++ b/examples/tests-subdomain-routing/routes/twill.php
@@ -1,8 +1,5 @@
 <?php
 
-use Illuminate\Support\Facades\Route;
+use A17\Twill\Facades\TwillRoutes;
 
-// Register Twill routes here eg.
-// Route::module('posts');
-
-Route::module('pages');
+TwillRoutes::module('pages');

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -3,14 +3,15 @@
 use A17\Twill\Http\Controllers\Admin\AppSettingsController;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Route;
+use A17\Twill\Facades\TwillRoutes;
 
 if (config('twill.enabled.users-management')) {
-    Route::module('users', ['except' => ['sort', 'feature']]);
+    TwillRoutes::module('users', ['except' => ['sort', 'feature']]);
     Route::name('users.resend.registrationEmail')->get('users/{user}/registration-email', 'UserController@resendRegistrationEmail');
 
     if (config('twill.enabled.permissions-management')) {
-        Route::module('groups', ['except' => ['sort', 'feature', 'search']]);
-        Route::module('roles', ['except' => ['sort', 'feature']]);
+        TwillRoutes::module('groups', ['except' => ['sort', 'feature', 'search']]);
+        TwillRoutes::module('roles', ['except' => ['sort', 'feature']]);
     }
 }
 

--- a/src/Commands/ModuleMake.php
+++ b/src/Commands/ModuleMake.php
@@ -313,7 +313,7 @@ class ModuleMake extends Command
             $this->createCapsuleRoutes();
         } elseif ($this->isSingleton) {
             $this->createSingletonSeed($modelName);
-            $this->addEntryToRoutesFile("\nRoute::singleton('{$singularModuleName}');");
+            $this->addEntryToRoutesFile("\nTwillRoutes::singleton('{$singularModuleName}');");
         } else {
             $moduleNameForRoute = $navModuleName;
             if ($this->hasOption('parentModel') && $parent = $this->option('parentModel')) {
@@ -322,7 +322,7 @@ class ModuleMake extends Command
 
                 $moduleNameForRoute = $firstPart . '.' . $secondPart;
             }
-            $this->addEntryToRoutesFile("\nRoute::module('{$moduleNameForRoute}');");
+            $this->addEntryToRoutesFile("\nTwillRoutes::module('{$moduleNameForRoute}');");
         }
 
         $navTitle = $this->isSingleton ? $modelName : $moduleTitle;

--- a/src/Commands/stubs/admin.stub
+++ b/src/Commands/stubs/admin.stub
@@ -1,6 +1,6 @@
 <?php
 
-use Illuminate\Support\Facades\Route;
+use A17\Twill\Facades\TwillRoutes;
 
 // Register Twill routes here eg.
-// Route::module('posts');
+// TwillRoutes::module('posts');

--- a/src/Commands/stubs/routes_admin.stub
+++ b/src/Commands/stubs/routes_admin.stub
@@ -1,3 +1,5 @@
 <?php
 
-Route::module('{{moduleName}}');
+use A17\Twill\Facades\TwillRoutes;
+
+TwillRoutes::module('{{moduleName}}');

--- a/src/Commands/stubs/routes_singleton_admin.stub
+++ b/src/Commands/stubs/routes_singleton_admin.stub
@@ -1,3 +1,5 @@
 <?php
 
-Route::singleton('{{moduleName}}');
+use A17\Twill\Facades\TwillRoutes;
+
+TwillRoutes::singleton('{{moduleName}}');

--- a/upgrade.php
+++ b/upgrade.php
@@ -12,6 +12,8 @@ $arrayRename = [
 $arrayRenameInFile = [
     'config/twill-navigation.php' => ['admin.', 'twill.'],
     'config/twill.php' => ['admin.', 'twill.'],
+    'routes/twill.php' => ['Route::module', 'TwillRoutes::module'],
+    'routes/twill.php+1' => ['Route::singleton', 'TwillRoutes::singleton'],
 ];
 
 foreach ($arrayRename as $original => $new) {
@@ -22,6 +24,7 @@ foreach ($arrayRename as $original => $new) {
 }
 
 foreach ($arrayRenameInFile as $file => $replace) {
+    $file = explode('+', $file)[0];
     if (file_exists(getcwd() . '/' . $file)) {
         echo "Replacing legacy routes in $file" . PHP_EOL;
         $contents = file_get_contents(getcwd() . '/' . $file);


### PR DESCRIPTION
Follow up of https://github.com/area17/twill/pull/1964 and https://github.com/area17/twill/issues/1961

This removes the macro's and uses the TwillRoutes facade instead.

Additional ideas:

`TwillRoutes::module(\App\Models\Page::class);`

~~Todo: Upgrade path.~~