### PR TITLE
fix:bug preserve default vselect value when undefined

### DIFF
--- a/frontend/js/components/VSelect.vue
+++ b/frontend/js/components/VSelect.vue
@@ -204,7 +204,7 @@
       },
       updateValue: function (value) {
         // see formStore mixin
-        if(!value) {
+        if (!value) {
           const allOption = this.options.find((o) => o.value === 'all');
           this.value = allOption ?? undefined
         } else {

--- a/frontend/js/components/VSelect.vue
+++ b/frontend/js/components/VSelect.vue
@@ -205,7 +205,7 @@
       updateValue: function (value) {
         // see formStore mixin
         if(!value) {
-          const allOption = this.options.find((o) => o.value === 'all' );
+          const allOption = this.options.find((o) => o.value === 'all');
           this.value = allOption ?? undefined
         } else {
           this.value = value

--- a/frontend/js/components/VSelect.vue
+++ b/frontend/js/components/VSelect.vue
@@ -207,7 +207,7 @@
         if(!value) {
           const allOption = this.options.find((o) => o.value === 'all' );
           this.value = allOption ?? undefined
-        }else {
+        } else {
           this.value = value
         }
         this.saveIntoStore()

--- a/frontend/js/components/VSelect.vue
+++ b/frontend/js/components/VSelect.vue
@@ -204,7 +204,12 @@
       },
       updateValue: function (value) {
         // see formStore mixin
-        this.value = value
+        if(!value) {
+          this.value = this.selected;
+        }else {
+          this.value = value
+        }
+
         this.saveIntoStore()
         this.$emit('change', value)
       },

--- a/frontend/js/components/VSelect.vue
+++ b/frontend/js/components/VSelect.vue
@@ -205,7 +205,8 @@
       updateValue: function (value) {
         // see formStore mixin
         if(!value) {
-          this.value = this.selected;
+          let allOption = this.options.find((o) => o.value === 'all' );
+          this.value = allOption ?? undefined
         }else {
           this.value = value
         }

--- a/frontend/js/components/VSelect.vue
+++ b/frontend/js/components/VSelect.vue
@@ -205,12 +205,11 @@
       updateValue: function (value) {
         // see formStore mixin
         if(!value) {
-          let allOption = this.options.find((o) => o.value === 'all' );
+          const allOption = this.options.find((o) => o.value === 'all' );
           this.value = allOption ?? undefined
         }else {
           this.value = value
         }
-
         this.saveIntoStore()
         this.$emit('change', value)
       },


### PR DESCRIPTION
<!--
  Thanks for opening a PR! Your contribution is much appreciated.
  Do you have any questions? Check out the contributing docs at https://github.com/area17/twill/blob/3.x/CONTRIBUTING.md, or ask in this Pull Request and a Twill maintainer will be happy to help :)
-->

## Description
Filters select :
When clearing filters  the select loses its default value, and the field displays an empty select :

<img width="756" alt="Capture d’écran 2023-07-30 à 12 20 07" src="https://github.com/area17/twill/assets/20904573/ec695f2c-936b-43c8-afee-84b667463328">


