### PR TITLE
remove ->reverse() from getAncestorsSlug()

### DIFF
--- a/src/Models/Behaviors/HasNesting.php
+++ b/src/Models/Behaviors/HasNesting.php
@@ -35,7 +35,7 @@ trait HasNesting
      */
     public function getAncestorsSlug(?string $locale = null): string
     {
-        return $this->getAncestors()->reverse()
+        return $this->getAncestors()
             ->map(function ($i) use ($locale) {
                 return $i->getSlug($locale);
             })


### PR DESCRIPTION
## Description

I removed ->reverse() from public function getAncestorsSlug() inside: A17\Twill\Models\Behaviors\HasNesting. Which fixes the issue of a wrong nesting order when going deeper then 1 level with nesting.

## Related Issues

Fixes #2302 
