### PR TITLE
Corrected option definition time24h

### DIFF
--- a/docs/content/1_docs/4_form-fields/07_datepicker.md
+++ b/docs/content/1_docs/4_form-fields/07_datepicker.md
@@ -46,7 +46,7 @@ DatePicker::make()
 | minDate         | Minimum selectable date                                                                                                  | string      |               |
 | maxDate         | Maximum selectable date                                                                                                  | string      |               |
 | withTime        | Define if the field will display the time selector                                                                       | boolean     | true          |
-| time24Hr        | Pick time with a 24h picker instead of AM/PM                                                                             | boolean     | false         |
+| time24h         | Pick time with a 24h picker instead of AM/PM                                                                             | boolean     | false         |
 | allowClear      | Adds a button to clear the field                                                                                         | boolean     | false         |
 | allowInput      | Allow manually editing the selected date in the field                                                                    | boolean     | false         |
 | altFormat       | Format used by [flatpickr](https://flatpickr.js.org/formatting/)                                                         | string      | F j, Y        |


### PR DESCRIPTION
## Description

The option `time24Hr` is incorrectly documented.  The option is actually defined as `time24h` in the DatePicker class.

While the DatePicker class does use the property/variable $time24Hr, I am assuming the option method was changed to `time24h` in v3 for a reason and the documentation is incorrect.

Alternatively this PR could be rejected and the method could be updated to match the documentation.