### PR TITLE
adds `direction` option to form text and wysiwyg inputs

### DIFF
--- a/docs/content/1_docs/4_form-fields/01_input.md
+++ b/docs/content/1_docs/4_form-fields/01_input.md
@@ -87,7 +87,7 @@ Input::make()
 | readonly    | Sets the field as readonly                                                                                               | boolean                                                     | false         |
 | default     | Sets a default value if empty                                                                                            | string                                                      |               |
 | mask        | Set a mask using the alpinejs mask plugin                                                                                | string                                                      |               |
-| direction   | Set custom input direction <small>(from `v3.0.3`)</small>                                                                | ltr<br/>rtl<br>auto                                                        | auto          |
+| direction   | Set custom input direction <small>(from `v3.1.0`)</small>                                                                | ltr<br/>rtl<br>auto                                                        | auto          |
 
 Specific options for the "number" type:
 
@@ -128,7 +128,7 @@ When used in a [block](../5_block-editor), no migration is needed, as data conta
 
 ## Manually setting input direction
 
-Introduced in `v3.0.3`
+Introduced in `v3.1.0`
 
 For certain types of input it maybe useful to manually set the direction to left-to-right (`ltr`) or right-to-left (`rtl`) depending upon the expected text input. 
 

--- a/docs/content/1_docs/4_form-fields/01_input.md
+++ b/docs/content/1_docs/4_form-fields/01_input.md
@@ -37,6 +37,7 @@ Input::make()
     type="textarea"
     :rows="3"
     :translated="true"
+    direction="ltr"
 />
 ```
 
@@ -62,7 +63,8 @@ Input::make()
     'note' => 'Hint message goes here',
     'placeholder' => 'Placeholder goes here',
     'type' => 'textarea',
-    'rows' => 3
+    'rows' => 3,
+    'direction' => 'ltr'
 ])
 ```
 
@@ -85,6 +87,7 @@ Input::make()
 | readonly    | Sets the field as readonly                                                                                               | boolean                                                     | false         |
 | default     | Sets a default value if empty                                                                                            | string                                                      |               |
 | mask        | Set a mask using the alpinejs mask plugin                                                                                | string                                                      |               |
+| direction   | Set custom input direction <small>(from `v3.0.3`)</small>                                                                | ltr<br/>rtl<br>auto                                                        | auto          |
 
 Specific options for the "number" type:
 
