### PR TITLE
Allow disabling automatic navigation on a Capsule package

### DIFF
--- a/src/Helpers/Capsule.php
+++ b/src/Helpers/Capsule.php
@@ -50,13 +50,19 @@ class Capsule
      */
     private $namespace;
 
+    /**
+     * @var bool
+     */
+    protected $automaticNavigation = true;
+
     public function __construct(
         string $name,
         string $namespace,
         string $path,
         string $singular = null,
         bool $enabled = true,
-        bool $packageCapsule = false
+        bool $packageCapsule = false,
+        bool $automaticNavigation = true
     ) {
         $this->name = $name;
         $this->path = $path;
@@ -64,6 +70,7 @@ class Capsule
         $this->namespace = $namespace;
         $this->singular = $singular;
         $this->packageCapsule = $packageCapsule;
+        $this->automaticNavigation = $automaticNavigation;
 
         $this->boot();
     }
@@ -339,6 +346,10 @@ class Capsule
 
     public function registerConfig(): void
     {
+        if (!$this->automaticNavigation) {
+            return;
+        }
+
         $config = Config::get('twill-navigation', []);
 
         if ($this->isSingleton()) {

--- a/src/TwillCapsules.php
+++ b/src/TwillCapsules.php
@@ -19,9 +19,10 @@ class TwillCapsules
         string $namespace,
         string $path,
         string $singular = null,
-        bool $enabled = true
+        bool $enabled = true,
+        bool $automaticNavigation = true
     ): Capsule {
-        $capsule = new Capsule($name, $namespace, $path, $singular, $enabled, true);
+        $capsule = new Capsule($name, $namespace, $path, $singular, $enabled, true, $automaticNavigation);
 
         $this->registerCapsule($capsule);
 


### PR DESCRIPTION
Currently the Capsule package injects itself automatically into the main navigation, this is not desirable on larger apps with lots of menu options.