### PR TITLE
Patched the moduleRoute helper so that it will rely on the config value

### DIFF
--- a/config/dashboard.php
+++ b/config/dashboard.php
@@ -12,7 +12,7 @@ return [
      */
     'modules' => [],
     'analytics' => ['enabled' => false],
-    'search_endpoint' => 'twill.search',
+    'search_endpoint' => config('twill.admin_route_name_prefix') . 'search',
 
     /*
     |--------------------------------------------------------------------------

--- a/docs/content/3_blog/2_twill-3-introducing-oop-builders.md
+++ b/docs/content/3_blog/2_twill-3-introducing-oop-builders.md
@@ -212,7 +212,7 @@ similar to that of the settings registration. In the app service provider we can
 TwillNavigation::addLink(
     NavigationLink::make()->forModule('blogs')->title('Blogs')
         ->setChildren([
-            NavigationLink::make()->forRoute('twill.app.settings.page', ['group' => 'blog'])->title('Blog settings'),
+            NavigationLink::make()->forRoute(config('twill.admin_route_name_prefix') . 'app.settings.page', ['group' => 'blog'])->title('Blog settings'),
         ])
 );
 

--- a/src/Commands/ListIcons.php
+++ b/src/Commands/ListIcons.php
@@ -72,7 +72,7 @@ class ListIcons extends Command
             ) {
                 return [
                     'name' => Str::before($file->getFilename(), '.svg'),
-                    'url' => route('twill.icons.show', [
+                    'url' => route(config('twill.admin_route_name_prefix') . 'icons.show', [
                         'file' => $file->getFilename(),
                     ]),
                 ];
@@ -92,7 +92,7 @@ class ListIcons extends Command
         });
 
         $this->table(['Icon', 'Preview URL'], $icons->toArray());
-        $this->info('All icons viewable at: ' . route('twill.icons.index'));
+        $this->info('All icons viewable at: ' . route(config('twill.admin_route_name_prefix') . 'icons.index'));
 
         return parent::handle();
     }

--- a/src/Helpers/routes_helpers.php
+++ b/src/Helpers/routes_helpers.php
@@ -21,7 +21,7 @@ if (! function_exists('moduleRoute')) {
         }
 
         // Create base route name
-        $routeName = config('twill.admin_route_name_prefix') . ($prefix ? $prefix . '.' : '');
+				$routeName = config('twill.admin_route_name_prefix') . ($prefix ? $prefix . '.' : '');
 
         // Prefix it with module name only if prefix doesn't contains it already
         if (

--- a/src/Helpers/routes_helpers.php
+++ b/src/Helpers/routes_helpers.php
@@ -21,7 +21,7 @@ if (! function_exists('moduleRoute')) {
         }
 
         // Create base route name
-        $routeName = 'twill.' . ($prefix ? $prefix . '.' : '');
+				$routeName = config('twill.admin_route_name_prefix') . ($prefix ? $prefix . '.' : '');
 
         // Prefix it with module name only if prefix doesn't contains it already
         if (

--- a/src/Http/Controllers/Admin/AppSettingsController.php
+++ b/src/Http/Controllers/Admin/AppSettingsController.php
@@ -78,7 +78,7 @@ class AppSettingsController extends ModuleController
     protected function getModuleRoute($id, $action): ?string
     {
         if ($action === 'update') {
-            return route('twill.app.settings.update', $id);
+            return route(config('twill.admin_route_name_prefix') . 'app.settings.update', $id);
         }
 
         return null;

--- a/src/Http/Controllers/Admin/FileLibraryController.php
+++ b/src/Http/Controllers/Admin/FileLibraryController.php
@@ -8,6 +8,7 @@ use A17\Twill\Services\Listings\Filters\TableFilters;
 use A17\Twill\Services\Uploader\SignAzureUpload;
 use A17\Twill\Services\Uploader\SignS3Upload;
 use A17\Twill\Services\Uploader\SignUploadListener;
+use Aws\S3\S3Client;
 use Illuminate\Config\Repository as Config;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Contracts\Foundation\Application;
@@ -16,6 +17,7 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Routing\ResponseFactory;
 use Illuminate\Routing\UrlGenerator;
+use Illuminate\Support\Facades\Storage;
 
 class FileLibraryController extends ModuleController implements SignUploadListener
 {
@@ -145,9 +147,9 @@ class FileLibraryController extends ModuleController implements SignUploadListen
                     'destroy',
                     $item->id
                 ) : null,
-                'updateUrl' => $this->urlGenerator->route('twill.file-library.files.single-update'),
-                'updateBulkUrl' => $this->urlGenerator->route('twill.file-library.files.bulk-update'),
-                'deleteBulkUrl' => $this->urlGenerator->route('twill.file-library.files.bulk-delete'),
+                'updateUrl' => $this->urlGenerator->route(config('twill.admin_route_name_prefix') . 'file-library.files.single-update'),
+                'updateBulkUrl' => $this->urlGenerator->route(config('twill.admin_route_name_prefix') . 'file-library.files.bulk-update'),
+                'deleteBulkUrl' => $this->urlGenerator->route(config('twill.admin_route_name_prefix') . 'file-library.files.bulk-delete'),
             ];
     }
 
@@ -285,6 +287,43 @@ class FileLibraryController extends ModuleController implements SignUploadListen
             })->toArray(),
             'tags' => $this->repository->getTagsList(),
         ], 200);
+    }
+
+    /**
+     * @param Request $request
+     * @return string
+     */
+    public function getStaticLink(Request $request) {
+        $disk = $this->config->get('twill.media_library.disk');
+        $diskConfig = config('filesystems.disks.' . $disk);
+
+        $client = new S3Client([
+            'credentials' => [
+                'key'    => $diskConfig['key'],
+                'secret' => $diskConfig['secret']
+            ],
+            'region' => $diskConfig['region'],
+            'version' => 'latest'
+        ]);
+
+        // does this object have public-read?
+        $public = collect($client->getObjectAcl([
+            'Bucket' => $diskConfig['bucket'], // REQUIRED
+            'Key' => $request->uuid, // REQUIRED
+        ])->search('Grants'))
+            ->where('Permission','READ')
+            ->where('Grantee.URL','http://acs.amazonaws.com/groups/global/AllUsers')
+            ->isNotEmpty();
+
+        if(!$public) {
+            $client->putObjectAcl([
+                'ACL' => 'public-read',
+                'Bucket' => $diskConfig['bucket'], // REQUIRED
+                'Key' => $request->uuid, // REQUIRED
+            ]);
+        }
+
+        return Storage::disk($disk)->url($request->uuid);
     }
 
     /**

--- a/src/Http/Controllers/Admin/IconsController.php
+++ b/src/Http/Controllers/Admin/IconsController.php
@@ -40,7 +40,7 @@ class IconsController extends Controller
 
                 return [
                     'name' => Str::before($file->getFilename(), '.svg'),
-                    'url' => route('twill.icons.show', [
+                    'url' => route(config('twill.admin_route_name_prefix') . 'icons.show', [
                         'file' => $file->getFilename(),
                     ]),
                 ];

--- a/src/Http/Controllers/Admin/LoginController.php
+++ b/src/Http/Controllers/Admin/LoginController.php
@@ -124,7 +124,7 @@ class LoginController extends Controller
 
         $request->session()->regenerateToken();
 
-        return $this->redirector->to(route('twill.login'));
+        return $this->redirector->to(route(config('twill.admin_route_name_prefix') . 'login'));
     }
 
     /**
@@ -143,7 +143,7 @@ class LoginController extends Controller
 
             $request->session()->put('2fa:user:id', $user->id);
 
-            return $this->redirector->to(route('twill.login-2fa.form'));
+            return $this->redirector->to(route(config('twill.admin_route_name_prefix') . 'login-2fa.form'));
         }
 
         $user->last_login_at = Carbon::now();
@@ -153,7 +153,7 @@ class LoginController extends Controller
             $this->logout($request);
             $token = Password::broker('twill_users')->getRepository()->create($user);
 
-            return $this->redirector->to(route('twill.password.reset.form', $token))->withErrors([
+            return $this->redirector->to(route(config('twill.admin_route_name_prefix') . 'password.reset.form', $token))->withErrors([
                 'error' => 'Your password needs to be reset before login',
             ]);
         }
@@ -190,7 +190,7 @@ class LoginController extends Controller
             return $this->redirector->intended($this->redirectTo);
         }
 
-        return $this->redirector->to(route('twill.login-2fa.form'))->withErrors([
+        return $this->redirector->to(route(config('twill.admin_route_name_prefix') . 'login-2fa.form'))->withErrors([
             'error' => 'Your one time password is invalid.',
         ]);
     }
@@ -230,7 +230,7 @@ class LoginController extends Controller
                 $request->session()->put('oauth:user_id', $user->id);
                 $request->session()->put('oauth:user', $oauthUser);
                 $request->session()->put('oauth:provider', $provider);
-                return $this->redirector->to(route('twill.login.oauth.showPasswordForm'));
+                return $this->redirector->to(route(config('twill.admin_route_name_prefix') . 'login.oauth.showPasswordForm'));
             } else {
                 $user->linkProvider($oauthUser, $provider);
 

--- a/src/Http/Controllers/Admin/ModuleController.php
+++ b/src/Http/Controllers/Admin/ModuleController.php
@@ -2233,7 +2233,7 @@ abstract class ModuleController extends Controller
                 'editor' => Config::get('twill.enabled.block-editor') && $this->moduleHas(
                     'blocks'
                 ) && ! $this->disableEditor,
-                'blockPreviewUrl' => Route::has('twill.blocks.preview') ? URL::route('twill.blocks.preview') : '#',
+                'blockPreviewUrl' => Route::has('twill.blocks.preview') ? URL::route(config('twill.admin_route_name_prefix') . 'blocks.preview') : '#',
                 'revisions' => $this->moduleHas('revisions') ? $item->revisionsArray() : null,
                 'submitOptions' => $this->getSubmitOptions($item),
                 'groupUserMapping' => $this->getGroupUserMapping(),

--- a/src/Http/Controllers/Admin/ResetPasswordController.php
+++ b/src/Http/Controllers/Admin/ResetPasswordController.php
@@ -114,7 +114,7 @@ class ResetPasswordController extends Controller
             ]);
         }
 
-        return $this->redirector->to(route('twill.password.reset.link'))->withErrors([
+        return $this->redirector->to(route(config('twill.admin_route_name_prefix') . 'password.reset.link'))->withErrors([
             'token' => 'Your password reset token has expired or could not be found, please retry.',
         ]);
     }
@@ -137,7 +137,7 @@ class ResetPasswordController extends Controller
             ]);
         }
 
-        return $this->redirector->to(route('twill.password.reset.link'))->withErrors([
+        return $this->redirector->to(route(config('twill.admin_route_name_prefix') . 'password.reset.link'))->withErrors([
             'token' => 'Your password reset token has expired or could not be found, please retry.',
         ]);
     }

--- a/src/Http/Controllers/Admin/SettingController.php
+++ b/src/Http/Controllers/Admin/SettingController.php
@@ -69,7 +69,7 @@ class SettingController extends Controller
             'section' => $section,
             'form_fields' => $this->settings->getFormFieldsForSection($section),
             'formBuilder' => Form::make(),
-            'saveUrl' => $this->urlGenerator->route('twill.settings.update', $section),
+            'saveUrl' => $this->urlGenerator->route(config('twill.admin_route_name_prefix') . 'settings.update', $section),
             'translate' => true,
         ])
         : $this->redirector->back();

--- a/src/Http/Controllers/Admin/UserController.php
+++ b/src/Http/Controllers/Admin/UserController.php
@@ -310,7 +310,7 @@ class UserController extends ModuleController
             Password::broker('twill_users')->getRepository()->create($user)
         );
 
-        return redirect()->route('twill.users.edit', ['user' => $user])->with(
+        return redirect()->route(config('twill.admin_route_name_prefix') . 'users.edit', ['user' => $user])->with(
             'status',
             'Registration email has been sent to the user!'
         );

--- a/src/Http/Middleware/Authenticate.php
+++ b/src/Http/Middleware/Authenticate.php
@@ -26,7 +26,7 @@ class Authenticate extends Middleware
             Auth::logout();
             return $request->expectsJson()
                 ? abort(403, 'Your account is not verified.')
-                : Redirect::guest(URL::route('twill.login.form'));
+                : Redirect::guest(URL::route(config('twill.admin_route_name_prefix') . 'login.form'));
         }
 
         return $next($request);
@@ -37,6 +37,6 @@ class Authenticate extends Middleware
      */
     protected function redirectTo($request)
     {
-        return route('twill.login.form');
+        return route(config('twill.admin_route_name_prefix') . 'login.form');
     }
 }

