### PR TITLE
* | Dashboard: add Fathom Analytics support

### DIFF
--- a/frontend/js/components/dashboard/statFeed.vue
+++ b/frontend/js/components/dashboard/statFeed.vue
@@ -38,9 +38,6 @@
       </a>
       </template>
     </div>
-    <footer class="box__footer statFeed__footer">
-      <a href="https://analytics.google.com/analytics/web" class="f--external" target="_blank">Google Analytics</a>
-    </footer>
   </div>
 </template>
 


### PR DESCRIPTION
## Description

Twill dashboard allows only Google Analytics as analytics solution.

This PR add Fathom Analytics support (https://usefathom.com)

To enable Fathom Analytics service, the following configuration is needed:

```
    'dashboard' => [
        'analytics' => [
            'enabled' => true,
            'service' => 'fathom',
            'fathom' => [
                'api_token' => '11222233333',
                'site_id' => 'FATHOMSITEID',
            ],
        ],
    ],
```

Procedure to get an API token: https://usefathom.com/api