### PR TITLE
Backport Node 14 syntax to comply to minimum reqs

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -166,7 +166,12 @@ const config = {
 
 if (useHttps) {
   const homeDir = process.env.HOME;
-  const host = process.env.APP_URL.split('//')[1] ?? process.env.APP_URL;
+  if (process.env.APP_URL.includes('//')) {
+    const host = process.env.APP_URL.split('//')[1];
+  }
+  else {
+    const host = process.env.APP_URL;
+  }
 
   // This takes the ssh certificates from your `valet secure` domain so that browsers (Looking at safari) stop
   // complaining about it.


### PR DESCRIPTION
This PR fixes a bug while running `twill:build` in a Node v8 environment.

While updating our site to the latest version of Twill 2—2.13.0, we ran into a bug while running `twill:build`. I have all the composer packages and their dependencies updated and installed and I ran `php artisan twill:update` successfully. But I'm running into a bug when I run `php artisan twill:build`:

```
 ERROR  Error loading /home/vagrant/website/vendor/area17/twill/vue.config.js:
 ERROR  SyntaxError: Unexpected token ?
/home/vagrant/website/vendor/area17/twill/vue.config.js:169
```

The culprit is this line here that uses the nullish coalescing operator (`??`):

```
const host = process.env.APP_URL.split('//')[1] ?? process.env.APP_URL;
```

I'm running node v8.17.0 and npm v6.13.4, as the [Twill documentation states](https://twillcms.com/docs/2.x/getting-started/#summary) that npm 6.13 is the recommended version. But according to node.green the nullish coalescing operator was [introduced in node v14](https://node.green/#ES2020-features--nullish-coalescing-operator-----)

This PR refactors `vue.config.js` to not use the ?? operator.