### PR TITLE
Fix error cause by missing target dir when copying custom icons

### DIFF
--- a/src/Commands/Build.php
+++ b/src/Commands/Build.php
@@ -237,6 +237,10 @@ class Build extends Command
         $targetDirectory = base_path('vendor/area17/twill/frontend/icons-custom');
         $originalIcons = config('twill.block_editor.core_icons');
 
+        if (!file_exists($targetDirectory)) {
+            mkdir($targetDirectory);
+        }
+
         foreach (config('twill.block_editor.directories.source.icons') as $iconDirectory) {
             // We do not want to process original icons.
             if ($iconDirectory !== $originalIcons) {


### PR DESCRIPTION
## Description

Add a check whether the target directory exists when copying custom icons in order to fix the ErrorException when running "twill:build" and having at least on custom icon. 

This implementation is analogous to that on that [was used in Twill 2.x](https://github.com/area17/twill/blob/a068e1b13c8a7c005bf61d1b57871f941018fc2f/src/Commands/Build.php#L233)

More information can be found in #2391

## Related Issues
 Fixes #2391 