### PR TITLE
[2.x] Fix block with long dynamic titles

### DIFF
--- a/frontend/js/components/blocks/BlockEditorItem.vue
+++ b/frontend/js/components/blocks/BlockEditorItem.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="block" :class="blockClasses">
-    <div class="block__header" @dblclick.prevent="toggleExpand()">
+    <div class="block__header" @dblclick.prevent="toggleExpand()" ref="header">
       <span v-if="withHandle" class="block__handle"></span>
       <div class="block__toggle">
         <a17-dropdown :ref="moveDropdown" class="f--small" position="bottom-left" v-if="withMoveDropdown" :maxHeight="270">
@@ -10,7 +10,10 @@
           </div>
         </a17-dropdown>
         <span class="block__counter f--tiny" v-else>{{ index + 1 }}</span>
-        <span class="block__title">{{ blockTitle }}</span>
+        <span class="block__title"
+        :style="{
+          'max-width': titleMaxWidth
+        }">{{ blockTitle }}</span>
       </div>
       <div class="block__actions">
         <slot name="block-actions"/>
@@ -77,7 +80,8 @@
         visible: false,
         hover: false,
         withMoveDropdown: true,
-        withAddDropdown: true
+        withAddDropdown: true,
+        titleMaxWidth: null
       }
     },
     filters: a17VueFilters,
@@ -159,7 +163,21 @@
 
         const blockFieldName = this.blockFieldName(fieldName)
         return this.fieldValueByName(blockFieldName)
+      },
+      updateTitleMaxWidth () {
+        if (this.titleFieldValue && this.$refs.header) {
+          this.titleMaxWidth = `calc(${this.$refs.header.offsetWidth * 0.45}px - 5ch)`
+        } else {
+          this.titleMaxWidth = '45%'
+        }
       }
+    },
+    mounted () {
+      this.updateTitleMaxWidth()
+      window.addEventListener('resize', this.updateTitleMaxWidth)
+    },
+    unmounted () {
+      window.removeEventListener('resize', this.updateTitleMaxWidth)
     },
     beforeMount () {
       if (!this.$slots['dropdown-numbers']) this.withMoveDropdown = false

--- a/frontend/js/components/blocks/BlockEditorItem.vue
+++ b/frontend/js/components/blocks/BlockEditorItem.vue
@@ -10,10 +10,12 @@
           </div>
         </a17-dropdown>
         <span class="block__counter f--tiny" v-else>{{ index + 1 }}</span>
-        <span class="block__title"
-        :style="{
-          'max-width': titleMaxWidth
-        }">{{ blockTitle }}</span>
+        <span
+          class="block__title"
+          :style="{
+            'max-width': titleMaxWidth
+          }"
+        >{{ blockTitle }}</span>
       </div>
       <div class="block__actions">
         <slot name="block-actions"/>


### PR DESCRIPTION
<!--
  Thanks for opening a PR! Your contribution is much appreciated.
  Do you have any questions? Check out the contributing docs at https://github.com/area17/twill/blob/2.x/CONTRIBUTING.md, 
  or ask in this Pull Request and a Twill maintainer will be happy to help :)
-->

## Description

Block with long dynamic titles overflow and do not respect max-width "45%" because `text-overflow` only apply with width of `px` values.

## Related Issues

Related to https://github.com/area17/twill/pull/1843

## Before and after

### Before

<img width="1073" alt="Capture d’écran, le 2022-12-06 à 15 11 44" src="https://user-images.githubusercontent.com/6365432/206013426-0d5bfa7f-d87f-400c-94d7-f53b24db5e6a.png">

### After

https://user-images.githubusercontent.com/6365432/206013556-e1959b88-2c59-472c-a0ab-4690b9c95b6a.mp4