@@ -122,3 +125,13 @@ Schema::table('articles', function (Blueprint $table) {
 ```
 
 When used in a [block](../5_block-editor), no migration is needed, as data contained in blocks, including componentBlocks, is stored in a separate table from the model, which is managed by Twill for you.
+
+## Manually setting input direction
+
+Introduced in `v3.0.3`
+
+For certain types of input it maybe useful to manually set the direction to left-to-right (`ltr`) or right-to-left (`rtl`) depending upon the expected text input. 
+
+For example, maybe you have an Arabic translated page and need URL which mixes Arabic with an `ltr` domain name and TLD. In this case content entry maybe proving difficult for your CMS users with a `rtl` input; in which case you may find setting the direction to `ltr` beneficial. 
+
+You may also simply just need a single Hebrew text entry in an otherwise `ltr` form. 

--- a/docs/content/1_docs/4_form-fields/02_wysiwyg.md
+++ b/docs/content/1_docs/4_form-fields/02_wysiwyg.md
@@ -101,20 +101,21 @@ $wysiwygOptions = [
 ```
 
 
-| Option         | Description                                                                                                              | Type/values      | Default value |
-|:---------------|:-------------------------------------------------------------------------------------------------------------------------|:-----------------|:--------------|
-| name           | Name of the field                                                                                                        | string           |               |
-| label          | Label of the field                                                                                                       | string           |               |
-| type           | Type of wysiwyg field                                                                                                    | quill<br/>tiptap | tiptap        |
-| toolbarOptions | Array of options/tools that will be displayed in the editor                                                              |                  | See above     |
-| editSource     | Displays a button to view source code                                                                                    | boolean          | false         |
-| hideCounter    | Hide the character counter displayed at the bottom                                                                       | boolean          | false         |
-| limitHeight    | Limit the editor height from growing beyond the viewport                                                                 | boolean          | false         |
-| translated     | Defines if the field is translatable                                                                                     | boolean          | false         |
-| maxlength      | Max character count of the field                                                                                         | integer          |           |
-| note           | Hint message displayed above the field                                                                                   | string           |               |
-| placeholder    | Text displayed as a placeholder in the field                                                                             | string           |               |
-| required       | Displays an indicator that this field is required<br/>A backend validation rule is required to prevent users from saving | boolean          | false         |
+| Option         | Description                                                                                                              | Type/values         | Default value |
+|:---------------|:-------------------------------------------------------------------------------------------------------------------------|:--------------------|:--------------|
+| name           | Name of the field                                                                                                        | string              |               |
+| label          | Label of the field                                                                                                       | string              |               |
+| type           | Type of wysiwyg field                                                                                                    | quill<br/>tiptap    | tiptap        |
+| toolbarOptions | Array of options/tools that will be displayed in the editor                                                              |                     | See above     |
+| editSource     | Displays a button to view source code                                                                                    | boolean             | false         |
+| hideCounter    | Hide the character counter displayed at the bottom                                                                       | boolean             | false         |
+| limitHeight    | Limit the editor height from growing beyond the viewport                                                                 | boolean             | false         |
+| translated     | Defines if the field is translatable                                                                                     | boolean             | false         |
+| maxlength      | Max character count of the field                                                                                         | integer             |           |
+| note           | Hint message displayed above the field                                                                                   | string              |               |
+| placeholder    | Text displayed as a placeholder in the field                                                                             | string              |               |
+| required       | Displays an indicator that this field is required<br/>A backend validation rule is required to prevent users from saving | boolean             | false         |
+| direction      | Set custom input direction <small>(from `v3.0.3`)</small>                                                                | ltr<br/>rtl<br>auto | auto          |
 
 Note that Quill outputs CSS classes in the HTML for certain toolbar modules (indent, font, align, etc.), and that the image module is not integrated with Twill's media library. It outputs the base64 representation of the uploaded image.
 It is not a recommended way of using and storing images, prefer using one or multiple `medias` form fields or blocks fields for flexible content. This will give you greater control over your frontend output.
@@ -171,3 +172,9 @@ For regular fields on models you will have to manually call `parseInternalLinks`
 ```blade
 {{ \A17\Twill\Facades\TwillUtil::parseInternalLinks($item->description) }}
 ```
+
+## Manually setting input direction
+
+Introduced in `v3.0.3`
+
+For certain types of input it maybe useful to manually set the direction to left-to-right (`ltr`) or right-to-left (`rtl`) depending upon the expected text input; for example you may need a single Hebrew text entry in an otherwise `ltr` form. 

--- a/docs/content/1_docs/4_form-fields/02_wysiwyg.md
+++ b/docs/content/1_docs/4_form-fields/02_wysiwyg.md
@@ -115,7 +115,7 @@ $wysiwygOptions = [
 | note           | Hint message displayed above the field                                                                                   | string              |               |
 | placeholder    | Text displayed as a placeholder in the field                                                                             | string              |               |
 | required       | Displays an indicator that this field is required<br/>A backend validation rule is required to prevent users from saving | boolean             | false         |
-| direction      | Set custom input direction <small>(from `v3.0.3`)</small>                                                                | ltr<br/>rtl<br>auto | auto          |
+| direction      | Set custom input direction <small>(from `v3.1.0`)</small>                                                                | ltr<br/>rtl<br>auto | auto          |
 
 Note that Quill outputs CSS classes in the HTML for certain toolbar modules (indent, font, align, etc.), and that the image module is not integrated with Twill's media library. It outputs the base64 representation of the uploaded image.
 It is not a recommended way of using and storing images, prefer using one or multiple `medias` form fields or blocks fields for flexible content. This will give you greater control over your frontend output.
@@ -175,6 +175,6 @@ For regular fields on models you will have to manually call `parseInternalLinks`
 
 ## Manually setting input direction
 
-Introduced in `v3.0.3`
+Introduced in `v3.1.0`
 
 For certain types of input it maybe useful to manually set the direction to left-to-right (`ltr`) or right-to-left (`rtl`) depending upon the expected text input; for example you may need a single Hebrew text entry in an otherwise `ltr` form. 

--- a/frontend/js/mixins/input.js
+++ b/frontend/js/mixins/input.js
@@ -12,6 +12,10 @@ export default {
       type: String,
       default: ''
     },
+    direction: {
+      type: String,
+      default: 'auto'
+    },
     name: {
       default: ''
     },

--- a/frontend/js/mixins/locale.js
+++ b/frontend/js/mixins/locale.js
@@ -41,6 +41,9 @@ export default {
       else return false
     },
     dirLocale: function () {
+      if (this.direction && this.direction !== 'auto') {
+        return this.direction;
+      }
       return (this.isLocaleRTL ? 'rtl' : 'auto')
     },
     displayedLocale: function () {

--- a/src/Services/Forms/Fields/Input.php
+++ b/src/Services/Forms/Fields/Input.php
@@ -7,6 +7,7 @@ use A17\Twill\Services\Forms\Fields\Traits\HasMaxlength;
 use A17\Twill\Services\Forms\Fields\Traits\HasMin;
 use A17\Twill\Services\Forms\Fields\Traits\HasOnChange;
 use A17\Twill\Services\Forms\Fields\Traits\HasPlaceholder;
+use A17\Twill\Services\Forms\Fields\Traits\HasDirection;
 use A17\Twill\Services\Forms\Fields\Traits\IsTranslatable;
 
 /**
@@ -19,6 +20,7 @@ class Input extends BaseFormField
     use HasMax;
     use HasMaxlength;
     use HasPlaceholder;
+    use HasDirection;
     use HasOnChange;
 
     /**

--- a/src/Services/Forms/Fields/Traits/HasDirection.php
+++ b/src/Services/Forms/Fields/Traits/HasDirection.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace A17\Twill\Services\Forms\Fields\Traits;
+
+trait HasDirection
+{
+    protected ?string $direction = null;
+
+    /**
+     * Sets the direction of the field.
+     */
+    public function direction(string $direction): static
+    {
+        $this->direction = $direction === 'ltr' || $direction === 'rtl' ? $direction : 'auto';
+
+        return $this;
+    }
+}

--- a/src/Services/Forms/Fields/Wysiwyg.php
+++ b/src/Services/Forms/Fields/Wysiwyg.php
@@ -6,6 +6,7 @@ use A17\Twill\Services\Forms\Fields\Helpers\TiptapWrapper;
 use A17\Twill\Services\Forms\Fields\Traits\HasMaxlength;
 use A17\Twill\Services\Forms\Fields\Traits\HasOnChange;
 use A17\Twill\Services\Forms\Fields\Traits\HasPlaceholder;
+use A17\Twill\Services\Forms\Fields\Traits\HasDirection;
 use A17\Twill\Services\Forms\Fields\Traits\IsTranslatable;
 
 class Wysiwyg extends BaseFormField
@@ -13,6 +14,7 @@ class Wysiwyg extends BaseFormField
     use IsTranslatable;
     use HasMaxlength;
     use HasPlaceholder;
+    use HasDirection;
     use HasOnChange;
 
     public bool $hideCounter = false;

--- a/src/View/Components/Fields/Input.php
+++ b/src/View/Components/Fields/Input.php
@@ -21,6 +21,7 @@ class Input extends TwillFormComponent
         // Component specific
         public string $type = 'text',
         public ?string $placeholder = '',
+        public ?string $direction = 'auto',
         public ?int $maxlength = null,
         public ?int $rows = null,
         public ?string $ref = null,

--- a/src/View/Components/Fields/Wysiwyg.php
+++ b/src/View/Components/Fields/Wysiwyg.php
@@ -21,6 +21,7 @@ class Wysiwyg extends TwillFormComponent
         // Component specific
         public bool $hideCounter = false,
         public ?string $placeholder = null,
+        public ?string $direction = 'auto',
         public bool $editSource = false,
         public ?array $toolbarOptions = null,
         public ?int $maxlength = null,

--- a/views/partials/form/_input.blade.php
+++ b/views/partials/form/_input.blade.php
@@ -8,6 +8,7 @@
             @if ($required) required: true, @endif
             @if ($note) note: '{{ $note }}', @endif
             @if ($placeholder) placeholder: '{{ addslashes($placeholder) }}', @endif
+            @if ($direction) direction: '{{ $direction }}', @endif
             @if ($maxlength) maxlength: {{ $maxlength }}, @endif
             @if ($disabled) disabled: true, @endif
             @if ($readOnly) readonly: true, @endif
@@ -35,6 +36,7 @@
         @if ($required) :required="true" @endif
         @if ($note) note="{{ $note }}" @endif
         @if ($placeholder) placeholder="{{ $placeholder }}" @endif
+        @if ($direction) direction="{{ $direction }}" @endif
         @if ($maxlength) :maxlength="{{ $maxlength }}" @endif
         @if ($disabled) disabled @endif
         @if ($readOnly) readonly @endif

--- a/views/partials/form/_wysiwyg.blade.php
+++ b/views/partials/form/_wysiwyg.blade.php
@@ -15,6 +15,7 @@
             @if ($required) required: true, @endif
             @if ($options) options: {!! e(json_encode($options)) !!}, @endif
             @if ($placeholder) placeholder: '{{ addslashes($placeholder) }}', @endif
+            @if ($direction) direction: '{{ $direction }}', @endif
             @if ($maxlength) maxlength: {{ $maxlength }}, @endif
             @if ($hideCounter) showCounter: false, @endif
             @if ($disabled) disabled: true, @endif
@@ -38,6 +39,7 @@
             @if ($required) :required="true" @endif
             @if ($options) :options='{!! json_encode($options) !!}' @endif
             @if ($placeholder) placeholder='{{ $placeholder }}' @endif
+            @if ($direction) direction="{{ $direction }}" @endif
             @if ($maxlength) :maxlength='{{ $maxlength }}' @endif
             @if ($hideCounter) :showCounter='false' @endif
             @if ($disabled) disabled @endif
@@ -64,6 +66,7 @@
             @if ($required) required: true, @endif
             @if ($options) options: {!! e(json_encode($options)) !!}, @endif
             @if ($placeholder) placeholder: '{{ addslashes($placeholder) }}', @endif
+            @if ($direction) direction: '{{ $direction }}', @endif
             @if ($maxlength) maxlength: {{ $maxlength }}, @endif
             @if ($hideCounter) showCounter: false, @endif
             @if ($disabled) disabled: true, @endif
@@ -86,6 +89,7 @@
             @if ($required) :required="true" @endif
             @if ($options) :options='{!! json_encode($options) !!}' @endif
             @if ($placeholder) placeholder='{{ $placeholder }}' @endif
+            @if ($direction) direction="{{ $direction }}" @endif
             @if ($maxlength) :maxlength='{{ $maxlength }}' @endif
             @if ($hideCounter) :showCounter='false' @endif
             @if ($disabled) disabled @endif


### PR DESCRIPTION
For certain types of input it maybe useful to manually set the direction to left-to-right (`ltr`) or right-to-left (`rtl`) depending upon the expected text input. 

For example, maybe you have an Arabic translated page and need URL which mixes Arabic with an `ltr` domain name and TLD. In this case content entry maybe proving difficult for your CMS users with a `rtl` input; in which case you may find setting the direction to `ltr` beneficial. 

You may also simply just need a single Hebrew text entry in an otherwise `ltr` form. 

This commit adds `direction` for this purpose:

```
Input::make()
    ->name('url')
    ->label(twillTrans('Url'))
    ->direction('ltr')
```
___

**NB:** In the documentation I've made reference to `direction` being added in `v3.0.3` as I'm not sure how this case is handled in Twill docs previously.
___

- [x] Add direction option and integrate
- [x] Update docs to reflect change
- [x] Check for any required tests