### PR TITLE
Fixes breaking changes in laravel analytics

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
     "myclabs/php-enum": "^1.5",
     "pragmarx/google2fa-qrcode": "^2.0",
     "spatie/laravel-activitylog": "^4.0",
-    "spatie/laravel-analytics": "^4.0",
+    "spatie/laravel-analytics": "^5.0",
     "spatie/once": "^3.0"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
     "myclabs/php-enum": "^1.5",
     "pragmarx/google2fa-qrcode": "^2.0",
     "spatie/laravel-activitylog": "^4.0",
-    "spatie/laravel-analytics": "^5.0",
+    "spatie/laravel-analytics": "^4.0|^5.0",
     "spatie/once": "^3.0"
   },
   "require-dev": {

--- a/docs/content/1_docs/11_dashboard/index.md
+++ b/docs/content/1_docs/11_dashboard/index.md
@@ -48,7 +48,7 @@ return [
 
 It is using Spatie's [Laravel Analytics](https://github.com/spatie/laravel-analytics) package.
 
-Follow [Spatie's documentation](https://github.com/spatie/laravel-analytics#how-to-obtain-the-credentials-to-communicate-with-google-analytics) to set up a Google service account and download a json file containing your credentials, and provide your Analytics view ID using the `ANALYTICS_VIEW_ID` environment variable.
+Follow [Spatie's documentation](https://github.com/spatie/laravel-analytics#how-to-obtain-the-credentials-to-communicate-with-google-analytics) to set up a Google service account and download a json file containing your credentials, and provide your Analytics view ID using the `ANALYTICS_PROPERTY_ID` environment variable.
 
 ## User activity
 

--- a/src/Http/Controllers/Admin/DashboardController.php
+++ b/src/Http/Controllers/Admin/DashboardController.php
@@ -287,29 +287,56 @@ class DashboardController extends Controller
      */
     private function getFacts()
     {
-        /** @var Analytics $analytics */
-        $analytics = app()->makeWith(Analytics::class, ['propertyId' => config('analytics.property_id')]);
+        // TODO: cleanup when dropping support for Laravel 9
+        $useV5API = true;
+        if (class_exists('Spatie\Analytics\Facades\Analytics')) {
+            /** @var Analytics $analytics */
+            $analytics = app()->makeWith(Analytics::class, ['propertyId' => config('analytics.property_id')]);
+        } else {
+            /** @var Analytics $analytics */
+            $analytics = app(Analytics::class);
+            $useV5API = false;
+        }
+
         try {
-            $response = $analytics->get(
-                Period::days(60),
-                ['totalUsers', 'screenPageViews', 'bounceRate', 'screenPageViewsPerSession'],
-                ['date']
-            );
+            if ($useV5API) {
+                $response = $analytics->get(
+                    Period::days(60),
+                    ['totalUsers', 'screenPageViews', 'bounceRate', 'screenPageViewsPerSession'],
+                    ['date']
+                );
+
+                $statsByDate = $response->map(function (array $item) {
+                    return [
+                        'date' => $item['date'],
+                        'users' => (int) $item['totalUsers'],
+                        'pageViews' => (int) $item['screenPageViews'],
+                        'bounceRate' => $item['bounceRate'],
+                        'pageviewsPerSession' => $item['screenPageViewsPerSession'],
+                    ];
+                })->reverse()->values();
+            } else {
+                $response = $analytics->performQuery(
+                    Period::days(60),
+                    'ga:users,ga:pageviews,ga:bouncerate,ga:pageviewsPerSession',
+                    ['dimensions' => 'ga:date']
+                );
+
+                $statsByDate = Collection::make($response['rows'] ?? [])->map(function (array $dateRow) {
+                    return [
+                        'date' => $dateRow[0],
+                        'users' => (int)$dateRow[1],
+                        'pageViews' => (int)$dateRow[2],
+                        'bounceRate' => $dateRow[3],
+                        'pageviewsPerSession' => $dateRow[4],
+                    ];
+                });
+            }
         } catch (InvalidConfiguration $exception) {
             $this->logger->error($exception);
 
             return [];
         }
-
-        $statsByDate = $response->map(function (array $item) {
-            return [
-                'date' => $item['date'],
-                'users' => (int) $item['totalUsers'],
-                'pageViews' => (int) $item['screenPageViews'],
-                'bounceRate' => $item['bounceRate'],
-                'pageviewsPerSession' => $item['screenPageViewsPerSession'],
-            ];
-        })->reverse()->values();
 
         $dummyData = null;
         if ($statsByDate->isEmpty()) {


### PR DESCRIPTION
## Description

Spatie's [Laravel Analytics](https://github.com/spatie/laravel-analytics) package was updated to work with Google Analytics 4.  This PR fixes breaking changes.  If you published laravel-analytics config, you'll need to update `view_id` to `property_id`. 

Google's Universal Analytics will stop working July 1, 2023.

## Related Issues

Fixes #2287 
