### PR TITLE
[3.x] Update migration helper for translations table

### DIFF
--- a/src/Helpers/migrations_helpers.php
+++ b/src/Helpers/migrations_helpers.php
@@ -55,7 +55,7 @@ if (!function_exists('createDefaultTranslationsTableFields')) {
         $table->softDeletes();
         $table->timestamps();
         $table->string('locale', 7)->index();
-        $table->boolean('active');
+        $table->boolean('active')->default(false);
 
         $table->foreign("{$tableNameSingular}_id", "fk_{$tableNameSingular}_translations_{$tableNameSingular}_id")->references('id')->on($tableNamePlural)->onDelete('CASCADE');
         $table->unique(["{$tableNameSingular}_id", 'locale'], "{$tableNameSingular}_id_locale_unique");


### PR DESCRIPTION
## Description

I was bitten by a bug related to the lack of a default value for the `active` field in the translations table while adding a record in PostgreSQL.
The error was:
```
production.ERROR: SQLSTATE[23502]: Not null violation: 7 ERROR:  null value in column "active" of relation "metadata_translations" violates not-null constraint
DETAIL:  Failing row contains (3161, 49, null, 2023-08-30 12:31:23, 2023-08-30 12:31:23, de, null, xxxxxxxx, null, null, null, null). (SQL: insert into "metadata_translations" ("locale", "title", "metadata_id", "updated_at", "created_at") values (de, xxxxxxx, 49, 2023-08-30 12:31:23, 2023-08-30 12:31:23) returning "id")
```

The active field in PostgreSQL is not nullable and doesn't have a default value.
This issue doesn't happen while translating using Twill UI but by trying to do it programmatically. 

This commit updates the migration helper for translations table to default active field to false to comply with some versions of PostgreSQL



## Related Issues

Fixes #2326 
