### PR TITLE
pass model name for getModelController helper function

### DIFF
--- a/src/Helpers/modules_helpers.php
+++ b/src/Helpers/modules_helpers.php
@@ -92,7 +92,7 @@ if (!function_exists('getModelController')) {
 
         if (!class_exists($controller)) {
             try {
-                $controller = TwillCapsules::getCapsuleForModel($model)->getControllerClass();
+                $controller = TwillCapsules::getCapsuleForModel($modelName)->getControllerClass();
             } catch (NoCapsuleFoundException) {
                 throw new Exception($controller . ' not found');
             }


### PR DESCRIPTION
<!--
  Thanks for opening a PR! Your contribution is much appreciated.
  Do you have any questions? Check out the contributing docs at https://github.com/area17/twill/blob/3.x/CONTRIBUTING.md, or ask in this Pull Request and a Twill maintainer will be happy to help :)
-->

## Description

Tweak for getting the Model Controller when belonging to a Capsule. TwillCapsules::getCapsuleForModel() expects the model name as a string.