--- a/src/Http/ViewComposers/FilesUploaderConfig.php
+++ b/src/Http/ViewComposers/FilesUploaderConfig.php
@@ -46,7 +46,7 @@ class FilesUploaderConfig
         // the execution of the appropriate implementation
         $endpointByType = [
             'local' => function () {
-                return $this->urlGenerator->route('twill.file-library.files.store');
+                return $this->urlGenerator->route(config('twill.admin_route_name_prefix') . 'file-library.files.store');
             },
             's3' => function () use ($libraryDisk) {
                 return s3Endpoint($libraryDisk);
@@ -58,14 +58,14 @@ class FilesUploaderConfig
 
         $signatureEndpointByType = [
             'local' => null,
-            's3' => $this->urlGenerator->route('twill.file-library.sign-s3-upload'),
-            'azure' => $this->urlGenerator->route('twill.file-library.sign-azure-upload'),
+            's3' => $this->urlGenerator->route(config('twill.admin_route_name_prefix') . 'file-library.sign-s3-upload'),
+            'azure' => $this->urlGenerator->route(config('twill.admin_route_name_prefix') . 'file-library.sign-azure-upload'),
         ];
 
         $filesUploaderConfig = [
             'endpointType' => $endpointType,
             'endpoint' => $endpointByType[$endpointType](),
-            'successEndpoint' => $this->urlGenerator->route('twill.file-library.files.store'),
+            'successEndpoint' => $this->urlGenerator->route(config('twill.admin_route_name_prefix') . 'file-library.files.store'),
             'signatureEndpoint' => $signatureEndpointByType[$endpointType],
             'endpointBucket' => $this->config->get('filesystems.disks.' . $libraryDisk . '.bucket', 'none'),
             'endpointRegion' => $this->config->get('filesystems.disks.' . $libraryDisk . '.region', 'none'),

--- a/src/Http/ViewComposers/MediasUploaderConfig.php
+++ b/src/Http/ViewComposers/MediasUploaderConfig.php
@@ -46,7 +46,7 @@ class MediasUploaderConfig
         // the execution of the appropriate implementation
         $endpointByType = [
             'local' => function () {
-                return $this->urlGenerator->route('twill.media-library.medias.store');
+                return $this->urlGenerator->route(config('twill.admin_route_name_prefix') . 'media-library.medias.store');
             },
             's3' => function () use ($libraryDisk) {
                 return s3Endpoint($libraryDisk);
@@ -58,14 +58,14 @@ class MediasUploaderConfig
 
         $signatureEndpointByType = [
             'local' => null,
-            's3' => $this->urlGenerator->route('twill.media-library.sign-s3-upload'),
-            'azure' => $this->urlGenerator->route('twill.media-library.sign-azure-upload'),
+            's3' => $this->urlGenerator->route(config('twill.admin_route_name_prefix') . 'media-library.sign-s3-upload'),
+            'azure' => $this->urlGenerator->route(config('twill.admin_route_name_prefix') . 'media-library.sign-azure-upload'),
         ];
 
         $mediasUploaderConfig = [
             'endpointType' => $endpointType,
             'endpoint' => $endpointByType[$endpointType](),
-            'successEndpoint' => $this->urlGenerator->route('twill.media-library.medias.store'),
+            'successEndpoint' => $this->urlGenerator->route(config('twill.admin_route_name_prefix') . 'media-library.medias.store'),
             'signatureEndpoint' => $signatureEndpointByType[$endpointType],
             'endpointBucket' => $this->config->get('filesystems.disks.' . $libraryDisk . '.bucket', 'none'),
             'endpointRegion' => $this->config->get('filesystems.disks.' . $libraryDisk . '.region', 'none'),

--- a/src/Models/Media.php
+++ b/src/Models/Media.php
@@ -7,16 +7,10 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 
-use HMTwill\Models\Behaviors\HasSchema;
-
 class Media extends Model
 {
 
-    use HasSchema;
-
     public $timestamps = true;
-
-    public $schemaType = 'imageObject';
 
     protected $fillable = [
         'uuid',

--- a/src/Models/Media.php
+++ b/src/Models/Media.php
@@ -7,9 +7,16 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 
+use HMTwill\Models\Behaviors\HasSchema;
+
 class Media extends Model
 {
+
+    use HasSchema;
+
     public $timestamps = true;
+
+    public $schemaType = 'imageObject';
 
     protected $fillable = [
         'uuid',
@@ -60,15 +67,11 @@ class Media extends Model
         return DB::table(config('twill.mediables_table', 'twill_mediables'))->where('media_id', $this->id)->count() === 0;
     }
 
-    public function isReferenced()
-    {
-        return DB::table(config('twill.mediables_table', 'twill_mediables'))->where('media_id', $this->id)->count() > 0;
-    }
-
     public function toCmsArray()
     {
         return [
             'id' => $this->id,
+            'uuid' => $this->uuid,
             'name' => $this->filename,
             'thumbnail' => ImageService::getCmsUrl($this->uuid, ['h' => '256']),
             'original' => ImageService::getRawUrl($this->uuid),
@@ -79,9 +82,9 @@ class Media extends Model
                 return $tag->name;
             }),
             'deleteUrl' => $this->canDeleteSafely() ? moduleRoute('medias', 'media-library', 'destroy', $this->id) : null,
-            'updateUrl' => route('twill.media-library.medias.single-update'),
-            'updateBulkUrl' => route('twill.media-library.medias.bulk-update'),
-            'deleteBulkUrl' => route('twill.media-library.medias.bulk-delete'),
+            'updateUrl' => route(config('twill.admin_route_name_prefix') . 'media-library.medias.single-update'),
+            'updateBulkUrl' => route(config('twill.admin_route_name_prefix') . 'media-library.medias.bulk-update'),
+            'deleteBulkUrl' => route(config('twill.admin_route_name_prefix') . 'media-library.medias.bulk-delete'),
             'metadatas' => [
                 'default' => [
                     'caption' => $this->caption,

--- a/src/Notifications/PasswordResetByAdmin.php
+++ b/src/Notifications/PasswordResetByAdmin.php
@@ -10,7 +10,7 @@ class PasswordResetByAdmin extends ResetPassword
     public function toMail($notifiable)
     {
         return (new MailMessage())->markdown('twill::emails.html.email', [
-            'url' => route('twill.login.form'),
+            'url' => route(config('twill.admin_route_name_prefix') . 'login.form'),
             'actionText' => 'Login',
             'copy' => 'You are receiving this email because your password has been changed by Admin.',
         ]);

--- a/src/Notifications/Reset.php
+++ b/src/Notifications/Reset.php
@@ -20,7 +20,7 @@ class Reset extends ResetPassword
                 'appName' => config('app.name')
             ]))
             ->markdown('twill::emails.html.email', [
-                'url' => route('twill.password.reset.form', $this->token),
+                'url' => route(config('twill.admin_route_name_prefix') . 'password.reset.form', $this->token),
                 'actionText' => twillTrans('twill::lang.notifications.reset.action'),
                 'copy' => twillTrans('twill::lang.notifications.reset.content'),
             ]);

--- a/src/Notifications/TemporaryPassword.php
+++ b/src/Notifications/TemporaryPassword.php
@@ -10,7 +10,7 @@ class TemporaryPassword extends ResetPassword
     public function toMail($notifiable)
     {
         return (new MailMessage())->markdown('twill::emails.html.email', [
-            'url' => route('twill.login.form'),
+            'url' => route(config('twill.admin_route_name_prefix') . 'login.form'),
             'actionText' => 'Login',
             'copy' => 'You are receiving this email because your password has been changed to: ' . $this->token,
         ]);

--- a/src/Notifications/Welcome.php
+++ b/src/Notifications/Welcome.php
@@ -20,7 +20,7 @@ class Welcome extends ResetPassword
                 'appName' => config('app.name')
             ]))
             ->markdown('twill::emails.html.email', [
-                'url' => route('twill.password.reset.welcome.form', $this->token),
+                'url' => route(config('twill.admin_route_name_prefix') . 'password.reset.welcome.form', $this->token),
                 'actionText' => twillTrans('twill::lang.notifications.welcome.action'),
                 'title' => twillTrans('twill::lang.notifications.welcome.title'),
                 'copy' => twillTrans('twill::lang.notifications.welcome.content', ['name' => config('app.name')]),

--- a/src/Services/Settings/SettingsGroup.php
+++ b/src/Services/Settings/SettingsGroup.php
@@ -53,7 +53,7 @@ class SettingsGroup
 
     public function getRoute(): string
     {
-        return 'twill.app.settings.page';
+			return config('twill.admin_route_name_prefix') . 'app.settings.page';
     }
 
     public function getHref(): string

--- a/src/View/Components/Navigation/NavigationLink.php
+++ b/src/View/Components/Navigation/NavigationLink.php
@@ -114,7 +114,7 @@ class NavigationLink extends Component
             $this->title(Str::title($module));
         }
 
-        $this->route = 'twill.' . $module;
+        $this->route = config('twill.admin_route_name_prefix') . $module;
 
         return $this;
     }
@@ -175,7 +175,7 @@ class NavigationLink extends Component
             $routeMatcher = Str::plural($moduleName);
         }
 
-        return 'twill.' . TwillRoutes::getModuleRouteFromRegistry(
+        return config('twill.admin_route_name_prefix') . TwillRoutes::getModuleRouteFromRegistry(
             Str::camel($routeMatcher)
         ) . '.' . ($action ?? 'index');
     }

--- a/tests/integration/AnonymousModulesTest.php
+++ b/tests/integration/AnonymousModulesTest.php
@@ -12,13 +12,13 @@ class AnonymousModulesTest extends TestCase
 
         $this->actingAs($this->superAdmin(), 'twill_users');
 
-        $this->getJson(route('twill.anonymousmodules.index'))
+        $this->getJson(route(config('twill.admin_route_name_prefix') . 'anonymousmodules.index'))
             ->assertJsonPath('tableData', []);
 
-        $this->post(route('twill.anonymousmodules.store'), ['title' => 'Test title'])
+        $this->post(route(config('twill.admin_route_name_prefix') . 'anonymousmodules.store'), ['title' => 'Test title'])
             ->assertJsonPath('redirect', 'http://twill.test/twill/anonymousmodules/1/edit');
 
-        $this->getJson(route('twill.anonymousmodules.index'))
+        $this->getJson(route(config('twill.admin_route_name_prefix') . 'anonymousmodules.index'))
             ->assertJsonPath('tableData.0.title', '<a href="http://twill.test/twill/anonymousmodules/1/edit" data-edit="true">Test title</a>');
     }
 }

--- a/tests/integration/Controllers/BasicControllerSettersTest.php
+++ b/tests/integration/Controllers/BasicControllerSettersTest.php
@@ -141,7 +141,7 @@ class BasicControllerSettersTest extends ModulesTestBase
         array $configSettersMethods = [],
         ?Request $request = null
     ): CategoryController {
-        $request = $request ?? Request::create(route('twill.personnel.authors.index'));
+        $request = $request ?? Request::create(route(config('twill.admin_route_name_prefix') . 'personnel.authors.index'));
 
         return new class($this->app, $request, $configSettersMethods) extends CategoryController {
 

--- a/tests/integration/Controllers/Tables/FeaturedColumnTest.php
+++ b/tests/integration/Controllers/Tables/FeaturedColumnTest.php
@@ -36,20 +36,20 @@ class FeaturedColumnTest extends TestCase
 
         $this->actingAs($this->superAdmin(), 'twill_users');
 
-        $this->post(route('twill.monitors.store'), ['title' => 'Test title'])
+        $this->post(route(config('twill.admin_route_name_prefix') . 'monitors.store'), ['title' => 'Test title'])
             ->assertStatus(200);
 
-        $featured = $this->getJson(route('twill.monitors.index'))
+        $featured = $this->getJson(route(config('twill.admin_route_name_prefix') . 'monitors.index'))
             ->json('tableData.0.featured');
 
         // Here we use a full fetch as there is a php 8, 8.1 difference regarding how booleans are casted. ('0' and 0).
         $this->assertEquals(0, (int) $featured);
 
         // Feature the content
-        $this->putJson(route('twill.monitors.feature'), ['id' => $class::latest()->first()->id, 'active' => false])
+        $this->putJson(route(config('twill.admin_route_name_prefix') . 'monitors.feature'), ['id' => $class::latest()->first()->id, 'active' => false])
             ->assertJsonPath('message', 'Monitor featured!');
 
-        $featured = $this->getJson(route('twill.monitors.index'))
+        $featured = $this->getJson(route(config('twill.admin_route_name_prefix') . 'monitors.index'))
             ->json('tableData.0.featured');
 
         $this->assertEquals(1, (int) $featured);

--- a/tests/integration/Controllers/Tables/Filters/FilterTestBase.php
+++ b/tests/integration/Controllers/Tables/Filters/FilterTestBase.php
@@ -21,7 +21,7 @@ class FilterTestBase extends ModulesTestBase
         array $extendQuickFilters = [],
         array $active = []
     ): AuthorController {
-        $request = Request::create(route('twill.personnel.authors.index'), 'GET', ['filter' => json_encode($active)]);
+        $request = Request::create(route(config('twill.admin_route_name_prefix') . 'personnel.authors.index'), 'GET', ['filter' => json_encode($active)]);
 
         return new class($this->app, $request, $filters, $quickFilters, $extendQuickFilters) extends AuthorController {
             public function __construct(

--- a/tests/integration/Controllers/Tables/TableSortingTest.php
+++ b/tests/integration/Controllers/Tables/TableSortingTest.php
@@ -35,7 +35,7 @@ class TableSortingTest extends ModulesTestBase
             },
         );
 
-        $this->getJson(route('twill.personnel.authors.index'))
+        $this->getJson(route(config('twill.admin_route_name_prefix') . 'personnel.authors.index'))
             ->assertJsonPath('tableData.0.id', 9)
             ->assertJsonPath('tableData.0.year', '2008')
             ->assertJsonPath('tableData.1.id', 7)
@@ -70,7 +70,7 @@ class TableSortingTest extends ModulesTestBase
             },
         );
 
-        $this->getJson(route('twill.personnel.authors.index', ['sortDir' => 'asc', 'sortKey' => 'year']))
+        $this->getJson(route(config('twill.admin_route_name_prefix') . 'personnel.authors.index', ['sortDir' => 'asc', 'sortKey' => 'year']))
             ->assertJsonPath('tableData.0.year', '2000')
             ->assertJsonPath('tableData.1.year', '2001')
             ->assertJsonPath('tableData.2.year', '2002')
@@ -95,7 +95,7 @@ class TableSortingTest extends ModulesTestBase
             },
         );
 
-        $this->getJson(route('twill.personnel.authors.index', ['sortDir' => 'desc', 'sortKey' => 'year']))
+        $this->getJson(route(config('twill.admin_route_name_prefix') . 'personnel.authors.index', ['sortDir' => 'desc', 'sortKey' => 'year']))
             ->assertJsonPath('tableData.0.year', '2009')
             ->assertJsonPath('tableData.1.year', '2008')
             ->assertJsonPath('tableData.2.year', '2007')
@@ -128,7 +128,7 @@ class TableSortingTest extends ModulesTestBase
             },
         );
 
