### PR TITLE
[3.x] Fix password resets constraint down migration

### DIFF
--- a/migrations/default/2023_01_17_111835_add_cascade_on_delete_to_password_resets.php
+++ b/migrations/default/2023_01_17_111835_add_cascade_on_delete_to_password_resets.php
@@ -22,7 +22,7 @@ return new class extends Migration {
     {
         $twillPasswordResetsTable = config('twill.password_resets_table', 'twill_password_resets');
         Schema::table($twillPasswordResetsTable, function (Blueprint $table) {
-            $table->dropForeign('email');
+            $table->dropForeign(['email']);
         });
     }
 };

--- a/src/Http/Controllers/Admin/ModuleController.php
+++ b/src/Http/Controllers/Admin/ModuleController.php
@@ -1124,7 +1124,7 @@ abstract class ModuleController extends Controller
 
         return [
             $item,
-            $id
+            $id,
         ];
     }
 


### PR DESCRIPTION
In a test suite that uses `use DatabaseMigrations;`, the down method of this migration was failing with:

```
PDOException: SQLSTATE[42704]: Undefined object: 7 ERROR:  constraint "email" of relation "twill_password_resets" does not exist
```