### PR TITLE
Fix Translation from Published to Scheduled

### DIFF
--- a/src/Http/Controllers/Admin/ModuleController.php
+++ b/src/Http/Controllers/Admin/ModuleController.php
@@ -798,7 +798,7 @@ abstract class ModuleController extends Controller
         if ($this->getIndexOption('includeScheduledInList') && $this->repository->isFillable('publish_start_date')) {
             $columns->add(
                 ScheduledStatus::make()
-                    ->title(twillTrans('twill::lang.listing.columns.published'))
+                    ->title(twillTrans('twill::lang.publisher.scheduled'))
                     ->optional()
             );
         }


### PR DESCRIPTION
Scheduling is a great feature, noticed that on the filter a wrong translation is referenced, so you get "Published" twice.
- This change will make it "Scheduled" or its translation.

![image](https://github.com/area17/twill/assets/8001717/b3eccb20-e3c1-4440-9175-f4e2bb246ffc)