### PR TITLE
Fix type of $forceLocale in translatedInput()

### DIFF
--- a/src/Models/Block.php
+++ b/src/Models/Block.php
@@ -75,7 +75,7 @@ class Block extends BaseModel implements TwillModelContract
         return $this->content[$name] ?? null;
     }
 
-    public function translatedInput(string $name, bool $forceLocale = null): mixed
+    public function translatedInput(string $name, string $forceLocale = null): mixed
     {
         $value = $this->content[$name] ?? null;
 


### PR DESCRIPTION

## Description

This fixes the type of the parameter in Models/Block::translatedInput()

## Related Issues

Fixes #2309
