### PR TITLE
~ | Doc: add missing type declaration / change fieldsGroupsFormFieldN…

### DIFF
--- a/docs/content/1_documentation/4_form-fields/field-grouping.md
+++ b/docs/content/1_documentation/4_form-fields/field-grouping.md
@@ -63,7 +63,7 @@ class Blog extends Model {
 To store the fields you want into the json we have to update the repository:
 
 ```php
-protected $fieldsGroups = [
+protected array $fieldsGroups = [
     'external_link' => [
         'link_target',
         'link_url',
@@ -72,8 +72,8 @@ protected $fieldsGroups = [
 ];
 
 # The below can be setup optionally, documented below.
-public $fieldsGroupsFormFieldNamesAutoPrefix = false;
-public $fieldsGroupsFormFieldNameSeparator = '_';
+public bool $fieldsGroupsFormFieldNamesAutoPrefix = false;
+public string $fieldsGroupsFormFieldNameSeparator = '_';
 ```
 
 Finally in our model form we can add the fields:
@@ -103,8 +103,8 @@ Finally in our model form we can add the fields:
 In the repository file you can setup the following parameters:
 
 ```php
-public $fieldsGroupsFormFieldNamesAutoPrefix = true;
-public $fieldsGroupsFormFieldNameSeparator = '.'; // Default is _
+public bool $fieldsGroupsFormFieldNamesAutoPrefix = true;
+public string $fieldsGroupsFormFieldNameSeparator = '-'; // Default is _
 ```
 
 This will automatically group/ungroup these fields based on the separator:


### PR DESCRIPTION
…ameSeparator modified value

Missing type declaration for:
- fieldsGroups
- fieldsGroupsFormFieldNamesAutoPrefix
- fieldsGroupsFormFieldNameSeparator

Change fieldsGroupsFormFieldNameSeparator modified value from "." to "-" as "." is not working while saving due to Arr:forget() that uses dot notation in HandleFieldsGroups::handleFieldsGroups()

<!--
  Thanks for opening a PR! Your contribution is much appreciated.
  Do you have any questions? Check out the contributing docs at https://github.com/area17/twill/blob/2.x/CONTRIBUTING.md, 
  or ask in this Pull Request and a Twill maintainer will be happy to help :)
-->

## Description

<!-- Write a description of the changes introduced by this PR -->
<!-- If this is introducing a new feature, it would be great if you can create a stub for documentation including bullet points for how to use the feature, code snippets, etc. -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
