### PR TITLE
[3.x] Singleton - Add support of capsule inside the seed method

### DIFF
--- a/src/Http/Controllers/Admin/SingletonModuleController.php
+++ b/src/Http/Controllers/Admin/SingletonModuleController.php
@@ -54,12 +54,20 @@ abstract class SingletonModuleController extends ModuleController
 
     private function seed(): void
     {
-        $seederName = '\\Database\\Seeders\\' . $this->getModelName() . 'Seeder';
-        if (!class_exists($seederName)) {
-            throw new \Exception("$seederName is missing");
+        $seederName = $this->getModelName() . 'Seeder';
+        $seederNamespace = '\\Database\\Seeders\\';
+
+        if (!class_exists($seederNamespace . $seederName)) {
+            $seederNamespace = TwillCapsules::getCapsuleForModel($this->modelName)->getSeedsNamespace() . '\\';
         }
 
-        $seeder = new $seederName();
+        $seederClass = $seederNamespace . $seederName;
+
+        if (!class_exists($seederClass)) {
+            throw new \Exception("$seederClass is missing");
+        }
+
+        $seeder = new $seederClass();
         $seeder->run();
     }
 


### PR DESCRIPTION
## Description

Hello! I am working with a singleton capsule, and I needed to seed automatically if my capsule was not loaded yet, as twill singleton did not support capsule seeders yet, I ended up with an error like `Database\Seeders\{class_name} is missing`.

So I took the opportunity to add the support of capsules directly. Please let me know if anything is missing! 

## Related Issues

Not as far as I know 

---
Cheers ✌🏽 
