### PR TITLE
[3.x] Fix duplicate action redirect route for nested parent-child mod…

### DIFF
--- a/src/Http/Controllers/Admin/ModuleController.php
+++ b/src/Http/Controllers/Admin/ModuleController.php
@@ -1443,6 +1443,21 @@ abstract class ModuleController extends Controller
             $this->fireEvent();
             activity()->performedOn($item)->log('duplicated');
 
+            // Handle nested module.
+            if (Str::contains($this->moduleName, '.')) {
+                $moduleName = Str::afterLast($this->moduleName, '.');
+                $singularParentModuleName = Str::singular(Str::beforeLast($this->moduleName, '.'));
+
+                $parameters = [
+                    Str::singular($moduleName) => $newItem->id,
+                    $singularParentModuleName => request()->query($singularParentModuleName),
+                ];
+            } else {
+                $parameters = [
+                    Str::singular($this->moduleName) => $newItem->id,
+                ];
+            }
+            
             return Response::json([
                 'message' => twillTrans('twill::lang.listing.duplicate.success', ['modelTitle' => $this->modelTitle]),
                 'variant' => FlashLevel::SUCCESS,
@@ -1450,7 +1465,7 @@ abstract class ModuleController extends Controller
                     $this->moduleName,
                     $this->routePrefix,
                     'edit',
-                    array_filter([Str::singular($this->moduleName) => $newItem->id])
+                    array_filter($parameters)
                 ),
             ]);
         }


### PR DESCRIPTION
…ules

For nested parent-child modules, the moduleRoute() call doesn't have the required parameters as the moduleName is "plural of parent module name + . + plural of child module name" (https://twill.io/docs/3.x/crud-modules/nested-modules.html#parent-child-modules).

So, if the moduleName contains '.':
- retrieve the real module name
- compute the parent module name and retrieve the value from the request query parameters

<!--
  Thanks for opening a PR! Your contribution is much appreciated.
  Do you have any questions? Check out the contributing docs at https://github.com/area17/twill/blob/2.x/CONTRIBUTING.md, 
  or ask in this Pull Request and a Twill maintainer will be happy to help :)
-->

## Description

<!-- Write a description of the changes introduced by this PR -->
<!-- If this is introducing a new feature, it would be great if you can create a stub for documentation including bullet points for how to use the feature, code snippets, etc. -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
