### PR TITLE
[3.x] Fix form builder check to allow not using the default content fieldset

### DIFF
--- a/src/Http/Controllers/Admin/ModuleController.php
+++ b/src/Http/Controllers/Admin/ModuleController.php
@@ -1144,7 +1144,7 @@ abstract class ModuleController extends Controller
 
         $controllerForm = $this->getForm($item);
 
-        if ($controllerForm->isNotEmpty()) {
+        if ($controllerForm->hasForm()) {
             $view = 'twill::layouts.form';
         } else {
             $view = Collection::make([

--- a/src/Http/Controllers/Admin/SingletonModuleController.php
+++ b/src/Http/Controllers/Admin/SingletonModuleController.php
@@ -39,7 +39,7 @@ abstract class SingletonModuleController extends ModuleController
 
         $controllerForm = $this->getForm($item);
 
-        if ($controllerForm->isNotEmpty()) {
+        if ($controllerForm->hasForm()) {
             $view = 'twill::layouts.form';
         } else {
             $view = "twill.{$this->moduleName}.form";


### PR DESCRIPTION
This fixes an issue that was breaking the form when no fields were added to the form, only fieldsets.