### PR TITLE
[3.x] Cleanup password resets table before applying constraint

### DIFF
--- a/migrations/default/2023_01_17_111835_add_cascade_on_delete_to_password_resets.php
+++ b/migrations/default/2023_01_17_111835_add_cascade_on_delete_to_password_resets.php
@@ -3,12 +3,18 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
 
 return new class extends Migration {
     public function up(): void
     {
         $twillPasswordResetsTable = config('twill.password_resets_table', 'twill_password_resets');
         $twillUsersTable = config('twill.users_table', 'twill_users');
+        
+        // remove stale password reset rows
+        DB::table($twillPasswordResetsTable)->whereNotIn('email', 
+            DB::table($twillUsersTable)->select('email')->distinct()->pluck('email')->toArray()
+        )->delete();
 
         Schema::table($twillPasswordResetsTable, function (Blueprint $table) use ($twillUsersTable) {
             $table->foreign('email')


### PR DESCRIPTION
On an environment with stale rows in the password resets table, the following error was happening:

```
[dev] INFO  Running migrations.
[dev] 2023_01_17_111835_add_cascade_on_delete_to_password_resets ....... 82ms FAIL
[dev] In Connection.php line 760:
[dev] SQLSTATE[23503]: Foreign key violation: 7 ERROR:  insert or update on table
[dev] "twill_password_resets" violates foreign key constraint "twill_password_re
[dev] sets_email_foreign"
[dev] DETAIL:  Key (email)=(email@example.com) is not present in table "twill_user
[dev] s". (SQL: alter table "twill_password_resets" add constraint "twill_passwor
[dev] d_resets_email_foreign" foreign key ("email") references "twill_users" ("em
[dev] ail") on delete cascade on update cascade)
```