### PR TITLE
Two misspellings...

### DIFF
--- a/docs/content/2_guides/1_page-builder-with-blade/9_adding-navigation.md
+++ b/docs/content/2_guides/1_page-builder-with-blade/9_adding-navigation.md
@@ -300,7 +300,7 @@ class file will hold our php logic, and the blade file will do the rendering.
 
 Again, we can use a command to do most of the work: `php artisan make:component Menu`
 
-This will generate the class `app/View/Components/Menu.php` and the blade file `resources/views/components/menu.php`.
+This will generate the class `app/View/Components/Menu.php` and the blade file `resources/views/components/menu.blade.php`.
 
 ### Preparing the tree
 
@@ -349,7 +349,7 @@ class Menu extends Component
 }
 ```
 
-So what we do here is requirest the tree of published menu links, then we send it to our components view file as "links"
+So what we do here is request the tree of published menu links, then we send it to our components view file as "links"
 .
 
 This will expose the `$links` variable to the blade file that we will now write.
@@ -358,7 +358,7 @@ This will expose the `$links` variable to the blade file that we will now write.
 
 Now that we have the necessary data in our blade file, we can write the markup.
 
-We will change the contents of `resources/views/components/menu.php` to this:
+We will change the contents of `resources/views/components/menu.blade.php` to this:
 
 ```phptorch
 {


### PR DESCRIPTION
Changed `menu.php` to `menu.blade.php` and fixed typo from "requirest" to "request". I assume that's what was intended. Unless you were going for the old english...

<!--
  Thanks for opening a PR! Your contribution is much appreciated.
  Do you have any questions? Check out the contributing docs at https://github.com/area17/twill/blob/3.x/CONTRIBUTING.md, or ask in this Pull Request and a Twill maintainer will be happy to help :)
-->

## Description

<!-- Write a description of the changes introduced by this PR -->
<!-- If this is introducing a new feature, it would be great if you can create a stub for documentation including bullet points for how to use the feature, code snippets, etc. -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
