### PR TITLE
Fix getCapsuleForModel() for when passing a Model object

### DIFF
--- a/src/TwillCapsules.php
+++ b/src/TwillCapsules.php
@@ -6,6 +6,7 @@ use A17\Twill\Exceptions\NoCapsuleFoundException;
 use A17\Twill\Helpers\Capsule;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
+use A17\Twill\Models\Contracts\TwillModelContract;
 
 class TwillCapsules
 {
@@ -65,8 +66,14 @@ class TwillCapsules
     /**
      * @throws \A17\Twill\Exceptions\NoCapsuleFoundException
      */
-    public function getCapsuleForModel(string $model): Capsule
+    public function getCapsuleForModel(string|TwillModelContract $model): Capsule
     {
+        if ($model instanceof TwillModelContract) {
+            $model = explode('\\', get_class($model));
+
+            $model = end($model);
+        }
+
         $capsule = $this->getRegisteredCapsules()->first(function (Capsule $capsule) use ($model) {
             return $capsule->getSingular() === $model;
         });


### PR DESCRIPTION
## Description

When trying to to `$model->fullUrl()` I found that I was always getting a `#` instead of the article URL, even having a HasSlug trait added to the model. I ended up finding that because this was a Twill Capsule it was not resolving the Capsule controller correctly, all because an Eloquent Model was being passed to `getCapsuleForModel()` instead of the model name and as it was also hidden behind this exception handler:

```php
try {
    $controller = getModelController($this);
} catch (Exception) {
    // Fallback to never crash on production.
    return '#';
}
```

This PR fixes this and correctly gives us an URL. It may also fix other Capsules resolution errors that could fall in the same "pass a model instead of a model name" category.