### PR TITLE
Missing .env line for disabling S3 storage

### DIFF
--- a/docs/src/getting-started/installation.md
+++ b/docs/src/getting-started/installation.md
@@ -94,6 +94,7 @@ IMGIX_SOURCE_HOST=source.imgix.net
 If you are not ready to use those third party services yet, can't use them, or have very limited image rendering needs, Twill also provides a local storage driver as well as a locale image rendering service powered by [Glide](https://glide.thephpleague.com/). The following .env variables should get you up and running:
 
 ```bash
+FILE_LIBRARY_ENDPOINT_TYPE=local
 MEDIA_LIBRARY_ENDPOINT_TYPE=local
 MEDIA_LIBRARY_IMAGE_SERVICE=A17\Twill\Services\MediaLibrary\Glide
 ```


### PR DESCRIPTION
## Description
Missing env variable FILE_LIBRARY_ENDPOINT_TYPE means Twill tries to utilize S3. This fix comes from a comment to issue #1530 .

## Related Issues
Addressed in #1530.
