### PR TITLE
[3.x] Add ability to accepts parameters when using BladePartial directive

### DIFF
--- a/src/Services/Forms/BladePartial.php
+++ b/src/Services/Forms/BladePartial.php
@@ -9,6 +9,7 @@ class BladePartial
 {
     protected function __construct(
         protected ?string $view = null,
+        protected ?array $params = [],
     ) {
     }
 
@@ -17,9 +18,10 @@ class BladePartial
         return new self();
     }
 
-    public function view(string $view): static
+    public function view(string $view, array $params = []): static
     {
         $this->view = $view;
+        $this->params = $params;
 
         return $this;
     }
@@ -30,13 +32,19 @@ class BladePartial
             return null;
         }
 
-        $form = ViewFacade::shared("form");
+        $form = ViewFacade::shared('form');
 
-        return ViewFacade::make($this->view, [
-            'item' => $form['item'] ?? null,
-            'form_fields' => $form['form_fields'] ?? [],
-            'formModuleName' => $form['moduleName'] ?? null,
-            'routePrefix' => $form['routePrefix'] ?? null,
-        ]);
+        return ViewFacade::make(
+            $this->view,
+            array_merge(
+            $this->params,
+            [
+                'item' => $form['item'] ?? null,
+                'form_fields' => $form['form_fields'] ?? [],
+                'formModuleName' => $form['moduleName'] ?? null,
+                'routePrefix' => $form['routePrefix'] ?? null,
+            ]
+        )
+        );
     }
 }

--- a/src/Services/Forms/BladePartial.php
+++ b/src/Services/Forms/BladePartial.php
@@ -18,9 +18,15 @@ class BladePartial
         return new self();
     }
 
-    public function view(string $view, array $params = []): static
+    public function view(string $view): static
     {
         $this->view = $view;
+
+        return $this;
+    }
+
+    public function withAdditionalParams(array $params = []): static
+    {
         $this->params = $params;
 
         return $this;

--- a/src/Services/Forms/BladePartial.php
+++ b/src/Services/Forms/BladePartial.php
@@ -37,14 +37,14 @@ class BladePartial
         return ViewFacade::make(
             $this->view,
             array_merge(
-            $this->params,
-            [
-                'item' => $form['item'] ?? null,
-                'form_fields' => $form['form_fields'] ?? [],
-                'formModuleName' => $form['moduleName'] ?? null,
-                'routePrefix' => $form['routePrefix'] ?? null,
-            ]
-        )
+                [
+                    'item' => $form['item'] ?? null,
+                    'form_fields' => $form['form_fields'] ?? [],
+                    'formModuleName' => $form['moduleName'] ?? null,
+                    'routePrefix' => $form['routePrefix'] ?? null,
+                ],
+                $this->params
+            )
         );
     }
 }


### PR DESCRIPTION
Add ability to accepts parameters when using the FormBuilder to include blade partials.

## Description

Right now we have the ability to use BladePartial in the FormBuilder for including view, but it is lacking the ability to send parameters/options to those views.
This pull requests aims to solve that situation.

## Example

With this PR we'll be able to do:
```php
use A17\Twill\Services\Forms\BladePartial;

...

    BladePartial::make()
        ->view('twill.shared.link', [
           'field_prefix' => 'recirculation',
           'label_note' => 'Optional. Page title will be used if empty.',
        ])
```