### PR TITLE
+ | Column - Listing - Link

### DIFF
--- a/src/Services/Listings/Columns/Link.php
+++ b/src/Services/Listings/Columns/Link.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace A17\Twill\Services\Listings\Columns;
+
+use A17\Twill\Models\Contracts\TwillModelContract;
+use A17\Twill\Services\Listings\TableColumn;
+use Closure;
+
+class Link extends TableColumn
+{
+    protected ?Closure $url = null;
+
+    protected Closure|string|null $content = null;
+
+    protected bool $targetBlank = false;
+
+    public function url(Closure $urlFunction): static
+    {
+        $this->url = $urlFunction;
+        return $this;
+    }
+
+    public function content(Closure|string $contentFunction): static
+    {
+        $this->content = $contentFunction;
+        return $this;
+    }
+
+    public function shouldOpenInNewWindow(bool $shouldOpenInNewWindow = true): static
+    {
+        $this->targetBlank = $shouldOpenInNewWindow;
+        return $this;
+    }
+
+    protected function getRenderValue(TwillModelContract $model): string
+    {
+        $url = null;
+        if (($urlFunction = $this->url) !== null) {
+            $url = $urlFunction($model);
+        }
+
+        $content = null;
+        if (($contentFunction = $this->content) !== null) {
+            if (is_string($this->content)) {
+                $content = $this->content;
+            } else {
+                $content = $contentFunction($model);
+            }
+        }
+
+        if ($url === null) {
+            return $content;
+        }
+
+        return
+            '<a href="' . $url . '"' . ($this->targetBlank ? ' target="_blank"' : '') . '>'
+            . ($content ?? $url)
+            . '</a>';
+    }
+}


### PR DESCRIPTION
## Description

Add Link as available Listings Columns, allowing to create a link with:
- url: callback
- content: string or callback
- shouldOpenInNewWindow: to add `target="_blank"` on the rendered link

**Usage examples:**

Link to a route, with the URL displayed and opened in a new window.
```
        $tableColumns->add(
            Link::make()
                ->field('url')
                ->title('URL')
                ->url(function (Model $item) {
                    return route('item.show', ['slug' => $item->slug], true);
                })
                ->shouldOpenInNewWindow()
        );
```

Link to a twill route, with dynamic content.
```
        $tableColumns->add(
            Link::make()
                ->field('requests')
                ->title('Requests')
                ->url(function (Model $item) {
                    $filter = [
                        'status' => 'all',
                        'item' => $item->id,
                    ];
                    return route('twill.requests.index', ['filter' => json_encode($filter)]);
                })
                ->content(function (Model $item) {
                    return $item->requests?->count();
                })
        );
```
