### PR TITLE
Fix wrong property name in 12_nested-modules.md

### DIFF
--- a/docs/content/1_docs/3_modules/12_nested-modules.md
+++ b/docs/content/1_docs/3_modules/12_nested-modules.md
@@ -161,7 +161,7 @@ class IssueArticleController extends BaseModuleController
                 NestedBreadcrumbs::make()
                     ->forParent(
                         parentModule: 'issues',
-                        module: $this->modelName,
+                        module: $this->moduleName,
                         activeParentId: request('issue'),
                         repository: \App\Repositories\IssueRepository::class
                     )


### PR DESCRIPTION
Changed wrong property name in the documentation.
