### PR TITLE
Minor docs style fixes

### DIFF
--- a/docs/_templates/components/alert.blade.php
+++ b/docs/_templates/components/alert.blade.php
@@ -2,24 +2,24 @@
 @if ($type === 'tip')
     <div class="bg-purple-light p-30 rounded-[4px] mt-30">
         @if($title != null)
-            <h4 class="text-purple f-h4 font-bold mt-0">{{$title}}</h4>
+            <h4 class="text-purple f-h4 font-bold !mt-0 uppercase">{{$title}}</h4>
         @else
-            <h4 class="text-purple f-h4 font-bold mt-0">Tip</h4>
+            <h4 class="text-purple f-h4 font-bold !mt-0 uppercase">Tip</h4>
         @endif
         <div class="ml-3">
-            <p class="text-sm font-medium text-green-800">{{$slot}}</p>
+            {{$slot}}
         </div>
     </div>
 @elseif($type === 'warning')
     <div class="bg-yellow-light p-30 rounded-[4px] mt-30">
 
         @if($title != null)
-            <h4 class="text-yellow f-h4 font-bold mt-0">{{$title}}</h4>
+            <h4 class="text-yellow f-h4 font-bold !mt-0 uppercase">{{$title}}</h4>
         @else
-            <h4 class="text-yellow f-h4 font-bold mt-0">Warning</h4>
+            <h4 class="text-yellow f-h4 font-bold !mt-0 uppercase">Warning</h4>
         @endif
-        <div class="ml-3">
-            <p class="text-sm font-medium text-yellow-800">{{$slot}}</p>
+        <div class="ml-3 text-sm font-medium">
+            {{$slot}}
         </div>
 
     </div>
@@ -27,20 +27,19 @@
     <div class="rounded-md bg-blue-50 p-4">
         <div class="flex">
             <div class="ml-3">
-                <p class="text-sm font-medium text-blue-800">{{$slot}}</p>
+                {{$slot}}
             </div>
         </div>
     </div>
 @elseif($type === 'danger')
     <div class="bg-red-light p-30 rounded-[4px] mt-30">
         @if($title != null)
-            <h4 class="text-red f-h4 font-bold mt-0">{{$title}}</h4>
+            <h4 class="text-red f-h4 font-bold !mt-0 uppercase">{{$title}}</h4>
         @else
-            <h4 class="text-red f-h4 font-bold mt-0">Danger</h4>
+            <h4 class="text-red f-h4 font-bold !mt-0 uppercase">Danger</h4>
         @endif
-        <div class="ml-3">
-            <p class="text-sm font-medium text-red-800">{{$slot}}</p>
+        <div class="ml-3 text-sm font-medium">
+            {{$slot}}
         </div>
-
     </div>
 @endif

--- a/docs/_templates/css/chaptersNav.css
+++ b/docs/_templates/css/chaptersNav.css
@@ -11,11 +11,6 @@
     margin-top: 0;
   }
 
-  .chapters-nav ul {
-    border: 1px solid var(--grey);
-    padding: 16px;
-  }
-
   .chapters-nav a {
     @apply no-underline f-body-2 font-medium;
     text-decoration: none !important;
@@ -47,6 +42,7 @@
     margin-top: 16px;
   }
 
+  .chapters-nav ul ul,
   .chapters-nav-fixed ul ul {
     margin-top: 8px;
     padding-left: 16px;

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "format": "prettier --write *.js .*.{js,yml} 'frontend/**/*.{js,vue,scss}'",
     "lint": "vue-cli-service lint frontend",
     "prod": "npm run build",
-    "clean-customs": "rm -rf frontend/js/components/blocks/customs/* && rm -rf frontend/js/components/customs/* && touch frontend/js/components/customs/.keep"
+    "clean-customs": "rm -rf frontend/js/components/blocks/customs/* && rm -rf frontend/js/components/customs/* && touch frontend/js/components/customs/.keep",
+    "docs": "rm -rf docs/_build/* && ./vendor/bin/testbench twill:staticdocs:serve"
   },
   "dependencies": {
     "@alpinejs/mask": "^3.10.0",


### PR DESCRIPTION

## Description

- Fixing errant border on chapters nav at smaller sizes
- Adding a script to the `package.json` to allow for quick docs serving
- Fixing `alert.blade.php` title case to be inline with current docs
- Removing issue which was causing an empty `<p>` at end of `alert.blade.php`

Screenshots:

**Border issue:**

![Screen Shot 2023-01-24 at 12 05 27 PM](https://user-images.githubusercontent.com/2029565/214360083-410695db-43d6-45d0-98db-0de4881cb92e.png)

**Border fix:**
![Screen Shot 2023-01-24 at 12 06 36 PM](https://user-images.githubusercontent.com/2029565/214360141-667341c5-0221-4d52-9952-6d7d2e20104b.png)

**Alert issue:**
![Screen Shot 2023-01-24 at 12 08 06 PM](https://user-images.githubusercontent.com/2029565/214360300-8b3c0e4b-895d-4f30-8816-38a0d3b9be95.png)

**Alert fix:**
![Screen Shot 2023-01-24 at 12 08 21 PM](https://user-images.githubusercontent.com/2029565/214360358-8d820b37-0a4a-4dda-bfeb-a8b2aae20af7.png)


