### PR TITLE
Duplicate nested columns keys fix

### DIFF
--- a/docs/content/1_docs/3_modules/6_table-builder.md
+++ b/docs/content/1_docs/3_modules/6_table-builder.md
@@ -172,9 +172,9 @@ unpublished.
 
 ##### NestedData
 
-`NestedData::make()`
+`NestedData::make()->...`
 
-This field requires no additional methods, it shows information about the nested models.
+Renders the `field` using the relationship of the same name. It shows information and a link about the nested model.
 
 ##### Languages
 

--- a/src/Services/Listings/Columns/NestedData.php
+++ b/src/Services/Listings/Columns/NestedData.php
@@ -9,13 +9,6 @@ use Illuminate\Support\Str;
 
 class NestedData extends TableColumn
 {
-    public static function make(): static
-    {
-        $item = parent::make();
-        $item->field('children');
-        return $item;
-    }
-
     public function sortable(bool $sortable = true): static
     {
         if ($sortable && $this->sortFunction === null) {

--- a/tests/integration/Controllers/Tables/NestedDataColumnTest.php
+++ b/tests/integration/Controllers/Tables/NestedDataColumnTest.php
@@ -19,7 +19,7 @@ class NestedDataColumnTest extends NestedModuleTestBase
 
     public function testColumn(): void
     {
-        $column = NestedData::make()->title('Child');
+        $column = NestedData::make()->field('children')->title('Child');
 
         $this->assertEquals('0 children', $column->renderCell($this->parent));
     }
@@ -27,7 +27,7 @@ class NestedDataColumnTest extends NestedModuleTestBase
     public function testSingleChild(): void {
         $this->parent->children()->create(['title' => 'Child 1', 'published' => true]);
 
-        $column = NestedData::make()->title('Child');
+        $column = NestedData::make()->field('children')->title('Child');
         $this->assertEquals('1 child', $column->renderCell($this->parent));
     }
 
@@ -35,7 +35,7 @@ class NestedDataColumnTest extends NestedModuleTestBase
         $this->parent->children()->create(['title' => 'Child 1', 'published' => true]);
         $this->parent->children()->create(['title' => 'Child 1', 'published' => true]);
 
-        $column = NestedData::make()->title('Child');
+        $column = NestedData::make()->field('children')->title('Child');
         $this->assertEquals('2 children', $column->renderCell($this->parent));
     }
 }


### PR DESCRIPTION
If there are several `NestedData` table columns, the value is duplicated because the keys are always `children` and it's impossible to overwrite them