### PR TITLE
Update TwillServiceProvider.php

### DIFF
--- a/src/TwillServiceProvider.php
+++ b/src/TwillServiceProvider.php
@@ -93,7 +93,7 @@ class TwillServiceProvider extends ServiceProvider
         $this->addViewComposers();
 
         $this->check2FA();
-        
+
         Blade::componentNamespace('A17\\Twill\\View\\Components\\Partials', 'twill.partials');
         Blade::componentNamespace('A17\\Twill\\View\\Components\\Layout', 'twill.layout');
         Blade::componentNamespace('A17\\Twill\\View\\Components\\Fields', 'twill');

--- a/src/TwillServiceProvider.php
+++ b/src/TwillServiceProvider.php
@@ -93,6 +93,10 @@ class TwillServiceProvider extends ServiceProvider
         $this->addViewComposers();
 
         $this->check2FA();
+        
+        Blade::componentNamespace('A17\\Twill\\View\\Components\\Partials', 'twill.partials');
+        Blade::componentNamespace('A17\\Twill\\View\\Components\\Layout', 'twill.layout');
+        Blade::componentNamespace('A17\\Twill\\View\\Components\\Fields', 'twill');
     }
 
     private function requireHelpers(): void
@@ -118,10 +122,6 @@ class TwillServiceProvider extends ServiceProvider
         $this->registerFacades();
 
         $this->app->bind(TwillCapsules::class);
-
-        Blade::componentNamespace('A17\\Twill\\View\\Components\\Partials', 'twill.partials');
-        Blade::componentNamespace('A17\\Twill\\View\\Components\\Layout', 'twill.layout');
-        Blade::componentNamespace('A17\\Twill\\View\\Components\\Fields', 'twill');
 
         \A17\Twill\Facades\TwillBlocks::registerComponentBlocks(
             '\\App\\View\\Components\\Twill\\Blocks',


### PR DESCRIPTION
Add the blade components in the boot method so it resolves at the correct time.

Fixes https://github.com/area17/twill/issues/2222

The issue was that the blade facade was being resolved too early. Jetstream (and other packages) may register afterResolve callbacks to add blade components.

The current position of the Blade facade usage would already have it resolved before jetstream got the chance to register the afterResolve hook.