### PR TITLE
Ignore missing or disabled modules/capsules for permissions

### DIFF
--- a/src/Exceptions/ModuleNotFoundException.php
+++ b/src/Exceptions/ModuleNotFoundException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace A17\Twill\Exceptions;
+
+class ModuleNotFoundException extends \Exception
+{
+
+}

--- a/src/Helpers/modules_helpers.php
+++ b/src/Helpers/modules_helpers.php
@@ -1,9 +1,11 @@
 <?php
 
+use Illuminate\Support\Str;
 use A17\Twill\Models\Permission;
 use Illuminate\Filesystem\Filesystem;
-use Illuminate\Support\Str;
+use A17\Twill\Facades\TwillCapsules;
 use A17\Twill\Exceptions\ModuleNotFoundException;
+use A17\Twill\Exceptions\NoCapsuleFoundException;
 
 if (! function_exists('getAllModules')) {
     function getAllModules()
@@ -31,10 +33,10 @@ if (! function_exists('getModelByModuleName')) {
     function getModelByModuleName($moduleName)
     {
         try {
-            $capsule = \A17\Twill\Facades\TwillCapsules::getCapsuleForModule($moduleName);
+            $capsule = TwillCapsules::getCapsuleForModule($moduleName);
 
             return $capsule->getModel();
-        } catch (\A17\Twill\Exceptions\NoCapsuleFoundException $e) {
+        } catch (NoCapsuleFoundException $e) {
         }
 
         $model = config('twill.namespace') . '\\Models\\' . Str::studly(Str::singular($moduleName));

--- a/src/Helpers/modules_helpers.php
+++ b/src/Helpers/modules_helpers.php
@@ -3,6 +3,7 @@
 use A17\Twill\Models\Permission;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Str;
+use A17\Twill\Exceptions\ModuleNotFoundException;
 
 if (! function_exists('getAllModules')) {
     function getAllModules()
@@ -29,9 +30,17 @@ if (! function_exists('getAllModules')) {
 if (! function_exists('getModelByModuleName')) {
     function getModelByModuleName($moduleName)
     {
+        try {
+            $capsule = \A17\Twill\Facades\TwillCapsules::getCapsuleForModule($moduleName);
+
+            return $capsule->getModel();
+        } catch (\A17\Twill\Exceptions\NoCapsuleFoundException $e) {
+        }
+
         $model = config('twill.namespace') . '\\Models\\' . Str::studly(Str::singular($moduleName));
+
         if (! class_exists($model)) {
-            throw new Exception($model . ' not existed');
+            throw new Exception($model . ' does not exist');
         }
 
         return $model;
@@ -62,7 +71,7 @@ if (! function_exists('getModelRepository')) {
         $repository = config('twill.namespace') . '\\Repositories\\' . ucfirst($model) . 'Repository';
 
         if (! class_exists($repository)) {
-            throw new Exception($repository . ' not found');
+            throw new ModuleNotFoundException($repository . ' not found');
         }
 
         return app($repository);

--- a/src/Models/Permission.php
+++ b/src/Models/Permission.php
@@ -3,6 +3,7 @@
 namespace A17\Twill\Models;
 
 use A17\Twill\Enums\PermissionLevel;
+use A17\Twill\Exceptions\ModuleNotFoundException;
 use A17\Twill\Facades\TwillPermissions;
 use Illuminate\Support\Str;
 use Illuminate\Foundation\Auth\User;
@@ -103,7 +104,11 @@ class Permission extends BaseModel
         return self::permissionableModules()->filter(function ($module) {
             return !strpos($module, '.');
         })->mapWithKeys(function ($module) {
-            return [$module => getRepositoryByModuleName($module)->get([], [], [], -1)];
+            try {
+                return [$module => getRepositoryByModuleName($module)->get([], [], [], -1)];
+            } catch (ModuleNotFoundException $e) {
+                return [];
+            }
         });
     }
 


### PR DESCRIPTION
When a package Capsule is disabled, Twill will raise a Model not found exception. This PR fixes this.