### PR TITLE
fix: typo in create modal docs

### DIFF
--- a/docs/content/2_guides/3_adding-fields-to-the-create-modal.md
+++ b/docs/content/2_guides/3_adding-fields-to-the-create-modal.md
@@ -47,7 +47,7 @@ class BlogController extends BaseModuleController
                 ->onChange('formatPermalink'),
             Wysiwyg::make()
                 ->name('description')
-                ->label('Descrription')
+                ->label('Description')
                 ->translatable(),
             Input::make()
                 ->name('slug')


### PR DESCRIPTION
<!--
  Thanks for opening a PR! Your contribution is much appreciated.
  Do you have any questions? Check out the contributing docs at https://github.com/area17/twill/blob/3.x/CONTRIBUTING.md, or ask in this Pull Request and a Twill maintainer will be happy to help :)
-->

## Description

<!-- Write a description of the changes introduced by this PR -->
<!-- If this is introducing a new feature, it would be great if you can create a stub for documentation including bullet points for how to use the feature, code snippets, etc. -->

Fixed a typo in the create modal docs, removed an additional `r` in `Description`.
