### PR TITLE
Enable resend email only when user is published

### DIFF
--- a/views/users/form.blade.php
+++ b/views/users/form.blade.php
@@ -243,7 +243,7 @@
             user_name: '{{ $item->name }}',
             registered_at: '{{ $item->isActivated() ? $item->registered_at->format('d M Y') : "Pending ({$item->created_at->format('d M Y')})" }}',
             last_login_at: '{{ $item->isActivated() && $item->last_login_at ? $item->last_login_at->format('d M Y, H:i') : null }}',
-            resend_registration_link: '{{ !$item->isActivated() ? route('twill.users.resend.registrationEmail', ['user' => $item]) : null }}',
+            resend_registration_link: '{{ $item->isPublished() && !$item->isActivated() ? route('twill.users.resend.registrationEmail', ['user' => $item]) : null }}',
             is_activated: {{ json_encode($item->isActivated()) }}
             }
         @endcan


### PR DESCRIPTION
Without this change, admins were able to resend the registration email before actually enabling the user.