### PR TITLE
Fix `Options::fromArray` argument order

### DIFF
--- a/src/Services/Forms/Options.php
+++ b/src/Services/Forms/Options.php
@@ -16,7 +16,7 @@ class Options extends Collection
      */
     public static function fromArray(array $options): static
     {
-        return static::make(collect($options)->map(function ($key, $value) {
+        return static::make(collect($options)->map(function ($value, $key) {
             if ($value instanceof Option) {
                 return $value;
             }
@@ -24,6 +24,6 @@ class Options extends Collection
             return is_array($value)
                 ? Option::make(...$value)
                 : Option::make($key, $value);
-        }));
+        })->values());
     }
 }

--- a/tests/unit/Services/Forms/OptionsTest.php
+++ b/tests/unit/Services/Forms/OptionsTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace A17\Twill\Tests\Unit\Services\Forms;
+
+use A17\Twill\Services\Forms\Option;
+use A17\Twill\Services\Forms\Options;
+use A17\Twill\Tests\Unit\TestCase;
+
+class OptionsTest extends TestCase
+{
+    public static function inputs(): array
+    {
+        return [
+            'array of objects' => [
+                [
+                    Option::make('foo', 'Foo label'),
+                    Option::make('bar', 'Bar label', false),
+                ],
+                false,
+            ],
+
+            'array of key-value pairs' => [
+                [
+                    'foo' => 'Foo label',
+                    'bar' => 'Bar label',
+                ],
+                true,
+            ],
+
+            'array of arrays' => [
+                [
+                    [
+                        'value' => 'foo',
+                        'label' => 'Foo label',
+                    ],
+                    [
+                        'value' => 'bar',
+                        'label' => 'Bar label',
+                        'selectable' => false,
+                    ],
+                ],
+                false,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider inputs
+     */
+    public function testFromArray(array $options, bool $barShouldBeSelectable): void
+    {
+        $options = Options::fromArray($options);
+
+        $this->assertEquals([
+            [
+                'value' => 'foo',
+                'label' => 'Foo label',
+                'selectable' => true,
+            ],
+            [
+                'value' => 'bar',
+                'label' => 'Bar label',
+                'selectable' => $barShouldBeSelectable,
+            ],
+        ], $options->toArray());
+    }
+}


### PR DESCRIPTION
Fixes an issue where you could never provide an `Option` instance or array to the `fromArray` method. The second argument for Laravel collections is the array key, and that can only be a scalar value. Also added tests to verify the workings of the method.

The `->values()` addition ensures that the array is always turned into a list, in case a key-value pair is provided.
