### PR TITLE
Allow dashboard modules to wrap onto next line

### DIFF
--- a/frontend/js/components/dashboard/shortcutCreator.vue
+++ b/frontend/js/components/dashboard/shortcutCreator.vue
@@ -83,13 +83,19 @@
     border-bottom: 1px solid $color__border;
   }
 
+  .shortcutCreator .wrapper--reverse {
+    @include breakpoint('medium+') {
+      flex-flow: row-reverse;
+    }
+  }
+
   .shortcutCreator__listing {
     display: flex;
     flex-grow: 1;
     flex-flow: column nowrap;
 
     @include breakpoint('small+') {
-      flex-flow: row nowrap;
+      flex-flow: row wrap;
     }
   }
 


### PR DESCRIPTION
Fixes #707

- Dashboard modules will wrap onto next line if there are more than 5 on desktop, more than 3 on tablet
- May require design input regarding borders, this is the current output:

<img width="1495" alt="Screenshot 2023-06-23 at 3 10 19 PM" src="https://github.com/area17/twill/assets/35342624/4a7f4cf0-94ea-43cf-b71c-9e837a265779">
