### PR TITLE
Add HasReadOnly trait to Input field

### DIFF
--- a/src/Services/Forms/Fields/Input.php
+++ b/src/Services/Forms/Fields/Input.php
@@ -8,6 +8,7 @@ use A17\Twill\Services\Forms\Fields\Traits\HasMin;
 use A17\Twill\Services\Forms\Fields\Traits\HasOnChange;
 use A17\Twill\Services\Forms\Fields\Traits\HasPlaceholder;
 use A17\Twill\Services\Forms\Fields\Traits\HasDirection;
+use A17\Twill\Services\Forms\Fields\Traits\HasReadOnly;
 use A17\Twill\Services\Forms\Fields\Traits\IsTranslatable;
 
 /**
@@ -20,6 +21,7 @@ class Input extends BaseFormField
     use HasMax;
     use HasMaxlength;
     use HasPlaceholder;
+    use HasReadOnly;
     use HasDirection;
     use HasOnChange;
 

--- a/src/Services/Forms/Fields/Traits/HasReadOnly.php
+++ b/src/Services/Forms/Fields/Traits/HasReadOnly.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace A17\Twill\Services\Forms\Fields\Traits;
+
+trait HasReadOnly
+{
+    protected ?bool $readOnly = false;
+
+    /**
+     * Marks the field as read only.
+     */
+    public function readOnly(bool $readOnly = true): static
+    {
+        $this->readOnly = $readOnly;
+
+        return $this;
+    }
+}


### PR DESCRIPTION
## Description

This change adds a `readOnly` property and function for form fields as a trait. This trait is applied to the input form field.

This change brings the code in line with the documentation for the [Input](https://twillcms.com/docs/form-fields/input.html) field.

## Related Issues

Fixes #2330 
