### PR TITLE
Fix x-position of full height crops being reset at some ratios/screen sizes

### DIFF
--- a/frontend/js/components/Cropper.vue
+++ b/frontend/js/components/Cropper.vue
@@ -181,7 +181,21 @@
       },
       initCrop: function () {
         const crop = this.toNaturalCrop(this.crop)
-        this.cropper.setData(crop)
+        // Mike (mike@area17.com) --
+        //
+        // it seems due to rounding errors(?) that sometimes
+        // the x position can be reset incorrectly
+        // see: https://github.com/fengyuanchen/cropperjs/issues/1057
+        //
+        // from my testing it seems to be a little inconsistent and unpredictable
+        // I guess you just need for the rounding error to happen
+        // But, it seems setting the properties individually avoids this...
+        //
+        // -- Mike (mike@area17.com)
+        this.cropper.setData({ x: crop.x })
+        this.cropper.setData({ y: crop.y })
+        this.cropper.setData({ width: crop.width })
+        this.cropper.setData({ height: crop.height })
       },
       test: function () {
         const crop = this.toNaturalCrop({ x: 0, y: 0, width: 380, height: 475 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "alpinejs": "^3.10.0",
         "axios": "^0.21.2",
         "core-js": "^3.9.1",
-        "cropperjs": "1.5.6",
+        "cropperjs": "^1.5.13",
         "date-fns": "1.29.0",
         "fine-uploader": "^5.16.2",
         "fine-uploader-wrappers": "^1.1.0",
@@ -5087,9 +5087,9 @@
       }
     },
     "node_modules/cropperjs": {
-      "version": "1.5.6",
-      "resolved": "https://registry.npmjs.org/cropperjs/-/cropperjs-1.5.6.tgz",
-      "integrity": "sha512-eAgWf4j7sNJIG329qUHIFi17PSV0VtuWyAu9glZSgu/KlQSrfTQOC2zAz+jHGa5fAB+bJldEnQwvJEaJ8zRf5A=="
+      "version": "1.5.13",
+      "resolved": "https://registry.npmjs.org/cropperjs/-/cropperjs-1.5.13.tgz",
+      "integrity": "sha512-by7jKAo73y5/Do0K6sxdTKHgndY0NMjG2bEdgeJxycbcmHuCiMXqw8sxy5C5Y5WTOTcDGmbT7Sr5CgKOXR06OA=="
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -17765,9 +17765,9 @@
       }
     },
     "cropperjs": {
-      "version": "1.5.6",
-      "resolved": "https://registry.npmjs.org/cropperjs/-/cropperjs-1.5.6.tgz",
-      "integrity": "sha512-eAgWf4j7sNJIG329qUHIFi17PSV0VtuWyAu9glZSgu/KlQSrfTQOC2zAz+jHGa5fAB+bJldEnQwvJEaJ8zRf5A=="
+      "version": "1.5.13",
+      "resolved": "https://registry.npmjs.org/cropperjs/-/cropperjs-1.5.13.tgz",
+      "integrity": "sha512-by7jKAo73y5/Do0K6sxdTKHgndY0NMjG2bEdgeJxycbcmHuCiMXqw8sxy5C5Y5WTOTcDGmbT7Sr5CgKOXR06OA=="
     },
     "cross-spawn": {
       "version": "7.0.3",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "alpinejs": "^3.10.0",
     "axios": "^0.21.2",
     "core-js": "^3.9.1",
-    "cropperjs": "1.5.6",
+    "cropperjs": "^1.5.13",
     "date-fns": "1.29.0",
     "fine-uploader": "^5.16.2",
     "fine-uploader-wrappers": "^1.1.0",


### PR DESCRIPTION
Attempting to fix #1194, which seems to be an issue with [cropper.js ](https://github.com/fengyuanchen/cropperjs/issues/1057)

And ultimately is likely caused by rounding errors..

It seems setting individual crop settings instead, of attempting to set them all in one go fixes it, at least within Twill.

Be worth another set of eyes testing this in a Twill install and confirming to make sure I'm not seeing things...