-        $this->getJson(route('twill.personnel.authors.index'))
+        $this->getJson(route(config('twill.admin_route_name_prefix') . 'personnel.authors.index'))
             ->assertJsonPath('tableData.0.year', '2000')
             ->assertJsonPath('tableData.1.year', '2001')
             ->assertJsonPath('tableData.2.year', '2002')
@@ -161,7 +161,7 @@ class TableSortingTest extends ModulesTestBase
             },
         );
 
-        $this->getJson(route('twill.personnel.authors.index'))
+        $this->getJson(route(config('twill.admin_route_name_prefix') . 'personnel.authors.index'))
             ->assertJsonPath('tableData.0.year', '2009')
             ->assertJsonPath('tableData.1.year', '2008')
             ->assertJsonPath('tableData.2.year', '2007')
@@ -200,7 +200,7 @@ class TableSortingTest extends ModulesTestBase
             },
         );
 
-        $this->getJson(route('twill.personnel.authors.index'))
+        $this->getJson(route(config('twill.admin_route_name_prefix') . 'personnel.authors.index'))
             ->assertJsonPath('tableData.0.year', '2009')
             ->assertJsonPath('tableData.1.year', '2008')
             ->assertJsonPath('tableData.2.year', '2007')

--- a/tests/integration/Dashboard/DashboardTest.php
+++ b/tests/integration/Dashboard/DashboardTest.php
@@ -27,10 +27,10 @@ class DashboardTest extends TestCase
 
     public function testLogsActivity(): void
     {
-        $this->post(route('twill.computers.store'), ['title' => 'Test title'])
+        $this->post(route(config('twill.admin_route_name_prefix') . 'computers.store'), ['title' => 'Test title'])
             ->assertJsonPath('redirect', 'http://twill.test/twill/computers/1/edit');
 
-        $this->post(route('twill.licences.store'), ['title' => 'Test title'])
+        $this->post(route(config('twill.admin_route_name_prefix') . 'licences.store'), ['title' => 'Test title'])
             ->assertJsonPath('redirect', 'http://twill.test/twill/licences/1/edit');
 
         $this->assertCount(2, $activity = Activity::all());
@@ -61,10 +61,10 @@ class DashboardTest extends TestCase
                 ],
             ],
         ]);
