### PR TITLE
Added option to also run db migrations when running twill:update command

### DIFF
--- a/src/Commands/Update.php
+++ b/src/Commands/Update.php
@@ -21,7 +21,7 @@ class Update extends Command
         $this->call('view:clear');
         if($this->option('migrate')
             || $this->confirm('Do you want to run any pending database migrations now?')) {
-            $this->call('migrate');``
+            $this->call('migrate');
         }
     }
 

--- a/src/Commands/Update.php
+++ b/src/Commands/Update.php
@@ -6,8 +6,8 @@ use Illuminate\Filesystem\Filesystem;
 
 class Update extends Command
 {
-    protected $signature = 'twill:update {--fromBuild}';
-    protected $description = 'Publish new updated Twill assets';
+    protected $signature = 'twill:update {--fromBuild} {--migrate}';
+    protected $description = 'Publish new updated Twill assets and optionally run database migrations';
 
     public function __construct(public Filesystem $files)
     {
@@ -19,6 +19,10 @@ class Update extends Command
         $this->publishAssets();
         $this->call('twill:flush-manifest');
         $this->call('view:clear');
+        if($this->option('migrate')
+            || $this->confirm('Do you want to run any pending database migrations now?')) {
+            $this->call('migrate');``
+        }
     }
 
     /**

--- a/src/Commands/Update.php
+++ b/src/Commands/Update.php
@@ -19,8 +19,7 @@ class Update extends Command
         $this->publishAssets();
         $this->call('twill:flush-manifest');
         $this->call('view:clear');
-        if($this->option('migrate')
-            || $this->confirm('Do you want to run any pending database migrations now?')) {
+        if ($this->option('migrate') || $this->confirm('Do you want to run any pending database migrations now?')) {
             $this->call('migrate');
         }
     }

--- a/tests/Browser/CapsuleSingletonTest.php
+++ b/tests/Browser/CapsuleSingletonTest.php
@@ -10,7 +10,8 @@ class CapsuleSingletonTest extends BrowserTestCase
 
     public function testCapsuleAutoSeeds(): void
     {
-        $this->artisan('twill:update');
+        $this->artisan('twill:update')
+            ->expectsConfirmation('Do you want to run any pending database migrations now?', 'no');
         $this->browse(function (Browser $browser) {
             $browser->loginAs($this->superAdmin, 'twill_users');
             $browser->visitTwill();

--- a/tests/Browser/CustomComponentTest.php
+++ b/tests/Browser/CustomComponentTest.php
@@ -57,7 +57,8 @@ class CustomComponentTest extends BrowserTestCase
 
         $this->assertFileExists($path . DIRECTORY_SEPARATOR . 'HelloWorld.vue');
 
-        $this->artisan('twill:build', ['--install' => false, '--customComponentsSource' => $path]);
+        $this->artisan('twill:build', ['--install' => false, '--customComponentsSource' => $path])
+            ->expectsConfirmation('Do you want to run any pending database migrations now?', 'no');
 
         $this->browse(function (Browser $browser) {
             $browser->loginAs($this->superAdmin, 'twill_users');

--- a/tests/Browser/CustomComponentTest.php
+++ b/tests/Browser/CustomComponentTest.php
@@ -33,7 +33,8 @@ class CustomComponentTest extends BrowserTestCase
 
     public function testBeforeBuild(): void
     {
-        $this->artisan('twill:update');
+        $this->artisan('twill:update')
+            ->expectsConfirmation('Do you want to run any pending database migrations now?', 'no');
         $this->browse(function (Browser $browser) {
             $browser->loginAs($this->superAdmin, 'twill_users');
 

--- a/tests/integration/Commands/UpdateTest.php
+++ b/tests/integration/Commands/UpdateTest.php
@@ -8,6 +8,18 @@ class UpdateTest extends TestCase
 {
     public function testCanExecuteUpdateCommand()
     {
-        $this->assertExitCodeIsGood($this->artisan('twill:update')->run());
+        $this->assertExitCodeIsGood(
+            $this->artisan('twill:update')
+                ->expectsConfirmation('Do you want to run any pending database migrations now?', 'no')
+                ->run()
+        );
+    }
+
+    public function testCanExecuteUpdateWithMigrationCommand()
+    {
+        $this->assertExitCodeIsGood(
+            $this->artisan('twill:update --migrate')
+                ->run()
+        );
     }
 }

--- a/tests/integration/Commands/UpdateTest.php
+++ b/tests/integration/Commands/UpdateTest.php
@@ -15,7 +15,7 @@ class UpdateTest extends TestCase
         );
     }
 
-    public function testCanExecuteUpdateWithMigrationCommand()
+    public function testCanExecuteUpdateWithMigrationOptionCommand()
     {
         $this->assertExitCodeIsGood(
             $this->artisan('twill:update --migrate')


### PR DESCRIPTION
## Description

This PR adds an option to also run database migrations when running twill:update command.

There is a new option {--migrate} and also a Yes/No prompt.

```
php artisan twill:update --migrate
```

OR
```
php artisan twill:update

   INFO  Publishing [assets] assets.

  Copying directory [/xxx/twill-assets] to [public] ............................. DONE

Twill manifest was flushed from cache.
   INFO  Compiled views cleared successfully.

 Do you want to run any pending database migrations now? (yes/no) [no]:
 > yes

   INFO  Nothing to migrate.
```

## Related Issues

No related issues.
