### PR TITLE
Additional explanation on migration for Input field type.

### DIFF
--- a/docs/content/1_docs/4_form-fields/01_input.md
+++ b/docs/content/1_docs/4_form-fields/01_input.md
@@ -121,4 +121,4 @@ Schema::table('articles', function (Blueprint $table) {
 });
 ```
 
-When used in a [block](../5_block-editor), no migration is needed, as data contained in blocks, including componentBlocks, is stored in a separate table from the model.
+When used in a [block](../5_block-editor), no migration is needed, as data contained in blocks, including componentBlocks, is stored in a separate table from the model, which is managed by Twill for you.

--- a/docs/content/1_docs/4_form-fields/01_input.md
+++ b/docs/content/1_docs/4_form-fields/01_input.md
@@ -121,4 +121,4 @@ Schema::table('articles', function (Blueprint $table) {
 });
 ```
 
-When used in a [block](../5_block-editor), no migration is needed.
+When used in a [block](../5_block-editor), no migration is needed, as data contained in blocks, including componentBlocks, is stored in a separate table from the model.


### PR DESCRIPTION
Thought it might be useful to briefly explain why no migration is required when using this field in a block.

I think it likely that one of the first things that people would be doing when exploring Twill, is creating forms, and this would be one of the first fields they would likely be using, so this PR points them to an important concept in Twill.

<!--
  Thanks for opening a PR! Your contribution is much appreciated.
  Do you have any questions? Check out the contributing docs at https://github.com/area17/twill/blob/3.x/CONTRIBUTING.md, or ask in this Pull Request and a Twill maintainer will be happy to help :)
-->


