### PR TITLE
[3.x] Make A17Block to be configurable class

### DIFF
--- a/src/Helpers/BlockRenderer.php
+++ b/src/Helpers/BlockRenderer.php
@@ -97,7 +97,7 @@ class BlockRenderer
         }
 
         // Load the original block if it exists or make a new one then fill it with the data from the request.
-        $block = A17Block::findOrNew($data['id'] ?? null);
+        $block = twillModel('block')::findOrNew($data['id'] ?? null);
         $block->fill(
             [
                 'type' => $type,
@@ -249,7 +249,7 @@ class BlockRenderer
         $class = Block::findFirstWithType($block->type);
 
         /** @var \A17\Twill\Models\Block[] $childBlocks */
-        $childBlocks = A17Block::whereParentId($block->id)->orderBy('position')->get();
+        $childBlocks = twillModel('block')::whereParentId($block->id)->orderBy('position')->get();
 
         $children = [];
 

--- a/src/TwillServiceProvider.php
+++ b/src/TwillServiceProvider.php
@@ -126,7 +126,7 @@ class TwillServiceProvider extends ServiceProvider
             'users' => User::class,
             'media' => Media::class,
             'files' => File::class,
-            'blocks' => Block::class,
+            'blocks' => twillModel('block'),
             'groups' => Group::class,
         ]);
 

--- a/src/TwillServiceProvider.php
+++ b/src/TwillServiceProvider.php
@@ -126,7 +126,7 @@ class TwillServiceProvider extends ServiceProvider
             'users' => User::class,
             'media' => Media::class,
             'files' => File::class,
-            'blocks' => twillModel('block'),
+            'blocks' => Block::class,
             'groups' => Group::class,
         ]);
 

--- a/tests/integration/Repositories/DuplicateTest.php
+++ b/tests/integration/Repositories/DuplicateTest.php
@@ -111,13 +111,13 @@ class DuplicateTest extends TestCase
         $this->assertEquals('English title', $model->title);
         $this->assertCount(1, $model->blocks);
 
-        $this->assertCount(1, Block::get());
+        $this->assertCount(1, twillModel('block')::get());
 
         $duplicate = $module->getRepository()->duplicate($model->id);
 
         $this->assertCount(1, $model->repeaterdata);
         $this->assertCount(1, $duplicate->blocks);
-        $this->assertCount(2, Block::get());
+        $this->assertCount(2, twillModel('block')::get());
 
         $this->assertNotEquals($duplicate->blocks->first()->id, $model->blocks->first()->id);
     }


### PR DESCRIPTION
## Description

Twill should accept A17\Twill\Models\Block to be configurable as mentioned in https://github.com/area17/twill/blob/3.x/config/models.php

## Related Issues

Remake for https://github.com/area17/twill/pull/2016
