### PR TITLE
Add HasColumns trait for checkboxes and radios

### DIFF
--- a/src/Services/Forms/Fields/Checkboxes.php
+++ b/src/Services/Forms/Fields/Checkboxes.php
@@ -3,6 +3,7 @@
 namespace A17\Twill\Services\Forms\Fields;
 
 use A17\Twill\Services\Forms\Fields\Traits\HasBorder;
+use A17\Twill\Services\Forms\Fields\Traits\HasColumns;
 use A17\Twill\Services\Forms\Fields\Traits\HasMax;
 use A17\Twill\Services\Forms\Fields\Traits\HasMin;
 use A17\Twill\Services\Forms\Fields\Traits\HasOptions;
@@ -17,6 +18,7 @@ class Checkboxes extends BaseFormField
     use HasMin;
     use Inlineable;
     use HasBorder;
+    use HasColumns;
 
     public static function make(): static
     {

--- a/src/Services/Forms/Fields/Radios.php
+++ b/src/Services/Forms/Fields/Radios.php
@@ -3,6 +3,7 @@
 namespace A17\Twill\Services\Forms\Fields;
 
 use A17\Twill\Services\Forms\Fields\Traits\HasBorder;
+use A17\Twill\Services\Forms\Fields\Traits\HasColumns;
 use A17\Twill\Services\Forms\Fields\Traits\HasOptions;
 use A17\Twill\Services\Forms\Fields\Traits\Inlineable;
 use A17\Twill\Services\Forms\Fields\Traits\IsTranslatable;
@@ -13,6 +14,7 @@ class Radios extends BaseFormField
     use HasOptions;
     use Inlineable;
     use HasBorder;
+    use HasColumns;
 
     public static function make(): static
     {

--- a/src/Services/Forms/Fields/Traits/HasColumns.php
+++ b/src/Services/Forms/Fields/Traits/HasColumns.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace A17\Twill\Services\Forms\Fields\Traits;
+
+trait HasColumns
+{
+    protected int $columns = 0;
+
+    /**
+     * The amount of column to show the option in (when using unpack).
+     */
+    public function columns(int $columns = 1): static
+    {
+        $this->columns = $columns;
+
+        return $this;
+    }
+}

--- a/src/Services/Forms/Fields/Traits/Unpackable.php
+++ b/src/Services/Forms/Fields/Traits/Unpackable.php
@@ -4,6 +4,8 @@ namespace A17\Twill\Services\Forms\Fields\Traits;
 
 trait Unpackable
 {
+    use HasColumns;
+
     protected bool $unpack = false;
 
     /**
@@ -12,16 +14,6 @@ trait Unpackable
     public function unpack(bool $unpack = true): static
     {
         $this->unpack = $unpack;
-
-        return $this;
-    }
-
-    /**
-     * The amount of column to show the option in (when using unpack).
-     */
-    public function columns(int $columns = 1): static
-    {
-        $this->columns = $columns;
 
         return $this;
     }


### PR DESCRIPTION
Per [documentation](https://twillcms.com/docs/form-fields/radios.html) for radio boxes, `columns` is a valid configuration option, but it is not possible to use it on the 'formbuilder'. This PR creates a new `HasColumns` trait that is applied to the `Radios` and `Checkboxes` class.