### PR TITLE
Fixes incorrect order of nested items when item is more than 2 levels deep

### DIFF
--- a/src/Models/Behaviors/HasNesting.php
+++ b/src/Models/Behaviors/HasNesting.php
@@ -35,7 +35,7 @@ trait HasNesting
      */
     public function getAncestorsSlug(?string $locale = null): string
     {
-        return $this->getAncestors()->sortBy('_lft')
+        return $this->getAncestors()->sortBy($this->getLftName())
             ->map(function ($i) use ($locale) {
                 return $i->getSlug($locale);
             })

--- a/src/Models/Behaviors/HasNesting.php
+++ b/src/Models/Behaviors/HasNesting.php
@@ -35,7 +35,7 @@ trait HasNesting
      */
     public function getAncestorsSlug(?string $locale = null): string
     {
-        return $this->getAncestors()->reverse()
+        return $this->getAncestors()->sortBy('_lft')
             ->map(function ($i) use ($locale) {
                 return $i->getSlug($locale);
             })


### PR DESCRIPTION
## Incorrect order of nested items when item is more than 2 levels deep.

## Description
The getAncestors() from the nestedset package doesn't set any default order which means that the ancestors returned are in order of creation (id) rather than hierarchical order.

Rather than making the assumption as to what order the ancestor items were created it is better to sort the collection by the _lft column (as the defaultOrder() method does in the package).

See https://github.com/lazychaser/laravel-nestedset#ancestors-and-descendants for more info.

## Related Issues
Fixes https://github.com/area17/twill/issues/2387 https://github.com/area17/twill/issues/2302 https://github.com/area17/twill/issues/2280