### PR TITLE
Add title prefix support to component blocks.

### DIFF
--- a/src/Services/Blocks/Block.php
+++ b/src/Services/Blocks/Block.php
@@ -154,6 +154,8 @@ class Block
         );
 
         $class->title = $componentClass::getBlockTitle();
+        $class->titleField = $componentClass::getBlockTitleField();
+        $class->hideTitlePrefix = $componentClass::shouldHidePrefix();
         $class->rulesForTranslatedFields = (new $componentClass())->getTranslatableValidationRules();
         $class->rules = (new $componentClass())->getValidationRules();
 

--- a/src/View/Components/Blocks/TwillBlockComponent.php
+++ b/src/View/Components/Blocks/TwillBlockComponent.php
@@ -81,10 +81,22 @@ abstract class TwillBlockComponent extends Component
     }
 
     /**
-     * The $block argument is optional as there may not be a block yet.
-     * You will have to write your own condition if you want to utilize data from the block.
+     * You can use this method to use a form field to get the title of the block in the used blocks list.
+     *
+     * By default this will be prefixed with getBlockTitle, you can disable that by returning true in shouldHidePrefix.
      */
-    public static function getBlockTitle(?Block $block = null): string
+    public static function getBlockTitleField(): ?string {
+        return null;
+    }
+
+    /**
+     * If the prefix should be hidden when using getBlockTitleField.
+     */
+    public static function shouldHidePrefix(): bool {
+        return false;
+    }
+
+    public static function getBlockTitle(): string
     {
         return Str::replace('Block', '', Str::afterLast(static::class, '\\'));
     }


### PR DESCRIPTION
This pr allows component blocks to set the title prefix and title field:

```php
<?php

namespace App\View\Components\Twill\Blocks;

use A17\Twill\Services\Forms\Fields\BlockEditor;
use A17\Twill\Services\Forms\Fields\Wysiwyg;
use A17\Twill\Services\Forms\Form;
use A17\Twill\Services\Forms\Fields\Input;
use A17\Twill\View\Components\Blocks\TwillBlockComponent;
use Illuminate\Contracts\View\View;

class Demo extends TwillBlockComponent
{
    public static function getBlockTitleField(): ?string
    {
        return 'title';
    }

    public static function shouldHidePrefix(): bool {
        return true;
    }

    public function getForm(): Form
    {
        return Form::make([
            Input::make()->name('title'),
            Wysiwyg::make()->name('text'),
            BlockEditor::make()->name('left')
        ]);
    }

    public function render(): View
    {
        return view('components.twill.blocks.demo');
    }

}
```