### PR TITLE
Always include `locale` in the mediables pivot

### DIFF
--- a/src/Models/Behaviors/HasMedias.php
+++ b/src/Models/Behaviors/HasMedias.php
@@ -44,20 +44,18 @@ trait HasMedias
             Media::class,
             'mediable',
             config('twill.mediables_table', 'twill_mediables')
-        )->withPivot(
-            array_merge([
-                'crop',
-                'role',
-                'crop_w',
-                'crop_h',
-                'crop_x',
-                'crop_y',
-                'lqip_data',
-                'ratio',
-                'metadatas',
-            ], config('twill.media_library.translated_form_fields', false) ? ['locale'] : [])
-        )
-            ->withTimestamps()->orderBy(config('twill.mediables_table', 'twill_mediables') . '.id', 'asc');
+        )->withPivot([
+            'crop',
+            'role',
+            'crop_w',
+            'crop_h',
+            'crop_x',
+            'crop_y',
+            'lqip_data',
+            'ratio',
+            'metadatas',
+            'locale',
+        ])->withTimestamps()->orderBy(config('twill.mediables_table', 'twill_mediables') . '.id', 'asc');
     }
 
     private function findMedia($role, $crop = 'default')


### PR DESCRIPTION
<!--
  Thanks for opening a PR! Your contribution is much appreciated.
  Do you have any questions? Check out the contributing docs at https://github.com/area17/twill/blob/3.x/CONTRIBUTING.md, or ask in this Pull Request and a Twill maintainer will be happy to help :)
-->

## Description

https://github.com/area17/twill/pull/2320 added support for copying the locale when duplicating models with mediables, but since the locale isn't included in the pivot when the config was false, this would have caused the value from the pivot to be null and thus causes the tests to fail.

The fix is to always include locale in the pivot, regardless of the config.

```
Illuminate\Database\QueryException: SQLSTATE[23000]: Integrity constraint violation: 1048 Column 'locale' cannot be null (Connection: mysql, SQL: insert into `twill_mediables` (`created_at`, `crop`, `crop_h`, `crop_w`, `crop_x`, `crop_y`, `locale`, `media_id`, `mediable_id`, `mediable_type`, `metadatas`, `ratio`, `role`, `updated_at`) values (2023-11-03 08:57:44, default, ?, ?, ?, ?, ?, 1, 2, App\Models\XBleafe, [], default, cover, 2023-11-03 08:57:44))
```
