### PR TITLE
Remove duplicate database calls for AppSettings

### DIFF
--- a/src/Services/Settings/SettingsGroup.php
+++ b/src/Services/Settings/SettingsGroup.php
@@ -18,6 +18,8 @@ class SettingsGroup
 
     private ?Closure $availableWhen = null;
 
+    private ?AppSetting $appSetting = null;
+
     public static function make(): self
     {
         return new self();
@@ -70,12 +72,12 @@ class SettingsGroup
 
     public function getSettingsModel(): AppSetting
     {
-        $settingsModel = AppSetting::where(['name' => $this->getName()])->first();
+        $settingsModel = $this->appSetting ?? AppSetting::where(['name' => $this->getName()])->first();
         if (!$settingsModel) {
             $settingsModel = AppSetting::create(['name' => $this->getName()]);
         }
 
-        return $settingsModel;
+        return $this->appSetting = $settingsModel;
     }
 
     /**

--- a/src/TwillAppSettings.php
+++ b/src/TwillAppSettings.php
@@ -16,6 +16,8 @@ class TwillAppSettings
      */
     private array $settingsGroups = [];
 
+    private array $groupBlockCache = [];
+
     public function registerSettingsGroup(SettingsGroup $section): void
     {
         $this->settingsGroups[$section->getName()] = $section;
@@ -103,12 +105,17 @@ class TwillAppSettings
 
     public function getGroupDataForSectionAndName(string $group, string $section): Block
     {
+        $cacheKey = $group . $section;
+        if (array_key_exists($cacheKey, $this->groupBlockCache)) {
+            return $this->groupBlockCache[$cacheKey];
+        }
+
         $groupObject = $this->getGroupForGroupAndSectionName($group, $section);
 
-        return $groupObject->getSettingsModel()->blocks()
-            ->where('editor_name', $section)
-            ->where('parent_id', null)
-            ->firstOrFail();
+        return $this->groupBlockCache[$cacheKey] = $groupObject->getSettingsModel()->blocks()
+                                                               ->where('editor_name', $section)
+                                                               ->where('parent_id', null)
+                                                               ->firstOrFail();
     }
 
     public function getBlockServiceForGroupAndSection(string $group, string $section): BlockService


### PR DESCRIPTION
## Description

Using the AppSettings facade created a ton of duplicate calls to the database.

This PR introduces two small in-memory array caches to entirely remove those duplicate calls