### PR TITLE
Changed example value to better reflect given example on 16_field-gro…

### DIFF
--- a/docs/content/1_docs/4_form-fields/16_field-grouping.md
+++ b/docs/content/1_docs/4_form-fields/16_field-grouping.md
@@ -104,7 +104,7 @@ In the repository file you can setup the following parameters:
 
 ```php
 public bool $fieldsGroupsFormFieldNamesAutoPrefix = true;
-public string $fieldsGroupsFormFieldNameSeparator = '-'; // Default is _
+public string $fieldsGroupsFormFieldNameSeparator = '.'; // Default is _
 ```
 
 This will automatically group/ungroup these fields based on the separator:


### PR DESCRIPTION
In Field Grouping documentation examples show $fieldsGroupsFormFieldNameSeparator variable with "-" value, but blade example bellow it uses a dot. I would suggest to change example variable value to ".", or to alter blade example to use "-" instead of ".".