### PR TITLE
[3.x] Fix duplicate block duplicate with children

### DIFF
--- a/src/Repositories/Behaviors/HandleBlocks.php
+++ b/src/Repositories/Behaviors/HandleBlocks.php
@@ -520,6 +520,7 @@ trait HandleBlocks
 
             $repository = app()->make(BlockRepository::class);
             $repository->afterDuplicate($block, $newBlock);
+            $this->afterDuplicateHandleBlocks($block, $newBlock);
         }
     }
 


### PR DESCRIPTION
The BlockRepository does not use the HandleBlocks trait, so when calling afterDuplicate(), the afterDuplicateHandleBlocks method is not found in traitsMethods() and there's no "recursivity" of blocks duplication.

A quick fix is to manually call afterDuplicateHandleBlocks() on the newly created block.