### PR TITLE
[3.x] Fix - create icons target folder if it doesn't exist

### DIFF
--- a/src/Commands/Build.php
+++ b/src/Commands/Build.php
@@ -237,6 +237,10 @@ class Build extends Command
         $targetDirectory = base_path('vendor/area17/twill/frontend/icons-custom');
         $originalIcons = config('twill.block_editor.core_icons');
 
+        if (!file_exists($targetDirectory)) {
+            mkdir($targetDirectory);
+        }
+
         foreach (config('twill.block_editor.directories.source.icons') as $iconDirectory) {
             // We do not want to process original icons.
             if ($iconDirectory !== $originalIcons) {


### PR DESCRIPTION
## Description

Quick fix for the command `twill:build` if the app contains custom icons.