### PR TITLE
Updated namespace paths from Admin to Twill  on Custom Page

### DIFF
--- a/docs/content/1_docs/13_custom-cms-pages/1_index.md
+++ b/docs/content/1_docs/13_custom-cms-pages/1_index.md
@@ -26,9 +26,9 @@ return [
 - Add a controller to handle the request
 
 ```php
-// file: app/Http/Controllers/Admin/CustomPageController.php
+// file: app/Http/Controllers/Twill/CustomPageController.php
 
-namespace App\Http\Controllers\Admin;
+namespace App\Http\Controllers\Twill;
 
 use A17\Twill\Http\Controllers\Admin\Controller;
 
@@ -36,7 +36,7 @@ class CustomPageController extends Controller
 {
     public function show()
     {
-        return view('admin.customPage');
+        return view('twill.customPage');
     }
 }
 ```
@@ -44,7 +44,7 @@ class CustomPageController extends Controller
 - And create the view
 
 ```php
-// file: resources/views/admin/customPage.blade.php
+// file: resources/views/twill/customPage.blade.php
 
 @extends('twill::layouts.free')
 


### PR DESCRIPTION
<!--
  Thanks for opening a PR! Your contribution is much appreciated.
  Do you have any questions? Check out the contributing docs at https://github.com/area17/twill/blob/3.x/CONTRIBUTING.md, or ask in this Pull Request and a Twill maintainer will be happy to help :)
-->

## Description

This PR is to reference the correct Namespace for the Controller and Blade for customPage example. Previously this was referencing Admin rather than Twill.

<!-- Write a description of the changes introduced by this PR -->
<!-- If this is introducing a new feature, it would be great if you can create a stub for documentation including bullet points for how to use the feature, code snippets, etc. -->

## Related Issues

None – was raised in the discord channel
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