-        $this->post(route('twill.computers.store'), ['title' => 'Test title'])
+        $this->post(route(config('twill.admin_route_name_prefix') . 'computers.store'), ['title' => 'Test title'])
             ->assertJsonPath('redirect', 'http://twill.test/twill/computers/1/edit');
 
-        $this->post(route('twill.licences.store'), ['title' => 'Test title'])
+        $this->post(route(config('twill.admin_route_name_prefix') . 'licences.store'), ['title' => 'Test title'])
             ->assertJsonPath('redirect', 'http://twill.test/twill/licences/1/edit');
 
         $allActivities = $this->getInvadedDashboardController()->getAllActivities();
@@ -99,10 +99,10 @@ class DashboardTest extends TestCase
 
         // Create 20 of each content.
         for ($i = 0; $i < 20; $i++) {
-            $this->post(route('twill.computers.store'), ['title' => 'Test title' . $i])
+            $this->post(route(config('twill.admin_route_name_prefix') . 'computers.store'), ['title' => 'Test title' . $i])
                 ->assertOk();
 
-            $this->post(route('twill.licences.store'), ['title' => 'Test title' . $i])
+            $this->post(route(config('twill.admin_route_name_prefix') . 'licences.store'), ['title' => 'Test title' . $i])
                 ->assertOk();
         }
 
