### PR TITLE
Added foreign key to email in password_resets table

### DIFF
--- a/migrations/default/2020_02_09_000001_create_twill_default_users_tables.php
+++ b/migrations/default/2020_02_09_000001_create_twill_default_users_tables.php
@@ -31,10 +31,14 @@ class CreateTwillDefaultUsersTables extends Migration
         $twillPasswordResetsTable = config('twill.password_resets_table', 'twill_password_resets');
 
         if (!Schema::hasTable($twillPasswordResetsTable)) {
-            Schema::create($twillPasswordResetsTable, function (Blueprint $table) {
+            Schema::create($twillPasswordResetsTable, function (Blueprint $table) use ($twillUsersTable) {
                 $table->string('email')->index();
                 $table->string('token')->index();
                 $table->timestamp('created_at')->nullable();
+                $table->foreign('email')
+                    ->references('email')->on($twillUsersTable)
+                    ->cascadeOnUpdate()
+                    ->cascadeOnDelete();
             });
         }
     }


### PR DESCRIPTION
<!--
  Thanks for opening a PR! Your contribution is much appreciated.
  Do you have any questions? Check out the contributing docs at https://github.com/area17/twill/blob/2.x/CONTRIBUTING.md, 
  or ask in this Pull Request and a Twill maintainer will be happy to help :)
-->

## Description

<!-- Write a description of the changes introduced by this PR -->
<!-- If this is introducing a new feature, it would be great if you can create a stub for documentation including bullet points for how to use the feature, code snippets, etc. -->

This PR adds a foreign key to email field of twill_password_resets table and allows the password reset token to be deleted when the corresponding user is hard deleted.
This change allows a user deleted before he had set his password, to receive a new token and a new invitation email.

