### PR TITLE
Fix searchColumns overriding

### DIFF
--- a/src/Http/Controllers/Admin/ModuleController.php
+++ b/src/Http/Controllers/Admin/ModuleController.php
@@ -398,7 +398,7 @@ abstract class ModuleController extends Controller
             $this->getSideFieldsets($this->repository->getBaseModel())->registerDynamicRepeaters();
         }
 
-        $this->searchColumns = [$this->titleColumnKey];
+        $this->searchColumns = array_merge([$this->titleColumnKey], $this->searchColumns);
     }
 
     /**


### PR DESCRIPTION
Assigning `$this->searchColumns = [$this->titleColumnKey];` (https://github.com/area17/twill/blob/3.x/src/Http/Controllers/Admin/ModuleController.php#L401) immediately overwrites `$this->searchColumns` from call `$this->setUpController();` several lines before.
This simple patch fixes this and merges `$this->titleColumnKey` with the previously seted up `$this->searchColumns`.