### PR TITLE
~ | Block::forComponent(): missing call to $componentClass::getBlockIcon()

### DIFF
--- a/src/Services/Blocks/Block.php
+++ b/src/Services/Blocks/Block.php
@@ -154,6 +154,7 @@ class Block
         );
 
         $class->title = $componentClass::getBlockTitle();
+        $class->icon = $componentClass::getBlockIcon();
         $class->rulesForTranslatedFields = (new $componentClass())->getTranslatableValidationRules();
         $class->rules = (new $componentClass())->getValidationRules();
 

--- a/src/Services/Blocks/Block.php
+++ b/src/Services/Blocks/Block.php
@@ -157,7 +157,6 @@ class Block
         $class->icon = $componentClass::getBlockIcon();
         $class->titleField = $componentClass::getBlockTitleField();
         $class->hideTitlePrefix = $componentClass::shouldHidePrefix();
-
         $class->rulesForTranslatedFields = (new $componentClass())->getTranslatableValidationRules();
         $class->rules = (new $componentClass())->getValidationRules();
 


### PR DESCRIPTION
Using TwillBlockComponent for a Block, the static method getBlockIcon() is never called, so its icon is always the default 'text'