### PR TITLE
[3.x] Fix conflicts between native Twill blocks and app/vendor blocks

### DIFF
--- a/src/Helpers/Capsule.php
+++ b/src/Helpers/Capsule.php
@@ -380,13 +380,13 @@ class Capsule
     {
         $resourcePath = $this->getConfig()['views_path'] ?? 'resources/views/admin';
 
-        foreach(['blocks', 'repeaters'] as $type) {
+        foreach (['blocks', 'repeaters'] as $type) {
             if (file_exists($path = "{$this->path}/$resourcePath/$type")) {
                 $paths = config("twill.block_editor.directories.source.$type");
 
                 $paths[] = [
                     'path' => $path,
-                    'source' => 'capsule::'.$this->name
+                    'source' => 'capsule::' . $this->name
                 ];
 
                 config(["twill.block_editor.directories.source.$type" => $paths]);

--- a/src/Services/Blocks/Block.php
+++ b/src/Services/Blocks/Block.php
@@ -18,6 +18,8 @@ class Block
 
     public const SOURCE_CUSTOM = 'custom';
 
+    public const SOURCE_VENDOR = 'vendor';
+
     public const TYPE_BLOCK = 'block';
 
     public const TYPE_SETTINGS = 'settings';

--- a/src/TwillServiceProvider.php
+++ b/src/TwillServiceProvider.php
@@ -131,7 +131,6 @@ class TwillServiceProvider extends ServiceProvider
         foreach (config('twill.block_editor.directories.source.blocks') as $value) {
             TwillBlocks::$blockDirectories[$value['path']] = [
                 'source' => $value['source'],
-                'type' => TwillBlocks::DIRECTORY_TYPE_APP,
                 'renderNamespace' => null
             ];
         }
@@ -139,7 +138,6 @@ class TwillServiceProvider extends ServiceProvider
         foreach (config('twill.block_editor.directories.source.repeaters') as $value) {
             TwillBlocks::$repeatersDirectories[$value['path']] = [
                 'source' => $value['source'],
-                'type' => TwillBlocks::DIRECTORY_TYPE_APP,
                 'renderNamespace' => null
             ];
         }


### PR DESCRIPTION
`twill.block_editor.directories` contains both Twill and app directories by default. Without this fix, Twill's default text block is taking over in the form instead of the app's text block.