### PR TITLE
[3.x] Fix blocks related browser clearing

### DIFF
--- a/examples/tests-browsers/app/Repositories/BookRepository.php
+++ b/examples/tests-browsers/app/Repositories/BookRepository.php
@@ -10,7 +10,7 @@ class BookRepository extends ModuleRepository
 {
     use HandleRevisions;
 
-    protected $relatedBrowsers = ['writers'];
+    protected $relatedBrowsers = ['writers', 'books'];
 
     public function __construct(Book $model)
     {

--- a/examples/tests-browsers/resources/views/twill/books/books-form.blade.php
+++ b/examples/tests-browsers/resources/views/twill/books/books-form.blade.php
@@ -13,4 +13,11 @@
         label="Writer"
         :max="4"
     />
+
+    <x-twill::browser
+      module-name="books"
+      name="book"
+      label="Book"
+      :max="4"
+    />
 @stop

--- a/src/Repositories/BlockRepository.php
+++ b/src/Repositories/BlockRepository.php
@@ -62,12 +62,12 @@ class BlockRepository extends ModuleRepository
     public function afterSave(TwillModelContract $model, array $fields): void
     {
         if (Schema::hasTable(config('twill.related_table', 'twill_related'))) {
+            $model->clearAllRelated();
+
             if (isset($fields['browsers'])) {
                 Collection::make($fields['browsers'])->each(function ($items, $browserName) use ($model) {
                     $model->saveRelated($items, $browserName);
                 });
-            } else {
-                $model->clearAllRelated();
             }
         }
 

--- a/tests/integration/Blocks/BlockBrowsersTest.php
+++ b/tests/integration/Blocks/BlockBrowsersTest.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace integration\Blocks;
+
+use A17\Twill\Facades\TwillBlocks;
+use A17\Twill\Services\Forms\Fields\BlockEditor;
+use A17\Twill\Services\Forms\Fields\Browser;
+use A17\Twill\Services\Forms\Form;
+use A17\Twill\Tests\Integration\Anonymous\AnonymousModule;
+use A17\Twill\Tests\Integration\TestCase;
+use A17\Twill\View\Components\Blocks\TwillBlockComponent;
+use App\Models\Book;
+use App\Models\Writer;
+use App\Repositories\BookRepository;
+use App\Repositories\WriterRepository;
+
+class BlockBrowsersTest extends TestCase
+{
+    public ?string $example = 'tests-browsers';
+
+    public function testBrowsersAreClearedWhenPostingSingle(): void
+    {
+        $module = AnonymousModule::make('blockbrowserstests', $this->app)
+            ->withFormFields(Form::make([
+                BlockEditor::make()
+            ]))
+            ->boot();
+
+        $block = new class extends TwillBlockComponent {
+            public static function getBlockIdentifier(): string
+            {
+                return 'test-block-browsers';
+            }
+
+            public function getForm(): Form
+            {
+                return Form::make([
+                    Browser::make()
+                        ->name('books')
+                        ->modules([Book::class]),
+                    Browser::make()
+                        ->name('writers')
+                        ->modules([Writer::class])
+                ]);
+            }
+
+            public function render(): string
+            {
+                return 'hello world!';
+            }
+        };
+
+
+        TwillBlocks::registerManualBlock($block::class);
+
+        $book = app(BookRepository::class)->create([
+            'title' => 'book title',
+            'published' => true,
+        ]);
+
+        $writer = app(WriterRepository::class)->create([
+            'title' => 'writer title',
+            'published' => true,
+        ]);
+
+        $blocks = [
+            'blocks' => [
+                [
+                    'browsers' => [
+                        'writers' => [
+                            [
+                                'id' => $writer->id,
+                                'endpointType' => '\\App\\Models\\Writer',
+                            ]
+                        ],
+                        'books' => [
+                            [
+                                'id' => $book->id,
+                                'endpointType' => '\\App\\Models\\Book',
+                            ]
+                        ]
+                    ],
+                    'medias' => [],
+                    'blocks' => [],
+                    'type' => 'a17-block-test-block-browsers',
+                    'content' => [],
+                    'id' => time(),
+                ],
+            ],
+        ];
+
+        $entity = $module->getRepository()->create([
+            'title' => 'Hello world',
+            'published' => true,
+        ]);
+
+        $update = $module->getRepository()->update($entity->id, $blocks)->refresh();
+
+        $block = $update->blocks->first();
+
+        $this->assertCount(1, $update->blocks);
+        $this->assertCount(2, $block->relatedItems()->get());
+        $this->assertEquals('writer title', $block->getRelated('writers')->first()->title);
+        $this->assertEquals('book title', $block->getRelated('books')->first()->title);
+
+        $blocks = [
+            'blocks' => [
+                [
+                    'browsers' => [
+                        'books' => [
+                            [
+                                'id' => $book->id,
+                                'endpointType' => '\\App\\Models\\Book',
+                            ]
+                        ]
+                    ],
+                    'medias' => [],
+                    'blocks' => [],
+                    'type' => 'a17-block-test-block-browsers',
+                    'content' => [],
+                    'id' => $block->id,
+                ],
+            ],
+        ];
+
+        $update = $module->getRepository()->update($entity->id, $blocks)->refresh();
+
+        $block = $update->blocks->first();
+
+        $this->assertCount(1, $update->blocks);
+        $this->assertCount(1, $block->relatedItems()->get());
+        $this->assertEmpty($block->getRelated('writers'));
+        $this->assertEquals('book title', $block->getRelated('books')->first()->title);
+    }
+}

--- a/tests/integration/Blocks/BlockBrowsersTest.php
+++ b/tests/integration/Blocks/BlockBrowsersTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace integration\Blocks;
+namespace A17\Twill\Tests\Integration\Blocks;
 
 use A17\Twill\Facades\TwillBlocks;
 use A17\Twill\Services\Forms\Fields\BlockEditor;

--- a/tests/integration/Blocks/BlockChildrenTest.php
+++ b/tests/integration/Blocks/BlockChildrenTest.php
@@ -1,9 +1,10 @@
 <?php
 
-namespace A17\Twill\Tests\Integration;
+namespace integration\Blocks;
 
 use A17\Twill\Repositories\ModuleRepository;
 use A17\Twill\Tests\Integration\Anonymous\AnonymousModule;
+use A17\Twill\Tests\Integration\TestCase;
 
 class BlockChildrenTest extends TestCase
 {

--- a/tests/integration/Blocks/BlockChildrenTest.php
+++ b/tests/integration/Blocks/BlockChildrenTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace integration\Blocks;
+namespace A17\Twill\Tests\Integration\Blocks;
 
 use A17\Twill\Repositories\ModuleRepository;
 use A17\Twill\Tests\Integration\Anonymous\AnonymousModule;

--- a/tests/integration/BrowsersTest.php
+++ b/tests/integration/BrowsersTest.php
@@ -11,6 +11,7 @@ use App\Repositories\BookRepository;
 use App\Repositories\LetterRepository;
 use App\Repositories\WriterRepository;
 use A17\Twill\Models\RelatedItem;
+use Illuminate\Support\Collection;
 
 class BrowsersTest extends TestCase
 {
@@ -23,7 +24,7 @@ class BrowsersTest extends TestCase
         $this->login();
     }
 
-    public function createWriters()
+    public function createWriters(): Collection
     {
         $this->assertEquals(0, Writer::count());
 
@@ -39,7 +40,7 @@ class BrowsersTest extends TestCase
         return $writers;
     }
 
-    public function createLetter()
+    public function createLetter(): Letter
     {
         $item = app(LetterRepository::class)->create([
             'title' => 'Lorem ipsum dolor sit amet',
@@ -51,7 +52,7 @@ class BrowsersTest extends TestCase
         return $item;
     }
 
-    public function createLetterWithWriters($writers)
+    public function createLetterWithWriters($writers): Letter
     {
         $item = $this->createLetter();
 
@@ -66,7 +67,7 @@ class BrowsersTest extends TestCase
         return $item;
     }
 
-    public function createBio()
+    public function createBio(): Bio
     {
         $item = app(BioRepository::class)->create([
             'title' => 'Lorem ipsum dolor sit amet',
@@ -78,7 +79,7 @@ class BrowsersTest extends TestCase
         return $item;
     }
 
-    public function createBioWithWriter($writer)
+    public function createBioWithWriter($writer): Bio
     {
         $item = $this->createBio();
 
@@ -93,7 +94,7 @@ class BrowsersTest extends TestCase
         return $item;
     }
 
-    public function createWriterWithbios()
+    public function createWriterWithbios(): Writer
     {
         $writers = $this->createWriters();
 
@@ -117,7 +118,7 @@ class BrowsersTest extends TestCase
         return $writers[0]->refresh();
     }
 
-    public function createBook()
+    public function createBook(): Book
     {
         $item = app(BookRepository::class)->create([
             'title' => 'Lorem ipsum dolor sit amet',
@@ -129,7 +130,7 @@ class BrowsersTest extends TestCase
         return $item;
     }
 
-    public function createBookWithWriters($writers)
+    public function createBookWithWriters($writers): Book
     {
         $item = $this->createBook();
 
@@ -146,14 +147,7 @@ class BrowsersTest extends TestCase
         return $item;
     }
 
-    // FIXME — this is needed for the new admin routes to take effect in the next test,
-    // because files are copied in `setUp()` after the app is initialized.
-    public function testDummy()
-    {
-        $this->assertTrue(true);
-    }
-
-    public function testBrowserBelongsToMany()
+    public function testBrowserBelongsToMany(): void
     {
         $writers = $this->createWriters();
         $letter = $this->createLetterWithWriters($writers);
@@ -166,7 +160,7 @@ class BrowsersTest extends TestCase
         );
     }
 
-    public function testBrowserBelongsToManyPreview()
+    public function testBrowserBelongsToManyPreview(): void
     {
         $writers = $this->createWriters();
         $letter = $this->createLetterWithWriters($writers);
@@ -176,7 +170,7 @@ class BrowsersTest extends TestCase
         $this->assertSee('This is an letter');
     }
 
-    public function testBrowserBelongsToManyPreviewRevisions()
+    public function testBrowserBelongsToManyPreviewRevisions(): void
     {
         $writers = $this->createWriters();
         $letter = $this->createLetterWithWriters($writers);
@@ -188,7 +182,7 @@ class BrowsersTest extends TestCase
         $this->assertSee('This is an letter');
     }
 
-    public function testBrowserBelongsToManyRestoreRevisions()
+    public function testBrowserBelongsToManyRestoreRevisions(): void
     {
         $writers = $this->createWriters();
         $letter = $this->createLetterWithWriters($writers);
@@ -200,7 +194,7 @@ class BrowsersTest extends TestCase
         $this->assertSee('You are currently editing an older revision of this content');
     }
 
-    public function testBrowserBelongsTo()
+    public function testBrowserBelongsTo(): void
     {
         $writers = $this->createWriters();
         $bio = $this->createBioWithWriter($writers[0]);
@@ -210,7 +204,7 @@ class BrowsersTest extends TestCase
         $this->assertEquals($writers[0]->id, Bio::first()->writer->id);
     }
 
-    public function testBrowserBelongsToPreview()
+    public function testBrowserBelongsToPreview(): void
     {
         $writers = $this->createWriters();
         $bio = $this->createBioWithWriter($writers[0]);
@@ -232,7 +226,7 @@ class BrowsersTest extends TestCase
         $this->assertSee('Writer: Charlie');
     }
 
-    public function testBrowserBelongsToPreviewRevisions()
+    public function testBrowserBelongsToPreviewRevisions(): void
     {
         $writers = $this->createWriters();
         $bio = $this->createBioWithWriter($writers[0]);
@@ -245,7 +239,7 @@ class BrowsersTest extends TestCase
         $this->assertSee('No writer');
     }
 
-    public function testBrowserBelongsToRestoreRevisions()
+    public function testBrowserBelongsToRestoreRevisions(): void
     {
         $writers = $this->createWriters();
         $bio = $this->createBioWithWriter($writers[0]);
@@ -257,7 +251,7 @@ class BrowsersTest extends TestCase
         $this->assertSee('You are currently editing an older revision of this content');
     }
 
-    public function testBrowserRelated()
+    public function testBrowserRelated(): void
     {
         $writers = $this->createWriters();
         $book = $this->createBookWithWriters($writers);
@@ -271,7 +265,7 @@ class BrowsersTest extends TestCase
         );
     }
 
-    public function testBrowserRelatedPreview()
+    public function testBrowserRelatedPreview(): void
     {
         $writers = $this->createWriters();
         $book = $this->createBookWithWriters($writers);
@@ -293,7 +287,7 @@ class BrowsersTest extends TestCase
         $this->assertSee('Writers: Charlie');
     }
 
-    public function testBrowserRelatedPreviewRevisions()
+    public function testBrowserRelatedPreviewRevisions(): void
     {
         $writers = $this->createWriters();
         $book = $this->createBookWithWriters($writers);
@@ -306,7 +300,7 @@ class BrowsersTest extends TestCase
         $this->assertSee('No writers');
     }
 
-    public function testBrowserRelatedRestoreRevisions()
+    public function testBrowserRelatedRestoreRevisions(): void
     {
         $writers = $this->createWriters();
         $book = $this->createBookWithWriters($writers);
@@ -318,7 +312,7 @@ class BrowsersTest extends TestCase
         $this->assertSee('You are currently editing an older revision of this content');
     }
 
-    public function testBrowserHasMany()
+    public function testBrowserHasMany(): void
     {
         $writer = $this->createWriterWithBios();
 
@@ -330,7 +324,7 @@ class BrowsersTest extends TestCase
         });
     }
 
-    public function testBrowserHasManyPreview()
+    public function testBrowserHasManyPreview(): void
     {
         $writer = $this->createWriterWithBios();
 
@@ -351,7 +345,7 @@ class BrowsersTest extends TestCase
         $this->assertSee('Bios: Biography 2');
     }
 
-    public function testBrowserHasManyPreviewRevisions()
+    public function testBrowserHasManyPreviewRevisions(): void
     {
         $writer = $this->createWriterWithBios();
 
@@ -363,7 +357,7 @@ class BrowsersTest extends TestCase
         $this->assertSee('No bios');
     }
 
-    public function testBrowserHasManyRestoreRevisions()
+    public function testBrowserHasManyRestoreRevisions(): void
     {
         $writer = $this->createWriterWithBios();
 
@@ -372,5 +366,51 @@ class BrowsersTest extends TestCase
             'revisionId' => $writer->revisions->last()->id,
         ]);
         $this->assertSee('You are currently editing an older revision of this content');
+    }
+
+    public function testBrowserAreClearedWhenOnlyOneIsEmpty(): void
+    {
+        $writer = $this->createWriters()->first();
+        $book = $this->createBook();
+
+        /** @var Book $parentBook */
+        $parentBook = app(BookRepository::class)->create([
+            'title' => 'Lorem ipsum dolor sit amet',
+            'published' => true,
+        ]);
+        $this->assertCount(0, $parentBook->relatedItems()->get());
+
+        $this->httpRequestAssert("/twill/books/{$parentBook->id}", 'PUT', [
+            'browsers' => [
+                'writers' => [
+                    [
+                        'id' => $writer->id,
+                        'endpointType' => '\\App\\Models\\Writer',
+                    ]
+                ],
+                'books' => [
+                    [
+                        'id' => $book->id,
+                        'endpointType' => '\\App\\Models\\Book',
+                    ]
+                ]
+            ],
+        ]);
+
+        $this->assertCount(2, $parentBook->relatedItems()->get());
+
+        $this->httpRequestAssert("/twill/books/{$parentBook->id}", 'PUT', [
+            'browsers' => [
+                'writers' => [
+                    [
+                        'id' => $writer->id,
+                        'endpointType' => '\\App\\Models\\Writer',
+                    ]
+                ],
+            ],
+        ]);
+
+        $this->assertCount(1, $parentBook->relatedItems()->get());
+        $this->assertEquals($writer->id, $parentBook->relatedItems()->get()->first()->related_id);
     }
 }


### PR DESCRIPTION
When using multiple browser fields in a block, empty browsers wouldn't be cleared from the `related` table if other browsers in the block were not also empty.

This bug is also on Twill 2.