### PR TITLE
[3.x] Fix return type

### DIFF
--- a/src/Models/Contracts/TwillModelContract.php
+++ b/src/Models/Contracts/TwillModelContract.php
@@ -7,7 +7,6 @@ use Illuminate\Database\Eloquent\Builder;
 /**
  * @mixin \Illuminate\Database\Eloquent\Model
  * @mixin \A17\Twill\Models\Model
- * @mixin \A17\Twill\Models\Behaviors\HasSlug
  *
  * @property int $id
  *

--- a/src/Services/Blocks/Block.php
+++ b/src/Services/Blocks/Block.php
@@ -186,7 +186,7 @@ class Block
         return new self($file, $type, $source, $name, $renderNamespace);
     }
 
-    public function newInstance(): self
+    public function newInstance(): static
     {
         return new static(
             $this->file,

--- a/src/Services/Forms/Fields/BaseFormField.php
+++ b/src/Services/Forms/Fields/BaseFormField.php
@@ -43,7 +43,7 @@ abstract class BaseFormField
         return $this;
     }
 
-    public function default(mixed $default): self
+    public function default(mixed $default): static
     {
         $this->default = $default;
 
@@ -53,7 +53,7 @@ abstract class BaseFormField
     /**
      * Set the label of the field, you can use twillTrans('') Laravel translatable strings here.
      */
