### PR TITLE
Allow configuring crops from block components.

### DIFF
--- a/docs/content/1_documentation/5_block-editor/02_creating-a-block-editor.md
+++ b/docs/content/1_documentation/5_block-editor/02_creating-a-block-editor.md
@@ -100,6 +100,31 @@ public static function getBlockIcon(): string
 }
 ```
 
+#### Crops
+
+Usually we would define image crop's in the block_editor config, but with block components you can define
+them inline in your component like this:
+
+```php
+public static function getCrops(): array
+{
+    return [
+        'content_image' => [
+            'default' => [
+                [
+                    'name' => 'default',
+                    'ratio' => 16 / 9,
+                    'minValues' => [
+                        'width' => 100,
+                        'height' => 100,
+                    ],
+                ],
+            ]
+        ]
+    ];
+}
+```
+
 #### Validation
 
 As with default blocks, you can also [validate](./08_validating-blocks.md) fields:

--- a/src/Commands/RefreshCrops.php
+++ b/src/Commands/RefreshCrops.php
@@ -2,6 +2,7 @@
 
 namespace A17\Twill\Commands;
 
+use A17\Twill\Facades\TwillBlocks;
 use A17\Twill\Models\Media;
 use Carbon\Carbon;
 use Illuminate\Database\DatabaseManager;
@@ -107,7 +108,7 @@ class RefreshCrops extends Command
 
         $mediasParams = app($this->modelName)->getMediasParams();
         if (empty($mediasParams)) {
-            $mediasParams = config('twill.block_editor.crops');
+            $mediasParams = TwillBlocks::getAllCropConfigs();
         }
 
         if (! isset($mediasParams[$this->roleName])) {

--- a/src/Helpers/BlockRenderer.php
+++ b/src/Helpers/BlockRenderer.php
@@ -2,6 +2,7 @@
 
 namespace A17\Twill\Helpers;
 
+use A17\Twill\Facades\TwillBlocks;
 use A17\Twill\Models\Behaviors\HasBlocks;
 use A17\Twill\Models\Block as A17Block;
 use A17\Twill\Models\Contracts\TwillModelContract;
@@ -194,7 +195,7 @@ class BlockRenderer
 
                 $locale = $locale ?? config('app.locale');
 
-                $crops = config('twill.block_editor.crops');
+                $crops = TwillBlocks::getAllCropConfigs();
 
                 if (array_key_exists($role, $crops)) {
                     Collection::make($mediasForRole)->each(function ($media) use (&$medias, $role, $locale) {

--- a/src/Repositories/Behaviors/HandleMedias.php
+++ b/src/Repositories/Behaviors/HandleMedias.php
@@ -2,6 +2,7 @@
 
 namespace A17\Twill\Repositories\Behaviors;
 
+use A17\Twill\Facades\TwillBlocks;
 use A17\Twill\Models\Contracts\TwillModelContract;
 use A17\Twill\Models\Media;
 use Illuminate\Support\Arr;
@@ -80,7 +81,7 @@ trait HandleMedias
 
                 if (
                     array_key_exists($role, $this->model->getMediasParams())
-                    || array_key_exists($role, config('twill.block_editor.crops', []))
+                    || array_key_exists($role, TwillBlocks::getAllCropConfigs())
                     || array_key_exists($role, config('twill.settings.crops', []))
                 ) {
                     Collection::make($mediasForRole)->each(function ($media) use (&$medias, $role, $locale) {

--- a/src/Repositories/BlockRepository.php
+++ b/src/Repositories/BlockRepository.php
@@ -2,6 +2,7 @@
 
 namespace A17\Twill\Repositories;
 
+use A17\Twill\Facades\TwillBlocks;
 use A17\Twill\Models\Contracts\TwillModelContract;
 use A17\Twill\Repositories\Behaviors\HandleFiles;
 use A17\Twill\Repositories\Behaviors\HandleMedias;
@@ -28,7 +29,7 @@ class BlockRepository extends ModuleRepository
 
     public function getCrops(string $role): array
     {
-        return $this->config->get('twill.block_editor.crops')[$role];
+        return TwillBlocks::getAllCropConfigs()[$role];
     }
 
     public function hydrate(TwillModelContract $model, array $fields): TwillModelContract

--- a/src/TwillBlocks.php
+++ b/src/TwillBlocks.php
@@ -318,7 +318,6 @@ class TwillBlocks
                     $this->cropConfigs = array_merge($this->cropConfigs, $crops);
                 }
             }
-
         }
 
         return $this->cropConfigs;

--- a/src/TwillBlocks.php
+++ b/src/TwillBlocks.php
@@ -4,7 +4,6 @@ namespace A17\Twill;
 
 use A17\Twill\Services\Blocks\Block;
 use A17\Twill\Services\Blocks\BlockCollection;
-use A17\Twill\Services\Forms\Fields\BaseFormField;
 use A17\Twill\Services\Forms\InlineRepeater;
 use A17\Twill\View\Components\Blocks\TwillBlockComponent;
 use Illuminate\Support\Collection;
@@ -52,7 +51,9 @@ class TwillBlocks
     /**
      * @return A17\Twill\Services\Blocks\BlockCollection
      */
-    private $blockCollection;
+    private ?BlockCollection $blockCollection = null;
+
+    private array $cropConfigs = [];
 
     /**
      * Registers a blocks directory.
@@ -296,5 +297,30 @@ class TwillBlocks
             ->map(function ($file) use ($source, $type, $renderNamespace) {
                 return Block::make($file, $type, $source, null, $renderNamespace);
             });
+    }
+
+    /**
+     * Gets all the crop configs, also those of component blocks.
+     */
+    public function getAllCropConfigs(): array
+    {
+        if (! $this->cropConfigs) {
+            $this->cropConfigs = config()->get('twill.block_editor.crops');
+
+            /** @var Block $block */
+            foreach ($this->getBlockCollection() as $block) {
+                if (! $block->componentClass) {
+                    continue;
+                }
+
+                $crops = $block->componentClass::getCrops();
+                if ($crops !== []) {
+                    $this->cropConfigs = array_merge($this->cropConfigs, $crops);
+                }
+            }
+
+        }
+
+        return $this->cropConfigs;
     }
 }

--- a/src/View/Components/Blocks/TwillBlockComponent.php
+++ b/src/View/Components/Blocks/TwillBlockComponent.php
@@ -47,6 +47,11 @@ abstract class TwillBlockComponent extends Component
         return $this->block->translatedInput($fieldName);
     }
 
+    public static function getCrops(): array
+    {
+        return [];
+    }
+
     /**
      * This string should contain no special characters or spaces.
      *

--- a/views/layouts/form.blade.php
+++ b/views/layouts/form.blade.php
@@ -205,9 +205,9 @@
     window['{{ config('twill.js_namespace') }}'].STORE.parents = {!! json_encode($parents ?? []) !!}
 
     @if (isset($item) && classHasTrait($item, \A17\Twill\Models\Behaviors\HasMedias::class))
-        window['{{ config('twill.js_namespace') }}'].STORE.medias.crops = {!! json_encode(($item->getMediasParams()) + config('twill.block_editor.crops') + (config('twill.settings.crops') ?? [])) !!}
+        window['{{ config('twill.js_namespace') }}'].STORE.medias.crops = {!! json_encode(($item->getMediasParams()) + \A17\Twill\Facades\TwillBlocks::getAllCropConfigs() + (config('twill.settings.crops') ?? [])) !!}
     @else
-        window['{{ config('twill.js_namespace') }}'].STORE.medias.crops = {!! json_encode(config('twill.block_editor.crops') + (config('twill.settings.crops') ?? [])) !!}
+        window['{{ config('twill.js_namespace') }}'].STORE.medias.crops = {!! json_encode(\A17\Twill\Facades\TwillBlocks::getAllCropConfigs() + (config('twill.settings.crops') ?? [])) !!}
     @endif
     window['{{ config('twill.js_namespace') }}'].STORE.medias.selected = {}
 


### PR DESCRIPTION
This pr allows block components to define their crops inline instead of using the config file:

```php
<?php

namespace App\View\Components\Twill\Blocks;

use A17\Twill\Services\Forms\Fields\Input;
use A17\Twill\Services\Forms\Fields\Medias;
use A17\Twill\Services\Forms\Fields\Wysiwyg;
use A17\Twill\Services\Forms\Form;
use A17\Twill\View\Components\Blocks\TwillBlockComponent;
use Illuminate\Contracts\View\View;

class Quote extends TwillBlockComponent
{
    public function render(): View
    {
        return view('components.twill.blocks.quote');
    }

    public function getForm(): Form
    {
        return Form::make([
            Input::make()->name('title'),
            Wysiwyg::make()->name('quote'),
            Medias::make()->name('content_image')->max(1)
        ]);
    }

    public static function getCrops(): array
    {
        return [
            'content_image' => [
                'default' => [
                    [
                        'name' => 'default',
                        'ratio' => 16 / 9,
                        'minValues' => [
                            'width' => 100,
                            'height' => 100,
                        ],
                    ],
                ]
            ]
        ];
    }
}
```