### PR TITLE
closing bracket missing

### DIFF
--- a/docs/content/1_docs/4_form-fields/02_wysiwyg.md
+++ b/docs/content/1_docs/4_form-fields/02_wysiwyg.md
@@ -52,7 +52,7 @@ Wysiwyg::make()
 @formField('wysiwyg', [
     'name' => 'case_study',
     'label' => 'Case study text',
-    'toolbarOptions' => [ [ 'header' => [1, 2, false] ],
+    'toolbarOptions' => [ [ 'header' => [1, 2, false] ] ],
     'placeholder' => 'Case study text',
     'maxlength' => 200,
     'editSource' => true,


### PR DESCRIPTION
The closing bracket on the toolbarOptions for the directive example is missing.
