### PR TITLE
Fix for VSelect component for using float values

### DIFF
--- a/frontend/js/components/VSelect.vue
+++ b/frontend/js/components/VSelect.vue
@@ -169,8 +169,11 @@
           } else {
             this.value = this.options.find(o => {
               // Try to always compare to the same type. But we only check for a numeric value. Because it can only be
-              // a string or a number for now.
+              // a string or a number (int or float) for now.
               if (typeof o.value === 'number') {
+                if(Number(o.value) === o.value && o.value % 1 !== 0){
+                  return o.value === parseFloat(value)
+                }
                 return o.value === parseInt(value)
               }
               return o.value === String(value)


### PR DESCRIPTION
## Description
Fixed handling for float values in Select component.
Previously, all Number values were handled always as int.
If you used float, the Select field just didn't determine the stored value.
