### PR TITLE
[3.x] Set browser sortable to true by default

### DIFF
--- a/src/Services/Forms/Fields/Browser.php
+++ b/src/Services/Forms/Fields/Browser.php
@@ -29,7 +29,7 @@ class Browser extends BaseFormField
 
     protected bool $wide = false;
 
-    protected bool $sortable = false;
+    protected bool $sortable = true;
 
     protected ?string $routePrefix = null;
 


### PR DESCRIPTION
This is to avoid having to use `->sortable()` on the `Browser` form builder field, as it is currently the default behavior in Twill 2.