@@ -135,10 +135,10 @@ class DashboardTest extends TestCase
 
         // Create 20 of each content.
         for ($i = 0; $i < 20; $i++) {
-            $this->post(route('twill.computers.store'), ['title' => 'Test title' . $i])
+            $this->post(route(config('twill.admin_route_name_prefix') . 'computers.store'), ['title' => 'Test title' . $i])
                 ->assertOk();
 
-            $this->post(route('twill.licences.store'), ['title' => 'Test title' . $i])
+            $this->post(route(config('twill.admin_route_name_prefix') . 'licences.store'), ['title' => 'Test title' . $i])
                 ->assertOk();
         }
 

--- a/tests/integration/MediaLibraryTest.php
+++ b/tests/integration/MediaLibraryTest.php
@@ -122,7 +122,7 @@ class MediaLibraryTest extends ModulesTestBase
         $this->assertFalse($media->delete());
 
         // Check we cannot remove it via the api.
-        $this->deleteJson(route('twill.media-library.medias.destroy', ['media' => $media]))->assertJson([
+        $this->deleteJson(route(config('twill.admin_route_name_prefix') . 'media-library.medias.destroy', ['media' => $media]))->assertJson([
             'message' => 'Media was not moved to trash. Something wrong happened!',
             'variant' => 'error',
         ]);
@@ -139,7 +139,7 @@ class MediaLibraryTest extends ModulesTestBase
         $this->assertFalse($media->delete());
 
         // Check we continue to be unable to remove.
-        $this->deleteJson(route('twill.media-library.medias.destroy', ['media' => $media]))->assertJson([
+        $this->deleteJson(route(config('twill.admin_route_name_prefix') . 'media-library.medias.destroy', ['media' => $media]))->assertJson([
             'message' => 'Media was not moved to trash. Something wrong happened!',
             'variant' => 'error',
         ]);
@@ -152,7 +152,7 @@ class MediaLibraryTest extends ModulesTestBase
         $this->assertTrue($media->refresh()->canDeleteSafely());
 
         // Finally delete the media.
-        $this->deleteJson(route('twill.media-library.medias.destroy', ['media' => $media]))->assertJson([
+        $this->deleteJson(route(config('twill.admin_route_name_prefix') . 'media-library.medias.destroy', ['media' => $media]))->assertJson([
             'message' => 'Media moved to trash!',
             'variant' => 'success',
         ]);

--- a/tests/integration/ModulesTestBase.php
+++ b/tests/integration/ModulesTestBase.php
@@ -155,7 +155,7 @@ abstract class ModulesTestBase extends TestCase
     {
         foreach (range(1, $count) as $c) {
             $this->httpJsonRequestAssert(
-                route('twill.personnel.authors.store'),
+                route(config('twill.admin_route_name_prefix') . 'personnel.authors.store'),
                 'POST',
                 $this->getCreateAuthorData($data)
             );

--- a/tests/integration/Navigation/NavigationBuilderTest.php
+++ b/tests/integration/Navigation/NavigationBuilderTest.php
@@ -32,7 +32,7 @@ class NavigationBuilderTest extends TestCase
     {
         $this->login();
 
-        TwillNavigation::addLink(NavigationLink::make()->forRoute('twill.users')->title('USERS'));
+        TwillNavigation::addLink(NavigationLink::make()->forRoute(config('twill.admin_route_name_prefix') . 'users')->title('USERS'));
 
         $navigation = TwillNavigation::buildNavigationTree();
 
@@ -44,7 +44,7 @@ class NavigationBuilderTest extends TestCase
         $this->login();
 
         $link = NavigationLink::make()
-            ->forRoute('twill.users.update', ['user' => $this->superAdmin()->id])
+            ->forRoute(config('twill.admin_route_name_prefix') . 'users.update', ['user' => $this->superAdmin()->id])
             ->title('Edit admin');
 
         $this->assertStringContainsString('/twill/users/' . $this->superAdmin()->id, $link->render());
@@ -54,12 +54,12 @@ class NavigationBuilderTest extends TestCase
     {
         $this->login();
 
-        $link = NavigationLink::make()->forRoute('twill.users.index')->title('USERS');
+        $link = NavigationLink::make()->forRoute(config('twill.admin_route_name_prefix') . 'users.index')->title('USERS');
 
         $this->assertStringNotContainsString('target="_blank"', $link->render());
 
         // Second time we say it should open in a new window.
-        $link = NavigationLink::make()->forRoute('twill.users.index')->title('USERS')->shouldOpenInNewWindow();
+        $link = NavigationLink::make()->forRoute(config('twill.admin_route_name_prefix') . 'users.index')->title('USERS')->shouldOpenInNewWindow();
 
         $this->assertStringContainsString('target="_blank"', $link->render());
     }
@@ -69,7 +69,7 @@ class NavigationBuilderTest extends TestCase
         config()->set('twill-navigation', ['some-data']);
 
         $this->expectException(CannotCombineNavigationBuilderWithLegacyConfig::class);
-        TwillNavigation::addLink(NavigationLink::make()->forRoute('twill.users')->title('USERS'));
+        TwillNavigation::addLink(NavigationLink::make()->forRoute('users')->title('USERS'));
     }
 
 }

--- a/tests/integration/Repositories/RepositoryRepeatersTest.php
+++ b/tests/integration/Repositories/RepositoryRepeatersTest.php
@@ -217,7 +217,7 @@ class RepositoryRepeatersTest extends ModulesTestBase
 
     public function testGetBrowserDataForRepeater(): void
     {
-        $this->getJson(route('twill.partners.browser', ['forRepeater' => 'true']))
+        $this->getJson(route(config('twill.admin_route_name_prefix') . 'partners.browser', ['forRepeater' => 'true']))
             ->assertJsonPath(
                 'data.0.repeaterFields',
                 [

--- a/tests/integration/Settings/SettingsFacadeTest.php
+++ b/tests/integration/Settings/SettingsFacadeTest.php
@@ -32,7 +32,7 @@ class SettingsFacadeTest extends TestCase
         // Make a post.
         $this->actingAs($this->superAdmin(), 'twill_users')
             ->putJson(
-                route('twill.app.settings.update', [$model]),
+                route(config('twill.admin_route_name_prefix') . 'app.settings.update', [$model]),
                 [
                     'blocks' => [
                         [

--- a/tests/integration/Settings/SettingsModelTest.php
+++ b/tests/integration/Settings/SettingsModelTest.php
@@ -32,7 +32,7 @@ class SettingsModelTest extends TestCase
 
         // When we open up the controller it should auto register it and settings should be in the menu.
         // The secondary nav should show both the first and second label.
-        $this->actingAs($this->superAdmin(), 'twill_users')->getJson(route('twill.app.settings.page', ['group' => 'test']))
+        $this->actingAs($this->superAdmin(), 'twill_users')->getJson(route(config('twill.admin_route_name_prefix') . 'app.settings.page', ['group' => 'test']))
             ->assertSee('Settings')
             ->assertSee('Test label')
             // Second.
@@ -55,7 +55,7 @@ class SettingsModelTest extends TestCase
 
         // When we open up the controller it should auto register it and settings should be in the menu.
         // The secondary nav should show both the first and second label.
-        $this->actingAs($this->superAdmin(), 'twill_users')->getJson(route('twill.app.settings.page', ['group' => 'test']))
+        $this->actingAs($this->superAdmin(), 'twill_users')->getJson(route(config('twill.admin_route_name_prefix') . 'app.settings.page', ['group' => 'test']))
             ->assertSee('Settings')
             ->assertSee('Test label')
             // Second.
@@ -88,7 +88,7 @@ class SettingsModelTest extends TestCase
         );
 
         $this->actingAs($this->superAdmin(), 'twill_users')
-            ->getJson(route('twill.app.settings.page', ['group' => 'test']))
+            ->getJson(route(config('twill.admin_route_name_prefix') . 'app.settings.page', ['group' => 'test']))
             ->assertSee('title field label');
     }
 
@@ -107,7 +107,7 @@ class SettingsModelTest extends TestCase
         // Make a post.
         $this->actingAs($this->superAdmin(), 'twill_users')
             ->putJson(
-                route('twill.app.settings.update', [$model]),
+                route(config('twill.admin_route_name_prefix') . 'app.settings.update', [$model]),
                 [
                     'blocks' => [
                         [
@@ -152,7 +152,7 @@ class SettingsModelTest extends TestCase
         );
 
         $this->actingAs($this->superAdmin(), 'twill_users')
-            ->get(route('twill.app.settings.page', ['group' => 'demo']))
+            ->get(route(config('twill.admin_route_name_prefix') . 'app.settings.page', ['group' => 'demo']))
             ->assertStatus(403);
     }
 }

--- a/tests/integration/SubdomainRoutingTest.php
+++ b/tests/integration/SubdomainRoutingTest.php
@@ -32,19 +32,19 @@ class SubdomainRoutingTest extends TestCase
         );
 
         $this->actingAs($this->superAdmin(), 'twill_users')
-            ->get(route('twill.dashboard', ['subdomain' => 'subdomain1']))
+            ->get(route(config('twill.admin_route_name_prefix') . 'dashboard', ['subdomain' => 'subdomain1']))
             ->assertSee('App 1 name')
             ->assertStatus(200);
 
         // The second request it would fail because of the config mismatch.
         $this->actingAs($this->superAdmin(), 'twill_users')
-            ->get(route('twill.dashboard', ['subdomain' => 'subdomain1']))
+            ->get(route(config('twill.admin_route_name_prefix') . 'dashboard', ['subdomain' => 'subdomain1']))
             ->assertSee('App 1 name')
             ->assertStatus(200);
 
         // Check that we can also request subdomain2 within the same runtime.
         $this->actingAs($this->superAdmin(), 'twill_users')
-            ->get(route('twill.dashboard', ['subdomain' => 'subdomain2']))
+            ->get(route(config('twill.admin_route_name_prefix') . 'dashboard', ['subdomain' => 'subdomain2']))
             ->assertSee('App 2 name')
             ->assertStatus(200);
     }
@@ -53,7 +53,7 @@ class SubdomainRoutingTest extends TestCase
     {
         $this->actingAs($this->superAdmin(), 'twill_users')
             //  We use json here to easily assert. In browsers this would display depending on the exception handler.
-            ->getJson(route('twill.dashboard', ['subdomain' => 'nonExistingDomain']))
+            ->getJson(route(config('twill.admin_route_name_prefix') . 'dashboard', ['subdomain' => 'nonExistingDomain']))
             ->assertJsonPath('message', 'Subdomain: nonexistingdomain')
             ->assertJsonPath('exception', 'A17\Twill\Exceptions\NoNavigationForSubdomainException')
             ->assertStatus(500);

--- a/views/auth/2fa.blade.php
+++ b/views/auth/2fa.blade.php
@@ -1,5 +1,5 @@
 @extends('twill::auth.layout', [
-    'route' => route('twill.login-2fa'),
+    'route' => route(config('twill.admin_route_name_prefix') . 'login-2fa'),
     'screenTitle' => twillTrans('twill::lang.auth.verify-login'),
 ])
 

--- a/views/auth/login.blade.php
+++ b/views/auth/login.blade.php
@@ -1,5 +1,5 @@
 @extends('twill::auth.layout', [
-    'route' => route('twill.login'),
+    'route' => route(config('twill.admin_route_name_prefix') . 'login'),
     'screenTitle' => twillTrans('twill::lang.auth.login-title')
 ])
 
@@ -11,7 +11,7 @@
 
     <fieldset class="login__fieldset">
         <label class="login__label" for="password">{{ twillTrans('twill::lang.auth.password') }}</label>
-        <a href="{{ route('twill.password.reset.link') }}" class="login__help f--small" tabindex="5"><span>{{ twillTrans('twill::lang.auth.forgot-password') }}</span></a>
+        <a href="{{ route(config('twill.admin_route_name_prefix') . 'password.reset.link') }}" class="login__help f--small" tabindex="5"><span>{{ twillTrans('twill::lang.auth.forgot-password') }}</span></a>
         <input type="password" name="password" id="password" class="login__input" required tabindex="2" />
     </fieldset>
 
@@ -19,7 +19,7 @@
 
     @if (config('twill.enabled.users-oauth', false))
         @foreach(config('twill.oauth.providers', []) as $index => $provider)
-            <a href="{!! route('twill.login.redirect', $provider) !!}" class="login__socialite login__{{$provider}}" tabindex="{{ 4 + $index }}">
+            <a href="{!! route(config('twill.admin_route_name_prefix') . 'login.redirect', $provider) !!}" class="login__socialite login__{{$provider}}" tabindex="{{ 4 + $index }}">
                 @includeIf('twill::auth.icons.' . $provider)
                 <span>Sign in with {{ ucfirst($provider)}}</span>
             </a>

--- a/views/auth/oauth-link.blade.php
+++ b/views/auth/oauth-link.blade.php
@@ -1,5 +1,5 @@
 @extends('twill::auth.layout', [
-    'route' => route('twill.login.oauth.linkProvider'),
+    'route' => route(config('twill.admin_route_name_prefix') . 'login.oauth.linkProvider'),
     'screenTitle' => twillTrans('twill::lang.auth.oauth-link-title', ['provider' => ucfirst($provider)]),
 ]),
 
@@ -11,12 +11,12 @@
 
     <fieldset class="login__fieldset">
         <label class="login__label" for="password">{{ twillTrans('twill::lang.auth.password') }}</label>
-        <a href="{{ route('twill.password.reset.link') }}" class="login__help f--small" tabindex="5"><span>{{ twillTrans('twill::lang.auth.login') }}</span></a>
+        <a href="{{ route(config('twill.admin_route_name_prefix') . 'password.reset.link') }}" class="login__help f--small" tabindex="5"><span>{{ twillTrans('twill::lang.auth.login') }}</span></a>
         <input type="password" name="password" id="password" class="login__input" required tabindex="2" />
     </fieldset>
 
     <input class="login__button" type="submit" value="{{ twillTrans('twill::lang.auth.login') }}" tabindex="3">
 
-    <a href="{!! route('twill.login') !!}" class="">{{ twillTrans('twill::lang.auth.back-to-login') }}</a>
+    <a href="{!! route(config('twill.admin_route_name_prefix') . 'login') !!}" class="">{{ twillTrans('twill::lang.auth.back-to-login') }}</a>
 
 @stop

--- a/views/auth/passwords/email.blade.php
+++ b/views/auth/passwords/email.blade.php
@@ -1,5 +1,5 @@
 @extends('twill::auth.layout', [
-    'route' => route('twill.password.reset.email'),
+    'route' => route(config('twill.admin_route_name_prefix') . 'password.reset.email'),
     'screenTitle' => twillTrans('twill::lang.auth.reset-password')
 ])
 

--- a/views/auth/passwords/reset.blade.php
+++ b/views/auth/passwords/reset.blade.php
@@ -3,7 +3,7 @@ $passwordText = isset($welcome) && $welcome ? twillTrans('twill::lang.auth.choos
 @endphp
 
 @extends('twill::auth.layout', [
-    'route' => route('twill.password.reset'),
+    'route' => route(config('twill.admin_route_name_prefix') . 'password.reset'),
     'screenTitle' => $passwordText
 ])
 

--- a/views/layouts/main.blade.php
+++ b/views/layouts/main.blade.php
@@ -3,6 +3,11 @@
 
 <head>
     @include('twill::partials.head')
+		<style>
+			.fieldset__content > hr {
+					display: none;
+			}
+		</style>
     @if (app()->environment('local', 'development') && config('twill.dev_mode', false))
         <script>
             window.hmr_url = '{{config('twill.dev_mode_url', 'http://localhost:8080')}}';
@@ -86,7 +91,7 @@
 </div>
 
 @if (config('twill.enabled.users-management'))
-    <form style="display: none" method="POST" action="{{ route('twill.logout') }}" data-logout-form>
+    <form style="display: none" method="POST" action="{{ route(config('twill.admin_route_name_prefix') . 'logout') }}" data-logout-form>
         @csrf
     </form>
 @endif
@@ -108,14 +113,14 @@
         wysiwygOptions: {!! json_encode(config('twill.media_library.media_caption_wysiwyg_options')) !!}
     }
     window['{{ config('twill.js_namespace') }}'].STORE.languages = {!! json_encode(getLanguagesForVueStore($form_fields ?? [], $translate ?? false)) !!};
-
+		
     @if (config('twill.enabled.media-library'))
         window['{{ config('twill.js_namespace') }}'].STORE.medias.types.push({
             value: 'image',
             text: '{{ twillTrans('twill::lang.media-library.images') }}',
             total: {{ \A17\Twill\Models\Media::count() }},
-            endpoint: '{{ route('twill.media-library.medias.index') }}',
-            tagsEndpoint: '{{ route('twill.media-library.medias.tags') }}',
+            endpoint: '{{ route(config('twill.admin_route_name_prefix') . 'media-library.medias.index') }}',
+            tagsEndpoint: '{{ route(config('twill.admin_route_name_prefix') . 'media-library.medias.tags') }}',
             uploaderConfig: {!! json_encode($mediasUploaderConfig) !!}
         })
         window['{{ config('twill.js_namespace') }}'].STORE.medias.showFileName = !!'{{ config('twill.media_library.show_file_name') }}'
@@ -126,8 +131,8 @@
             value: 'file',
             text: '{{ twillTrans('twill::lang.media-library.files') }}',
             total: {{ \A17\Twill\Models\File::count() }},
-            endpoint: '{{ route('twill.file-library.files.index') }}',
-            tagsEndpoint: '{{ route('twill.file-library.files.tags') }}',
+            endpoint: '{{ route(config('twill.admin_route_name_prefix') .'file-library.files.index') }}',
+            tagsEndpoint: '{{ route(config('twill.admin_route_name_prefix') .'file-library.files.tags') }}',
             uploaderConfig: {!! json_encode($filesUploaderConfig) !!}
         })
     @endif

--- a/views/layouts/main.blade.php
+++ b/views/layouts/main.blade.php
@@ -3,11 +3,6 @@
 
 <head>
     @include('twill::partials.head')
-		<style>
-			.fieldset__content > hr {
-					display: none;
-			}
-		</style>
     @if (app()->environment('local', 'development') && config('twill.dev_mode', false))
         <script>
             window.hmr_url = '{{config('twill.dev_mode_url', 'http://localhost:8080')}}';

--- a/views/partials/navigation/_overlay_navigation.blade.php
+++ b/views/partials/navigation/_overlay_navigation.blade.php
@@ -1,39 +1,39 @@
 <header class="headerMobile" data-header-mobile>
-    <nav class="headerMobile__nav">
-        <div class="container">
-            <x-twill.partials::navigation.title />
-            <div class="headerMobile__list">
-                @foreach ($linkGroups['left'] as $link)
-                    {!! $link->render('mobile') !!} <br />
-                @endforeach
-            </div>
-            <div class="headerMobile__list">
-                @foreach ($linkGroups['right'] as $link)
-                    {!! $link->render('mobile') !!}<br />
-                @endforeach
-                @if (($currentUser = auth()->user()) && config('twill.enabled.users-management'))
-                    <a
-                        href="{{ route('twill.users.index') }}">{{ twillTrans('twill::lang.nav.cms-users') }}</a><br />
-                    <a
-                        href="{{ route('twill.users.edit', $currentUser->id) }}">{{ twillTrans('twill::lang.nav.profile') }}</a><br />
-                    <a href="#" data-logout-btn>{{ twillTrans('twill::lang.nav.logout') }}</a>
-                @endif
-            </div>
-        </div>
-    </nav>
+	<nav class="headerMobile__nav">
+			<div class="container">
+					<x-twill.partials::navigation.title />
+					<div class="headerMobile__list">
+							@foreach ($linkGroups['left'] as $link)
+									{!! $link->render('mobile') !!} <br />
+							@endforeach
+					</div>
+					<div class="headerMobile__list">
+							@foreach ($linkGroups['right'] as $link)
+									{!! $link->render('mobile') !!}<br />
+							@endforeach
+							@if (($currentUser = auth()->user()) && config('twill.enabled.users-management'))
+									<a
+											href="{{ route(config('twill.admin_route_name_prefix') . 'users.index') }}">{{ twillTrans('twill::lang.nav.cms-users') }}</a><br />
+									<a
+											href="{{ route(config('twill.admin_route_name_prefix') . 'users.edit', $currentUser->id) }}">{{ twillTrans('twill::lang.nav.profile') }}</a><br />
+									<a href="#" data-logout-btn>{{ twillTrans('twill::lang.nav.logout') }}</a>
+							@endif
+					</div>
+			</div>
+	</nav>
 </header>
 
 <button class="ham @if (isset($search) && $search) ham--search @endif" data-ham-btn>
-    @if ($active_title)
-        <span class="ham__label">{{ $active_title }}</span>
-    @endif
-    <span class="btn ham__btn">
-        <span class="ham__icon">
-            <span class="ham__line"></span>
-        </span>
-        <span class="icon icon--close_modal"><svg>
-                <title>{{ twillTrans('twill::lang.nav.close-menu') }}</title>
-                <use xlink:href="#icon--close_modal"></use>
-            </svg></span>
-    </span>
+	@if ($active_title)
+			<span class="ham__label">{{ $active_title }}</span>
+	@endif
+	<span class="btn ham__btn">
+			<span class="ham__icon">
+					<span class="ham__line"></span>
+			</span>
+			<span class="icon icon--close_modal"><svg>
+							<title>{{ twillTrans('twill::lang.nav.close-menu') }}</title>
+							<use xlink:href="#icon--close_modal"></use>
+					</svg></span>
+	</span>
 </button>

--- a/views/partials/navigation/_title.blade.php
+++ b/views/partials/navigation/_title.blade.php
@@ -1,8 +1,8 @@
 <h1 class="header__title">
-    <a href={{ config('twill.enabled.dashboard') ? route('twill.dashboard') : '#' }}>
-        {{ config('app.name') }}
-        <span class="envlabel">
-            {{ app()->environment() === 'production' ? 'prod' : app()->environment() }}
-        </span>
-    </a>
+	<a href={{ config('twill.enabled.dashboard') ? route(config('twill.admin_route_name_prefix') . 'dashboard') : '#' }}>
+			{{ config('app.name') }}
+			<span class="envlabel">
+					{{ app()->environment() === 'production' ? 'prod' : app()->environment() }}
+			</span>
+	</a>
 </h1>

--- a/views/partials/navigation/_user.blade.php
+++ b/views/partials/navigation/_user.blade.php
@@ -11,7 +11,7 @@
     @endphp
 
     <a17-dropdown ref="userDropdown" position="bottom-right" :offset="-10">
-        <a href="{{ route('twill.users.edit', $currentUser->id) }}" @click.prevent="$refs.userDropdown.toggle()">
+        <a href="{{ route(config('twill.admin_route_name_prefix') . 'users.edit', $currentUser->id) }}" @click.prevent="$refs.userDropdown.toggle()">
             {{ $currentUser->role === 'SUPERADMIN' ? twillTrans('twill::lang.nav.admin') : $currentUser->name }}
             <span symbol="dropdown_module" class="icon icon--dropdown_module">
                 <svg>
@@ -24,7 +24,7 @@
             @if ($currentUser->can('access-user-management'))
                 <a href="{{ route($user_management_route) }}">{{ twillTrans('twill::lang.nav.cms-users') }}</a>
             @endif
-            <a href="{{ route('twill.users.edit', $currentUser->id) }}">{{ twillTrans('twill::lang.nav.profile') }}</a>
+            <a href="{{ route(config('twill.admin_route_name_prefix') . 'users.edit', $currentUser->id) }}">{{ twillTrans('twill::lang.nav.profile') }}</a>
             <a href="#" data-logout-btn>{{ twillTrans('twill::lang.nav.logout') }}</a>
         </div>
     </a17-dropdown>

--- a/views/partials/navigation/_user.blade.php
+++ b/views/partials/navigation/_user.blade.php
@@ -1,12 +1,12 @@
 @if(isset($currentUser) && config('twill.enabled.users-management'))
     @php
-        $user_management_route = 'twill.users.index';
+        $user_management_route = config('twill.admin_route_name_prefix') . 'users.index';
         if ($currentUser->can('edit-users')) {
-            $user_management_route = 'twill.users.index';
+            $user_management_route = config('twill.admin_route_name_prefix') . 'users.index';
         } elseif ($currentUser->can('edit-user-roles')) {
-            $user_management_route = 'twill.roles.index';
+            $user_management_route = config('twill.admin_route_name_prefix') . 'roles.index';
         } elseif ($currentUser->can('edit-user-groups')) {
-            $user_management_route = 'twill.groups.index';
+            $user_management_route = config('twill.admin_route_name_prefix') . 'groups.index';
         }
     @endphp
 

--- a/views/users/form.blade.php
+++ b/views/users/form.blade.php
@@ -243,7 +243,7 @@
             user_name: '{{ $item->name }}',
             registered_at: '{{ $item->isActivated() ? $item->registered_at->format('d M Y') : "Pending ({$item->created_at->format('d M Y')})" }}',
             last_login_at: '{{ $item->isActivated() && $item->last_login_at ? $item->last_login_at->format('d M Y, H:i') : null }}',
-            resend_registration_link: '{{ $item->isPublished() && !$item->isActivated() ? route('twill.users.resend.registrationEmail', ['user' => $item]) : null }}',
+            resend_registration_link: '{{ $item->isPublished() && !$item->isActivated() ? route(config('twill.admin_route_name_prefix') . 'users.resend.registrationEmail', ['user' => $item]) : null }}',
             is_activated: {{ json_encode($item->isActivated()) }}
             }
         @endcan


### PR DESCRIPTION
## Description

In the moduleRoute helper it relies on the hardcoded 'twill' admin prefix. This PR changes that so it relies on the value stated in the 'twill.admin_route_name_prefix' config.


## Related Issues

None seen, but this should fix issues if anyone is using a custom prefixed route group in admin
