### PR TITLE
handle locale value in afterDuplicateHandleMedias

### DIFF
--- a/src/Repositories/Behaviors/HandleMedias.php
+++ b/src/Repositories/Behaviors/HandleMedias.php
@@ -206,6 +206,7 @@ trait HandleMedias
                 'crop_x' => $media->pivot->crop_x,
                 'crop_y' => $media->pivot->crop_y,
                 'metadatas' => $media->pivot->metadatas,
+                'locale' => $media->pivot->locale,
             ];
 
             $newObject->medias()->attach($media->id, $newPushData);


### PR DESCRIPTION
Copies the locale value when duplicating a record with media fields.

<!--
  Thanks for opening a PR! Your contribution is much appreciated.
  Do you have any questions? Check out the contributing docs at https://github.com/area17/twill/blob/3.x/CONTRIBUTING.md, or ask in this Pull Request and a Twill maintainer will be happy to help :)
-->

## Description

<!-- Write a description of the changes introduced by this PR -->
<!-- If this is introducing a new feature, it would be great if you can create a stub for documentation including bullet points for how to use the feature, code snippets, etc. -->

When duplicating a translated media field, the locale value is not copied to the new record.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->

Fixes #2303
