### PR TITLE
Fixes to reduce excessive number of queries

### DIFF
--- a/src/Models/AppSetting.php
+++ b/src/Models/AppSetting.php
@@ -26,6 +26,19 @@ class AppSetting extends Model
 
     private bool $didRegisterSettingsBlocks = false;
 
+    public static function booted()
+    {
+        self::saving(function (self $model) {
+            /*
+             * Here we remove the 'blocks' relation so that any developer hooking
+             * into the saved event on the AppSetting can still fetch the settings
+             * with the new values. The next time the setting facade is called to
+             * retrieve a setting, the blocks relation is hydrated again.
+             */
+            $model->unsetRelation('blocks');
+        });
+    }
+
     /**
      * @return array|array<int,string>
      */

--- a/src/Services/Settings/SettingsGroup.php
+++ b/src/Services/Settings/SettingsGroup.php
@@ -18,6 +18,8 @@ class SettingsGroup
 
     private ?Closure $availableWhen = null;
 
+    private AppSetting $appSetting;
+
     public static function make(): self
     {
         return new self();
@@ -70,12 +72,9 @@ class SettingsGroup
 
     public function getSettingsModel(): AppSetting
     {
-        $settingsModel = AppSetting::where(['name' => $this->getName()])->first();
-        if (!$settingsModel) {
-            $settingsModel = AppSetting::create(['name' => $this->getName()]);
-        }
-
-        return $settingsModel;
+        return $this->appSetting ??= AppSetting::firstOrCreate([
+            'name' => $this->getName(),
+        ]);
     }
 
     /**

--- a/src/TwillAppSettings.php
+++ b/src/TwillAppSettings.php
@@ -105,7 +105,7 @@ class TwillAppSettings
     {
         $groupObject = $this->getGroupForGroupAndSectionName($group, $section);
 
-        return $groupObject->getSettingsModel()->blocks()
+        return $groupObject->getSettingsModel()->blocks
             ->where('editor_name', $section)
             ->where('parent_id', null)
             ->firstOrFail();

--- a/tests/integration/Settings/SettingsFacadeTest.php
+++ b/tests/integration/Settings/SettingsFacadeTest.php
@@ -5,6 +5,7 @@ namespace A17\Twill\Tests\Integration\Settings;
 use A17\Twill\Exceptions\Settings\SettingsGroupDoesNotExistException;
 use A17\Twill\Exceptions\Settings\SettingsSectionDoesNotExistException;
 use A17\Twill\Facades\TwillAppSettings;
+use A17\Twill\Models\AppSetting;
 use A17\Twill\Services\Settings\SettingsGroup;
 use A17\Twill\Tests\Integration\TestCase;
 
@@ -66,6 +67,9 @@ class SettingsFacadeTest extends TestCase
                 ]
             )
             ->assertStatus(200);
+
+        /** @see AppSetting::booted() */
+        $model->unsetRelation('blocks');
     }
 
     public function testTranslatedSettingsGetter(): void


### PR DESCRIPTION
## Description

In many of our projects, we use settings quite extensively. On one of the pages, the number of queries reached 84 (this includes application logic). With the changes from this PR, we have reduced this to 17.

The change in `SettingsGroup` 'caches' the AppSettings model, as `getSettingsModel()` is called in quite a few placed.

The change in `TwillAppSettings` loads the entire blocks relation into the model instead of creating a new query each time. Even when you have multiple sections within the same AppSettings, the `blocks` will only be loaded once.

The change in the `AppSetting` model is there in case someone wants to hook into the `saved` event of the AppSetting and expects to retrieve the new values. The same logic is in the test because technically the settings are updated in the same 'request' while the blocks were already loaded before the POST request.

## Related Issues

This aims to solve the same problem as #2304