-    public function label(string $label): self
+    public function label(string $label): static
     {
         $this->label = $label;
 
@@ -63,7 +63,7 @@ abstract class BaseFormField
     /**
      * Add a note to the field to display on the form.
      */
-    public function note(string $note): self
+    public function note(string $note): static
     {
         $this->note = $note;
 
@@ -73,7 +73,7 @@ abstract class BaseFormField
     /**
      * Marks the field as mandatory, however you still need to add validation rules.
      */
-    public function required(bool $required = true): self
+    public function required(bool $required = true): static
     {
         $this->required = $required;
 
@@ -85,7 +85,7 @@ abstract class BaseFormField
      *
      * There might be some fields not supporting this.
      */
-    public function disabled(bool $disabled = true): self
+    public function disabled(bool $disabled = true): static
     {
         $this->disabled = $disabled;
 

--- a/src/Services/Forms/Fields/BlockEditor.php
+++ b/src/Services/Forms/Fields/BlockEditor.php
@@ -27,14 +27,14 @@ class BlockEditor extends BaseFormField
         return parent::name($name);
     }
 
-    public function withoutSeparator(bool $withoutSeparator = true): self
+    public function withoutSeparator(bool $withoutSeparator = true): static
     {
         $this->withoutSeparator = $withoutSeparator;
 
         return $this;
     }
 
-    public function isSettings(bool $isSettings = true): self
+    public function isSettings(bool $isSettings = true): static
     {
         $this->isSettings = $isSettings;
 
@@ -44,7 +44,7 @@ class BlockEditor extends BaseFormField
     /**
      * Default is all, but using this method you can limit the block types the field can use.
      */
-    public function blocks(array $blocks): self
+    public function blocks(array $blocks): static
     {
         $this->blocks = $blocks;
 

--- a/src/Services/Forms/Fields/Browser.php
+++ b/src/Services/Forms/Fields/Browser.php
@@ -49,7 +49,7 @@ class Browser extends BaseFormField
     /**
      * Additional parameters to pass to the module route.
      */
-    public function params(array $params): self
+    public function params(array $params): static
     {
         $this->params = $params;
 
@@ -59,7 +59,7 @@ class Browser extends BaseFormField
     /**
      * A list of custom endpoints to use.
      */
-    public function endpoints(array $endpoints): self
+    public function endpoints(array $endpoints): static
     {
         $this->endpoints = $endpoints;
 
@@ -69,7 +69,7 @@ class Browser extends BaseFormField
     /**
      * A note to display inside the browser.
      */
-    public function browserNote(string $browserNote): self
+    public function browserNote(string $browserNote): static
     {
         $this->browserNote = $browserNote;
 
@@ -79,7 +79,7 @@ class Browser extends BaseFormField
     /**
      * The label to display for items, defaults to the field label.
      */
-    public function itemLabel(string $itemLabel): self
+    public function itemLabel(string $itemLabel): static
     {
         $this->itemLabel = $itemLabel;
 
@@ -93,7 +93,7 @@ class Browser extends BaseFormField
      *
      * Provide an array with: label, name, routePrefix, params
      */
-    public function modulesCustom(array $modules): self
+    public function modulesCustom(array $modules): static
     {
         $this->modules = $modules;
 
@@ -103,7 +103,7 @@ class Browser extends BaseFormField
     /**
      * Makes the modal window use the full width.
      */
-    public function wide(bool $wide = true): self
+    public function wide(bool $wide = true): static
     {
         $this->wide = $wide;
 
@@ -113,7 +113,7 @@ class Browser extends BaseFormField
     /**
      * Makes the columns in the browser sortable.
      */
-    public function sortable(bool $sortable = true): self
+    public function sortable(bool $sortable = true): static
     {
         $this->sortable = $sortable;
 
@@ -123,7 +123,7 @@ class Browser extends BaseFormField
     /**
      * Set a custom route prefix if needed.
      */
-    public function routePrefix(string $routePrefix): self
+    public function routePrefix(string $routePrefix): static
     {
         $this->routePrefix = $routePrefix;
 
@@ -133,7 +133,7 @@ class Browser extends BaseFormField
     /**
      * Conditionally show this field based on another browser field.
      */
-    public function connectedBrowserField(string $connectedBrowserField): self
+    public function connectedBrowserField(string $connectedBrowserField): static
     {
         $this->connectedBrowserField = $connectedBrowserField;
 
@@ -143,7 +143,7 @@ class Browser extends BaseFormField
     /**
      * A list of modules that can be be selected in the browser modal.
      */
-    public function modules(array $modules): self
+    public function modules(array $modules): static
     {
         if (count($modules) === 1 && ! isset($modules[0])) {
             $this->moduleName = getModuleNameByModel(array_pop($modules));

--- a/src/Services/Forms/Fields/Checkbox.php
+++ b/src/Services/Forms/Fields/Checkbox.php
@@ -27,7 +27,7 @@ class Checkbox extends BaseFormField
     /**
      * The message to show when confirming the checking of the checkbox.
      */
-    public function confirmMessageText(string $confirmMessageText): self
+    public function confirmMessageText(string $confirmMessageText): static
     {
         $this->confirmMessageText = $confirmMessageText;
 
@@ -41,7 +41,7 @@ class Checkbox extends BaseFormField
     /**
      * The title to show when confirming the checking of the checkbox.
      */
-    public function confirmTitleText(string $confirmTitleText): self
+    public function confirmTitleText(string $confirmTitleText): static
     {
         $this->confirmTitleText = $confirmTitleText;
 
@@ -55,7 +55,7 @@ class Checkbox extends BaseFormField
     /**
      * If the checkbox needs confirmation on ticking.
      */
-    public function requireConfirmation(bool $requireConfirmation = true): self
+    public function requireConfirmation(bool $requireConfirmation = true): static
     {
         $this->requireConfirmation = $requireConfirmation;
 

--- a/src/Services/Forms/Fields/DatePicker.php
+++ b/src/Services/Forms/Fields/DatePicker.php
@@ -37,7 +37,7 @@ class DatePicker extends BaseFormField
     /**
      * Hides the time picker.
      */
-    public function withoutTime(bool $withoutTime = true): self
+    public function withoutTime(bool $withoutTime = true): static
     {
         $this->withTime = !$withoutTime;
 
@@ -47,7 +47,7 @@ class DatePicker extends BaseFormField
     /**
      * Allows manual input.
      */
-    public function allowInput(bool $allowInput = true): self
+    public function allowInput(bool $allowInput = true): static
     {
         $this->allowInput = $allowInput;
 
@@ -57,7 +57,7 @@ class DatePicker extends BaseFormField
     /**
      * Allows to clear the input field.
      */
-    public function allowClear(bool $allowClear = true): self
+    public function allowClear(bool $allowClear = true): static
     {
         $this->allowClear = $allowClear;
 
@@ -67,7 +67,7 @@ class DatePicker extends BaseFormField
     /**
      * Makes it a time picker only.
      */
-    public function timeOnly(bool $timeOnly = true): self
+    public function timeOnly(bool $timeOnly = true): static
     {
         $this->withTime = true;
         $this->timeOnly = $timeOnly;
@@ -79,7 +79,7 @@ class DatePicker extends BaseFormField
     /**
      * If 24h format should be used.
      */
-    public function time24h(bool $time24h = true): self
+    public function time24h(bool $time24h = true): static
     {
         $this->time24Hr = $time24h;
 
@@ -89,7 +89,7 @@ class DatePicker extends BaseFormField
     /**
      * Define a custom date format.
      */
-    public function altFormat(string $altFormat): self
+    public function altFormat(string $altFormat): static
     {
         $this->altFormat = $altFormat;
 
@@ -99,7 +99,7 @@ class DatePicker extends BaseFormField
     /**
      * Set how many hours are increment when using the + and - actions.
      */
-    public function hourIncrement(int $hourIncrement = 1): self
+    public function hourIncrement(int $hourIncrement = 1): static
     {
         $this->hourIncrement = $hourIncrement;
 
@@ -109,7 +109,7 @@ class DatePicker extends BaseFormField
     /**
      * Set how many minutes are increment when using the + and - actions.
      */
-    public function minuteIncrement(int $minuteIncrement = 1): self
+    public function minuteIncrement(int $minuteIncrement = 1): static
     {
         $this->minuteIncrement = $minuteIncrement;
 

--- a/src/Services/Forms/Fields/Files.php
+++ b/src/Services/Forms/Fields/Files.php
@@ -48,7 +48,7 @@ class Files extends BaseFormField
     /**
      * Default is 0 which is unlimited (depending on server config).
      */
-    public function filesizeMax(int $filesizeMax): self
+    public function filesizeMax(int $filesizeMax): static
     {
         $this->filesizeMax = $filesizeMax;
 
@@ -58,7 +58,7 @@ class Files extends BaseFormField
     /**
      * The label to display for items, defaults to the field label.
      */
-    public function itemLabel(string $itemLabel): self
+    public function itemLabel(string $itemLabel): static
     {
         $this->itemLabel = $itemLabel;
 

--- a/src/Services/Forms/Fields/Files.php
+++ b/src/Services/Forms/Fields/Files.php
@@ -36,7 +36,7 @@ class Files extends BaseFormField
     /**
      * {@inheritDoc}
      */
-    public function label(string $label): BaseFormField
+    public function label(string $label): static
     {
         if (!$this->itemLabel) {
             $this->itemLabel = strtolower($label);

--- a/src/Services/Forms/Fields/Input.php
+++ b/src/Services/Forms/Fields/Input.php
@@ -65,7 +65,7 @@ class Input extends BaseFormField
     /**
      * Text to display (inside) before the actual input.
      */
-    public function prefix(string $prefix): self
+    public function prefix(string $prefix): static
     {
         $this->prefix = $prefix;
 
@@ -75,7 +75,7 @@ class Input extends BaseFormField
     /**
      * The type of input field like: text, number, email, ..
      */
-    public function type(string $type): self
+    public function type(string $type): static
     {
         $this->type = $type;
 
@@ -88,7 +88,7 @@ class Input extends BaseFormField
      *
      * @see https://alpinejs.dev/plugins/mask
      */
-    public function mask(string $mask): self
+    public function mask(string $mask): static
     {
         $this->mask = $mask;
 
@@ -98,7 +98,7 @@ class Input extends BaseFormField
     /**
      * The amount of rows, only used with textarea type.
      */
-    public function rows(int $rows): self
+    public function rows(int $rows): static
     {
         $this->rows = $rows;
 

--- a/src/Services/Forms/Fields/Map.php
+++ b/src/Services/Forms/Fields/Map.php
@@ -27,7 +27,7 @@ class Map extends BaseFormField
     /**
      * Completely remove the map.
      */
-    public function hideMap(bool $hideMap = true): self
+    public function hideMap(bool $hideMap = true): static
     {
         $this->showMap = !$hideMap;
 
@@ -37,7 +37,7 @@ class Map extends BaseFormField
     /**
      * Show the map by default.
      */
-    public function openMap(bool $openMap = true): self
+    public function openMap(bool $openMap = true): static
     {
         $this->openMap = $openMap;
 
@@ -47,7 +47,7 @@ class Map extends BaseFormField
     /**
      * Stores extended data into the field like lat/lon.
      */
-    public function saveExtendedData(bool $saveExtendedData = true): self
+    public function saveExtendedData(bool $saveExtendedData = true): static
     {
         $this->saveExtendedData = $saveExtendedData;
 
@@ -57,7 +57,7 @@ class Map extends BaseFormField
     /**
      * Make the field try to automatically detect the latitude and longitude.
      */
-    public function autoDetectLatLang(bool $autoDetectLatLang = true): self
+    public function autoDetectLatLang(bool $autoDetectLatLang = true): static
     {
         $this->autoDetectLatLngValue = $autoDetectLatLang;
 

--- a/src/Services/Forms/Fields/Medias.php
+++ b/src/Services/Forms/Fields/Medias.php
@@ -49,7 +49,7 @@ class Medias extends BaseFormField
     /**
      * Disables the additional metadata input fields.
      */
-    public function withoutAddInfo(bool $withoutAddInfo = true): self
+    public function withoutAddInfo(bool $withoutAddInfo = true): static
     {
         $this->withAddInfo = !$withoutAddInfo;
 
@@ -59,7 +59,7 @@ class Medias extends BaseFormField
     /**
      * Removes the video url field from the additional info section.
      */
-    public function withoutVideoUrl(bool $withoutVideoUrl = true): self
+    public function withoutVideoUrl(bool $withoutVideoUrl = true): static
     {
         $this->withVideoUrl = !$withoutVideoUrl;
 
@@ -69,7 +69,7 @@ class Medias extends BaseFormField
     /**
      * Removes the caption field from the additional info section.
      */
-    public function withoutCaption(bool $withoutCaption = true): self
+    public function withoutCaption(bool $withoutCaption = true): static
     {
         $this->withCaption = !$withoutCaption;
 
@@ -79,7 +79,7 @@ class Medias extends BaseFormField
     /**
      * Set the max length of the alt field.
      */
-    public function altTextMaxLength(bool $altTextMaxLength): self
+    public function altTextMaxLength(bool $altTextMaxLength): static
     {
         $this->altTextMaxLength = $altTextMaxLength;
 
@@ -89,7 +89,7 @@ class Medias extends BaseFormField
     /**
      * Set the max length of the caption field.
      */
-    public function captionMaxLength(int $captionMaxLength): self
+    public function captionMaxLength(int $captionMaxLength): static
     {
         $this->captionMaxLength = $captionMaxLength;
 
@@ -101,7 +101,7 @@ class Medias extends BaseFormField
      *
      * @see https://twill.io/docs/form-fields/medias.html#extra-metadatas
      */
-    public function extraMetadatas(array $extraMetadatas): self
+    public function extraMetadatas(array $extraMetadatas): static
     {
         $this->extraMetadatas = $extraMetadatas;
 
@@ -111,7 +111,7 @@ class Medias extends BaseFormField
     /**
      * The minimum width of the image.
      */
-    public function minWidth(int $minWidth): self
+    public function minWidth(int $minWidth): static
     {
         $this->widthMin = $minWidth;
 
@@ -121,7 +121,7 @@ class Medias extends BaseFormField
     /**
      * The minimum height of the image.
      */
-    public function minHeight(int $minHeight): self
+    public function minHeight(int $minHeight): static
     {
         $this->heightMin = $minHeight;
 
@@ -131,7 +131,7 @@ class Medias extends BaseFormField
     /**
      * Hide the cropper.
      */
-    public function hideActiveCrop(bool $hideActiveCrop = true): self
+    public function hideActiveCrop(bool $hideActiveCrop = true): static
     {
         $this->activeCrop = !$hideActiveCrop;
 

--- a/src/Services/Forms/Fields/MultiSelect.php
+++ b/src/Services/Forms/Fields/MultiSelect.php
@@ -47,49 +47,49 @@ class MultiSelect extends BaseFormField
     /**
      * If the options should be searchable.
      */
-    public function searchable(bool $searchable = true): self
+    public function searchable(bool $searchable = true): static
     {
         $this->searchable = $searchable;
 
         return $this;
     }
 
-    public function canAddNew(bool $canAddNew = true): self
+    public function canAddNew(bool $canAddNew = true): static
     {
         $this->addNew = $canAddNew;
 
         return $this;
     }
 
-    public function moduleName(string $moduleName): self
+    public function moduleName(string $moduleName): static
     {
         $this->moduleName = $moduleName;
 
         return $this;
     }
 
-    public function storeUrl(string $storeUrl): self
+    public function storeUrl(string $storeUrl): static
     {
         $this->storeUrl = $storeUrl;
 
         return $this;
     }
 
-    public function taggable(bool $taggable = true): self
+    public function taggable(bool $taggable = true): static
     {
         $this->taggable = $taggable;
 
         return $this;
     }
 
-    public function pushTags(bool $pushTags = true): self
+    public function pushTags(bool $pushTags = true): static
     {
         $this->pushTags = $pushTags;
 
         return $this;
     }
 
-    public function endpoint(string $endpoint): self
+    public function endpoint(string $endpoint): static
     {
         $this->endpoint = $endpoint;
 

--- a/src/Services/Forms/Fields/Repeater.php
+++ b/src/Services/Forms/Fields/Repeater.php
@@ -28,7 +28,7 @@ class Repeater extends BaseFormField
     /**
      * The name of the repeater, this also sets the name of field if not set yet.
      */
-    public function type(string $type): self
+    public function type(string $type): static
     {
         $this->type = $type;
 
@@ -42,7 +42,7 @@ class Repeater extends BaseFormField
     /**
      * Instead of a button show a link to add a new one.
      */
-    public function buttonAsLink(bool $buttonAsLink = true): self
+    public function buttonAsLink(bool $buttonAsLink = true): static
     {
         $this->buttonAsLink = $buttonAsLink;
 

--- a/src/Services/Forms/Fields/Traits/CanHaveButtonOnTop.php
+++ b/src/Services/Forms/Fields/Traits/CanHaveButtonOnTop.php
@@ -9,7 +9,7 @@ trait CanHaveButtonOnTop
     /**
      * Shows the browse button above instead of below the list of items.
      */
-    public function buttonOnTop(bool $buttonOnTop = true): self
+    public function buttonOnTop(bool $buttonOnTop = true): static
     {
         $this->buttonOnTop = $buttonOnTop;
 

--- a/src/Services/Forms/Fields/Traits/CanReorder.php
+++ b/src/Services/Forms/Fields/Traits/CanReorder.php
@@ -9,7 +9,7 @@ trait CanReorder
     /**
      * Disables the reordering of items.
      */
-    public function disableReorder(bool $disableReorder = true): self
+    public function disableReorder(bool $disableReorder = true): static
     {
         $this->reorder = !$disableReorder;
 

--- a/src/Services/Forms/Fields/Traits/HasBorder.php
+++ b/src/Services/Forms/Fields/Traits/HasBorder.php
@@ -9,7 +9,7 @@ trait HasBorder
     /**
      * Adds a border around the options.
      */
-    public function border(bool $border = true): self
+    public function border(bool $border = true): static
     {
         $this->border = $border;
 

--- a/src/Services/Forms/Fields/Traits/HasFieldNote.php
+++ b/src/Services/Forms/Fields/Traits/HasFieldNote.php
@@ -9,9 +9,10 @@ trait HasFieldNote
     /**
      * Adds a note.
      */
-    public function fieldNote(string $fieldNote): self
+    public function fieldNote(string $fieldNote): static
     {
         $this->fieldNote = $fieldNote;
+
         return $this;
     }
 }

--- a/src/Services/Forms/Fields/Traits/HasMax.php
+++ b/src/Services/Forms/Fields/Traits/HasMax.php
@@ -9,7 +9,7 @@ trait HasMax
     /**
      * Sets the max amount of items.
      */
-    public function max(int $max): self
+    public function max(int $max): static
     {
         $this->max = $max;
 

--- a/src/Services/Forms/Fields/Traits/HasMaxlength.php
+++ b/src/Services/Forms/Fields/Traits/HasMaxlength.php
@@ -9,9 +9,10 @@ trait HasMaxlength
     /**
      * Sets the max character length.
      */
-    public function maxLength(string $maxlength): self
+    public function maxLength(string $maxlength): static
     {
         $this->maxlength = $maxlength;
+
         return $this;
     }
 }

--- a/src/Services/Forms/Fields/Traits/HasMin.php
+++ b/src/Services/Forms/Fields/Traits/HasMin.php
@@ -9,7 +9,7 @@ trait HasMin
     /**
      * Sets the minimum amount of items.
      */
-    public function min(int $min): self
+    public function min(int $min): static
     {
         $this->min = $min;
 

--- a/src/Services/Forms/Fields/Traits/HasOnChange.php
+++ b/src/Services/Forms/Fields/Traits/HasOnChange.php
@@ -13,7 +13,7 @@ trait HasOnChange
     /**
      * The field to act on.
      */
-    public function ref(string $ref): self
+    public function ref(string $ref): static
     {
         $this->ref = $ref;
 
@@ -23,7 +23,7 @@ trait HasOnChange
     /**
      * Javascript to execute on change.
      */
-    public function onChange(string $onChange): self
+    public function onChange(string $onChange): static
     {
         $this->onChange = $onChange;
 
@@ -33,7 +33,7 @@ trait HasOnChange
     /**
      * Attribute to change.
      */
-    public function onChangeAttribute(string $onChangeAttribute): self
+    public function onChangeAttribute(string $onChangeAttribute): static
     {
         $this->onChangeAttribute = $onChangeAttribute;
 

--- a/src/Services/Forms/Fields/Traits/HasOptions.php
+++ b/src/Services/Forms/Fields/Traits/HasOptions.php
@@ -14,7 +14,7 @@ trait HasOptions
     /**
      * List of options to display in the field.
      */
-    public function options(Options $options): self
+    public function options(Options $options): static
     {
         $this->options = $options;
 
@@ -24,7 +24,7 @@ trait HasOptions
     /**
      * Adds a single option.
      */
-    public function addOption(Option $option): self
+    public function addOption(Option $option): static
     {
         if ($this->options === null) {
             $this->options = Options::make();

--- a/src/Services/Forms/Fields/Traits/HasPlaceholder.php
+++ b/src/Services/Forms/Fields/Traits/HasPlaceholder.php
@@ -9,9 +9,10 @@ trait HasPlaceholder
     /**
      * Sets the placeholder of the field.
      */
-    public function placeholder(string $placeholder): self
+    public function placeholder(string $placeholder): static
     {
         $this->placeholder = $placeholder;
+
         return $this;
     }
 }

--- a/src/Services/Forms/Fields/Traits/Inlineable.php
+++ b/src/Services/Forms/Fields/Traits/Inlineable.php
@@ -9,7 +9,7 @@ trait Inlineable
     /**
      * Shows the option inline.
      */
-    public function inline(bool $inline = true): self
+    public function inline(bool $inline = true): static
     {
         $this->inline = $inline;
 

--- a/src/Services/Forms/Fields/Traits/IsTranslatable.php
+++ b/src/Services/Forms/Fields/Traits/IsTranslatable.php
@@ -9,9 +9,10 @@ trait IsTranslatable
     /**
      * Makes the field translatable.
      */
-    public function translatable(bool $translatable = true): self
+    public function translatable(bool $translatable = true): static
     {
         $this->translated = $translatable;
+
         return $this;
     }
 }

--- a/src/Services/Forms/Fields/Traits/Unpackable.php
+++ b/src/Services/Forms/Fields/Traits/Unpackable.php
@@ -9,7 +9,7 @@ trait Unpackable
     /**
      * Shows the option in a grid.
      */
-    public function unpack(bool $unpack = true): self
+    public function unpack(bool $unpack = true): static
     {
         $this->unpack = $unpack;
 
@@ -19,7 +19,7 @@ trait Unpackable
     /**
      * The amount of column to show the option in (when using unpack).
      */
-    public function columns(int $columns = 1): self
+    public function columns(int $columns = 1): static
     {
         $this->columns = $columns;
 

--- a/src/Services/Forms/Fields/Wysiwyg.php
+++ b/src/Services/Forms/Fields/Wysiwyg.php
@@ -66,7 +66,7 @@ class Wysiwyg extends BaseFormField
     /**
      * Hides the character counter.
      */
-    public function hideCounter(bool $hideCounter = true): self
+    public function hideCounter(bool $hideCounter = true): static
     {
         $this->hideCounter = $hideCounter;
 
@@ -76,7 +76,7 @@ class Wysiwyg extends BaseFormField
     /**
      * Adds a edit source button.
      */
-    public function allowSource(bool $allowSource = true): self
+    public function allowSource(bool $allowSource = true): static
     {
         $this->editSource = $allowSource;
 
@@ -86,7 +86,7 @@ class Wysiwyg extends BaseFormField
     /**
      * Allows you to set custom toolbar options. This depends on the editor used.
      */
-    public function toolbarOptions(array $toolbarOptions): self
+    public function toolbarOptions(array $toolbarOptions): static
     {
         $this->toolbarOptions = $toolbarOptions;
 
@@ -96,7 +96,7 @@ class Wysiwyg extends BaseFormField
     /**
      * Allows you to set editor options. This depends on the editor used.
      */
-    public function options(array $options): self
+    public function options(array $options): static
     {
         $this->options = $options;
 
@@ -106,7 +106,7 @@ class Wysiwyg extends BaseFormField
     /**
      * The type of editor to use, defaults to quill, options are: tiptap
      */
-    public function type(string $type): self
+    public function type(string $type): static
     {
         $this->type = $type;
 
@@ -116,7 +116,7 @@ class Wysiwyg extends BaseFormField
     /**
      * Limits the height of the editor, otherwise grows infinitely.
      */
-    public function limitHeight(bool $limitHeight = true): self
+    public function limitHeight(bool $limitHeight = true): static
     {
         $this->limitHeight = $limitHeight;
 
@@ -126,7 +126,7 @@ class Wysiwyg extends BaseFormField
     /**
      * Enables syntax highlight.
      */
-    public function syntax(bool $syntax = true): self
+    public function syntax(bool $syntax = true): static
     {
         $this->syntax = $syntax;
 
@@ -136,7 +136,7 @@ class Wysiwyg extends BaseFormField
     /**
      * Set a custom theme for the syntax highlighter.
      */
-    public function customTheme(string $customTheme): self
+    public function customTheme(string $customTheme): static
     {
         $this->customTheme = $customTheme;
 
@@ -146,7 +146,7 @@ class Wysiwyg extends BaseFormField
     /**
      * Additional custom options.
      */
-    public function customOptions(array $customOptions): self
+    public function customOptions(array $customOptions): static
     {
         $this->customOptions = $customOptions;
 

--- a/src/Services/Forms/Fieldset.php
+++ b/src/Services/Forms/Fieldset.php
@@ -37,7 +37,7 @@ class Fieldset implements CanHaveSubfields
     /**
      * Set the id of the field.
      */
-    public function id(string $id): self
+    public function id(string $id): static
     {
         $this->id = $id;
 
@@ -47,7 +47,7 @@ class Fieldset implements CanHaveSubfields
     /**
      * Marks the fielset as open.
      */
-    public function open(bool $open = true): self
+    public function open(bool $open = true): static
     {
         $this->open = $open;
 
@@ -57,7 +57,7 @@ class Fieldset implements CanHaveSubfields
     /**
      * Marks the fielset as closed.
      */
-    public function closed(): self
+    public function closed(): static
     {
         $this->open = false;
 
@@ -67,7 +67,7 @@ class Fieldset implements CanHaveSubfields
     /**
      * Set the form fields of the fieldset.
      */
-    public function fields(array $fields): self
+    public function fields(array $fields): static
     {
         $this->fields = collect($fields);
 

--- a/src/Services/Forms/Form.php
+++ b/src/Services/Forms/Form.php
@@ -2,8 +2,8 @@
 
 namespace A17\Twill\Services\Forms;
 
-use Illuminate\Support\Collection;
 use Illuminate\Contracts\View\View;
+use Illuminate\Support\Collection;
 
 class Form extends Collection implements CanHaveSubfields
 {
@@ -13,14 +13,14 @@ class Form extends Collection implements CanHaveSubfields
     private bool $isCreate = false;
     private bool $forBlocks = false;
 
-    public function withFieldSets(Fieldsets $fieldsets): self
+    public function withFieldSets(Fieldsets $fieldsets): static
     {
         $this->fieldsets = $fieldsets;
 
         return $this;
     }
 
-    public function addFieldset(Fieldset $fieldset): self
+    public function addFieldset(Fieldset $fieldset): static
     {
         if (! $this->fieldsets) {
             $this->fieldsets = Fieldsets::make();
@@ -31,7 +31,7 @@ class Form extends Collection implements CanHaveSubfields
         return $this;
     }
 
-    public function toFrontend(?Form $sideFieldSets = null, bool $isCreate = false): self
+    public function toFrontend(?Form $sideFieldSets = null, bool $isCreate = false): static
     {
         $this->sideForm = $sideFieldSets;
 
@@ -81,7 +81,7 @@ class Form extends Collection implements CanHaveSubfields
         return $this->forBlocks;
     }
 
-    public function renderForBlocks(bool $renderForBlocks = true): self
+    public function renderForBlocks(bool $renderForBlocks = true): static
     {
         $this->forBlocks = $renderForBlocks;
 

--- a/src/Services/Forms/InlineRepeater.php
+++ b/src/Services/Forms/InlineRepeater.php
@@ -99,7 +99,7 @@ class InlineRepeater implements CanHaveSubfields
      * NOTE: You cannot have the same repeater twice in a form or page.
      * NOTE: If you have a repeater with a this name already, that one will be used instead.
      */
-    public function name(string $name): self
+    public function name(string $name): static
     {
         $this->name = $name;
 
@@ -113,7 +113,7 @@ class InlineRepeater implements CanHaveSubfields
     /**
      * Set the form fields of the repeater.
      */
-    public function fields(array $fields): self
+    public function fields(array $fields): static
     {
         $this->fields = collect($fields);
 

--- a/src/Services/Listings/Columns/Browser.php
+++ b/src/Services/Listings/Columns/Browser.php
@@ -10,7 +10,7 @@ class Browser extends TableColumn
 {
     private ?string $browser = null;
 
-    public function browser(string $browser): self
+    public function browser(string $browser): static
     {
         $this->browser = $browser;
         return $this;

--- a/src/Services/Listings/Columns/Image.php
+++ b/src/Services/Listings/Columns/Image.php
@@ -29,7 +29,7 @@ class Image extends TableColumn
     /**
      * The image role that is defined in your model. Can be left out as it will take the first one available.
      */
-    public function role(?string $role): self
+    public function role(?string $role): static
     {
         $this->role = $role;
         return $this;
@@ -38,7 +38,7 @@ class Image extends TableColumn
     /**
      * A specific crop to use for the image. Can be left out as it will take the first one available.
      */
-    public function crop(?string $crop): self
+    public function crop(?string $crop): static
     {
         $this->crop = $crop;
         return $this;
@@ -47,7 +47,7 @@ class Image extends TableColumn
     /**
      * Optional array of media parameters for more control over the rendering.
      */
-    public function mediaParams(array $params): self
+    public function mediaParams(array $params): static
     {
         $this->mediaParams = $params;
         return $this;
@@ -56,7 +56,7 @@ class Image extends TableColumn
     /**
      * If enabled the image will be rounded instead of square.
      */
-    public function rounded(bool $rounded = true): self
+    public function rounded(bool $rounded = true): static
     {
         $this->rounded = $rounded;
         return $this;

--- a/src/Services/Listings/Columns/NestedData.php
+++ b/src/Services/Listings/Columns/NestedData.php
@@ -16,7 +16,7 @@ class NestedData extends TableColumn
         return $item;
     }
 
-    public function sortable(bool $sortable = true): TableColumn
+    public function sortable(bool $sortable = true): static
     {
         if ($sortable && $this->sortFunction === null) {
             $this->order(function (Builder $builder, string $direction) {

--- a/src/Services/Listings/Columns/Relation.php
+++ b/src/Services/Listings/Columns/Relation.php
@@ -32,7 +32,7 @@ class Relation extends TableColumn
     /**
      * Set the relation that should be used.
      */
-    public function relation(string $relation): self
+    public function relation(string $relation): static
     {
         $this->relation = $relation;
         return $this;

--- a/src/Services/Listings/Filters/BasicFilter.php
+++ b/src/Services/Listings/Filters/BasicFilter.php
@@ -21,7 +21,7 @@ class BasicFilter extends TwillBaseFilter
      *
      * This is usually something you do not want to run manually.
      */
-    public function withFilterValue(mixed $value): self
+    public function withFilterValue(mixed $value): static
     {
         $this->appliedValue = $value;
 
@@ -31,7 +31,7 @@ class BasicFilter extends TwillBaseFilter
     /**
      * This removes the "All" option.
      */
-    public function withoutIncludeAll(bool $removeIncludeAll = true): self
+    public function withoutIncludeAll(bool $removeIncludeAll = true): static
     {
         $this->includeAll = !$removeIncludeAll;
 
@@ -41,7 +41,7 @@ class BasicFilter extends TwillBaseFilter
     /**
      * Sets the options that can be used to select, it should be a key->value collection.
      */
-    public function options(Collection $options): self
+    public function options(Collection $options): static
     {
         $this->options = $options;
 
@@ -51,7 +51,7 @@ class BasicFilter extends TwillBaseFilter
     /**
      * Set the default value of the filter.
      */
-    public function default(mixed $default): self
+    public function default(mixed $default): static
     {
         $this->default = $default;
 

--- a/src/Services/Listings/Filters/BelongsToFilter.php
+++ b/src/Services/Listings/Filters/BelongsToFilter.php
@@ -54,7 +54,7 @@ class BelongsToFilter extends BasicFilter
     /**
      * The relation field to use, this is usually something like "partner".
      */
-    public function field(string $fieldName): self
+    public function field(string $fieldName): static
     {
         $this->field = $fieldName;
 
@@ -75,7 +75,7 @@ class BelongsToFilter extends BasicFilter
     /**
      * The model of the relation target, if field is `partner` this would be `Partner::class`.
      */
-    public function model(string $model): self
+    public function model(string $model): static
     {
         $this->model = $model;
 
@@ -94,7 +94,7 @@ class BelongsToFilter extends BasicFilter
     /**
      * The field name that we use for displaying the item label.
      */
-    public function valueLabelField(string $valueLabelField): self
+    public function valueLabelField(string $valueLabelField): static
     {
         $this->valueLabelField = $valueLabelField;
 

--- a/src/Services/Listings/Filters/BooleanFilter.php
+++ b/src/Services/Listings/Filters/BooleanFilter.php
@@ -11,7 +11,7 @@ class BooleanFilter extends BasicFilter
     public const TRUE = 'yes';
     public const FALSE = 'no';
 
-    public static function make(): self
+    public static function make(): static
     {
         $filter = parent::make();
         $filter->options(
@@ -36,7 +36,7 @@ class BooleanFilter extends BasicFilter
         return $builder;
     }
 
-    public function field(string $fieldName): self
+    public function field(string $fieldName): static
     {
         $this->field = $fieldName;
 

--- a/src/Services/Listings/Filters/FieldSelectFilter.php
+++ b/src/Services/Listings/Filters/FieldSelectFilter.php
@@ -57,7 +57,7 @@ class FieldSelectFilter extends BasicFilter
         return $options;
     }
 
-    public function field(string $fieldName): self
+    public function field(string $fieldName): static
     {
         $this->field = $fieldName;
 
@@ -71,7 +71,7 @@ class FieldSelectFilter extends BasicFilter
     /**
      * This adds the "Without value" option if there are result with "null" value.
      */
-    public function withWithoutValueOption(bool $withoutValueOption = true): self
+    public function withWithoutValueOption(bool $withoutValueOption = true): static
     {
         $this->addWithoutValueOption = $withoutValueOption;
 

--- a/src/Services/Listings/Filters/FreeTextSearch.php
+++ b/src/Services/Listings/Filters/FreeTextSearch.php
@@ -31,14 +31,14 @@ class FreeTextSearch extends TwillBaseFilter
         return $builder;
     }
 
-    public function searchFor(string $searchString): self
+    public function searchFor(string $searchString): static
     {
         $this->searchString = $searchString;
 
         return $this;
     }
 
-    public function searchColumns(array $columns): self
+    public function searchColumns(array $columns): static
     {
         $this->searchColumns = $columns;
         return $this;

--- a/src/Services/Listings/Filters/QuickFilter.php
+++ b/src/Services/Listings/Filters/QuickFilter.php
@@ -13,7 +13,7 @@ class QuickFilter extends TwillBaseFilter
     /**
      * The callback that will tell the filter how many results there are.
      */
-    public function amount(\Closure $callback): self
+    public function amount(\Closure $callback): static
     {
         $this->amount = $callback;
 
@@ -25,7 +25,7 @@ class QuickFilter extends TwillBaseFilter
         return $this->isDefaultQuickFilter;
     }
 
-    public function default(): self
+    public function default(): static
     {
         $this->isDefaultQuickFilter = true;
 
@@ -35,7 +35,7 @@ class QuickFilter extends TwillBaseFilter
     /**
      * The scope to apply.
      */
-    public function scope(string $scope): self
+    public function scope(string $scope): static
     {
         $this->scope = $scope;
 

--- a/src/Services/Listings/Filters/TwillBaseFilter.php
+++ b/src/Services/Listings/Filters/TwillBaseFilter.php
@@ -18,7 +18,7 @@ abstract class TwillBaseFilter
     {
     }
 
-    public static function make(): self
+    public static function make(): static
     {
         return new static();
     }
@@ -26,7 +26,7 @@ abstract class TwillBaseFilter
     /**
      * Set a label to use for the filter.
      */
-    public function label(string $label): self
+    public function label(string $label): static
     {
         $this->label = $label;
 
@@ -41,7 +41,7 @@ abstract class TwillBaseFilter
     /**
      * Set the query string to use in the url
      */
-    public function queryString(string $queryString): self
+    public function queryString(string $queryString): static
     {
         $this->queryString = $queryString;
 
@@ -61,7 +61,7 @@ abstract class TwillBaseFilter
     /**
      * When passing a boolean, the filter will only be enabled when it is true.
      */
-    public function onlyEnableWhen(bool $enable = true): self
+    public function onlyEnableWhen(bool $enable = true): static
     {
         $this->enabled = $enable;
 
@@ -71,7 +71,7 @@ abstract class TwillBaseFilter
     /**
      * When passing a boolean, the filter will be disabled when it is true.
      */
-    public function disable(bool $disable = true): self
+    public function disable(bool $disable = true): static
     {
         $this->enabled = !$disable;
 
@@ -81,7 +81,7 @@ abstract class TwillBaseFilter
     /**
      * The closure to apply the filter.
      */
-    public function apply(\Closure $closure): self
+    public function apply(\Closure $closure): static
     {
         $this->apply = $closure;
 

--- a/src/Services/Listings/TableColumn.php
+++ b/src/Services/Listings/TableColumn.php
@@ -77,7 +77,7 @@ abstract class TableColumn
     /**
      * Sets the title of the column.
      */
-    public function title(?string $title): self
+    public function title(?string $title): static
     {
         $this->title = $title;
         return $this;
@@ -86,7 +86,7 @@ abstract class TableColumn
     /**
      * When enabled the column is sortable by clicking on the header.
      */
-    public function sortable(bool $sortable = true): self
+    public function sortable(bool $sortable = true): static
     {
         $this->sortable = $sortable;
         return $this;
@@ -95,7 +95,7 @@ abstract class TableColumn
     /**
      * When enabled this will be the default column the list is sorted by.
      */
-    public function sortByDefault(bool $defaultSort = true, string $direction = 'ASC'): self
+    public function sortByDefault(bool $defaultSort = true, string $direction = 'ASC'): static
     {
         $this->defaultSort = $defaultSort;
         $this->defaultSortDirection = $direction;
@@ -118,7 +118,7 @@ abstract class TableColumn
     /**
      * Makes the column optional, when set it can be hidden using the gear icon above the listing.
      */
-    public function optional(bool $optional = true): self
+    public function optional(bool $optional = true): static
     {
         $this->optional = $optional;
         return $this;
@@ -127,7 +127,7 @@ abstract class TableColumn
     /**
      * To be used with ->optional, but it will be hidden by default.
      */
-    public function hide(bool $visible = false): self
+    public function hide(bool $visible = false): static
     {
         $this->visible = $visible;
         return $this;
@@ -136,7 +136,7 @@ abstract class TableColumn
     /**
      * When enabled the content will be rendered as html.
      */
-    public function renderHtml(bool $html = true): self
+    public function renderHtml(bool $html = true): static
     {
         $this->html = $html;
         return $this;
@@ -145,13 +145,13 @@ abstract class TableColumn
     /**
      * Links the column content to a fixed url or url via the closure.
      */
-    public function linkCell(Closure|string $link): self
+    public function linkCell(Closure|string $link): static
     {
         $this->link = $link;
         return $this;
     }
 
-    public function linkToEdit(bool $linkToEdit = true): self
+    public function linkToEdit(bool $linkToEdit = true): static
     {
         $this->linkToEdit = $linkToEdit;
 
@@ -166,7 +166,7 @@ abstract class TableColumn
     /**
      * A separate sortKey if different from the field name.
      */
-    public function sortKey(?string $sortKey): self
+    public function sortKey(?string $sortKey): static
     {
         $this->sortKey = $sortKey;
         return $this;
@@ -185,7 +185,7 @@ abstract class TableColumn
      * Please note that when you are having a belongsToMany you have to carefully write your
      * join because otherwise you may end up with duplicate rows.
      */
-    public function order(\Closure $sortFunction): self
+    public function order(\Closure $sortFunction): static
     {
         $this->sortFunction = $sortFunction;
         return $this;
@@ -201,7 +201,7 @@ abstract class TableColumn
      *
      * You can use this to display for example a view or formatted date.
      */
-    public function customRender(Closure $renderFunction): self
+    public function customRender(Closure $renderFunction): static
     {
         $this->render = $renderFunction;
         return $this;


### PR DESCRIPTION
### A quick fix to silence IDE errors

I've noticed that setter methods used the self return type when returning $this. I believe it's best to return static now. This way users can extend classes without getting errors when chaining method calls.

I also removed the slugs mixin from the model interface since it is supposed to be an optional trait. Noticed it was added with the caching route fix but I'm not entirely sure why.