### PR TITLE
WIP Example - basic page builder - updates

### DIFF
--- a/docs/tailwind.config.js
+++ b/docs/tailwind.config.js
@@ -33,15 +33,15 @@ module.exports = {
     colors: feConfig.color.tokens,
     borderColor: {
       ...feConfig.color.tokens,
-      ...ApplyColorVariables(feConfig.color.tokens, feConfig.color.borderColor),
+      ...ApplyColorVariables(feConfig.color.tokens, feConfig.color.border),
     },
     textColor: {
       ...feConfig.color.tokens,
-      ...ApplyColorVariables(feConfig.color.tokens, feConfig.color.textColor),
+      ...ApplyColorVariables(feConfig.color.tokens, feConfig.color.text),
     },
     backgroundColor: {
       ...feConfig.color.tokens,
-      ...ApplyColorVariables(feConfig.color.tokens, feConfig.color.backgroundColor),
+      ...ApplyColorVariables(feConfig.color.tokens, feConfig.color.background),
     },
     extend: {
       spacing: {


### PR DESCRIPTION
Updating the styles of the basic page builder so that an installed example looks a little nicer.

When doing this I followed the [quickstart](https://github.com/area17/twill/blob/3.x/docs/content/1_documentation/2_getting-started/2_installation.md#quickstart) note that points to [this guide](https://github.com/area17/twill/blob/3.x/docs/content/2_guides/1_page-builder-with-blade/1_index.md) but I found it a little confusing.

So, I've added a [readme](https://github.com/area17/twill/tree/example-basic-page-builder/examples/basic-page-builder) to the `examples/basic-page-builder` examples folder with more precise instructions to get the example running.

When doing this, I had to downgrade some versions in my `composer.json`, specifically:

```
"laravel/framework": "^9.52.4",
```
And
```
"spatie/laravel-ignition": "^1.6.4"
```

And to install Twill I had to:
```
composer require area17/twill:3.0.0-rc4
```

But, I guess this is because 3 isn't released yet (`composer require area17/twill:"^3.0"` fails`).

The new readme mentions installing front end build tools - required to run the example successfully.

It was also confusing to me to install the example and then open a browser and see a 404. So I added notes in the readme about adding content via the CMS, but, I wonder if some content can be added automatically when running `php artisan twill:install basic-page-builder`?

Also updated the docs tailwind config which seems to have got a bit out of sync with itself.