### PR TITLE
Turn Move Dropdowns Off for Settings Blocks

### DIFF
--- a/frontend/js/components/blocks/Blocks.vue
+++ b/frontend/js/components/blocks/Blocks.vue
@@ -21,7 +21,7 @@
                               :opened="opened"
                               :with-handle="!isSettings"
                               :with-actions="!isSettings"
-                              :with-move-dropdown="isSettings"
+                              :with-move-dropdown="!isSettings"
                               @expand="setOpened"
                               v-if="availableBlocks.length">
                 <template v-for="availableBlock in availableBlocks">


### PR DESCRIPTION
The move dropdown feature does not apply in the settings context.

![image](https://github.com/area17/twill/assets/8001717/e6007ce0-81ed-47ad-8020-5588992ee894)
