### PR TITLE
Fix z-index publisher overlay

### DIFF
--- a/frontend/scss/globals/_sticky.scss
+++ b/frontend/scss/globals/_sticky.scss
@@ -38,7 +38,7 @@ Sticky elements default style
 
   /* publisher.vue */
   .publisher {
-    z-index: $zindex__modal;
+    z-index: $zindex__overlay;
 
     &.sticky__fixed,
     &.sticky__fixedTop {

--- a/frontend/scss/setup/_variables.scss
+++ b/frontend/scss/setup/_variables.scss
@@ -61,8 +61,8 @@ $bezier__ease-in-out: cubic-bezier(.5, 0, .5, 0);
 
 $zindex__tooltip:600;
 $zindex__notif:550;
-$zindex__modal:502;
-$zindex__overlay:501;
+$zindex__modal:500;
+$zindex__overlay:400;
 $zindex__user: 301;
 $zindex__search:300;
 $zindex__env:150;


### PR DESCRIPTION
This is fixing the z-index of the publisher overlay. It was displayed above the editor view.
This is reverting recent z-index changes.