### PR TITLE
Added dontAsk option to twill:make:module command

### DIFF
--- a/src/Commands/ModuleMake.php
+++ b/src/Commands/ModuleMake.php
@@ -30,6 +30,7 @@ class ModuleMake extends Command
         {--P|hasPosition}
         {--R|hasRevisions}
         {--N|hasNesting}
+        {--dontAsk}
         {--all}';
 
     /**
@@ -860,6 +861,10 @@ class ModuleMake extends Command
     {
         if (! $this->hasOption($option)) {
             return false;
+        }
+
+        if ($this->option('dontAsk')) {
+            return $this->option($option);
         }
 
         if ($this->option($option) || $this->option('all')) {


### PR DESCRIPTION
## Description

This PR adds a feature to the CLI Generator command.
You can add options to twill:make:module but you will be prompted for each not specified option.
Adding --dontAsk the command takes only the specified options and skip the others (as if you had answered no).

This could be useful if you want to automate some module creation processes.