### PR TITLE
Handling groups of fields fix

### DIFF
--- a/src/Repositories/Behaviors/HandleFieldsGroups.php
+++ b/src/Repositories/Behaviors/HandleFieldsGroups.php
@@ -119,7 +119,7 @@ trait HandleFieldsGroups
                 $fields[$group] = null;
             }
 
-            Arr::forget($fields, $groupFields);
+            $fields = array_filter($fields, fn($key) => !in_array($key, $groupFields), ARRAY_FILTER_USE_KEY);
         }
 
         return $fields;


### PR DESCRIPTION
If I use a dot as `fieldsGroupsFormFieldNameSeparator` some values in a group is not saves because laravel's method `Arr::forget` has a deep removing functionality which is not necessary here.