### PR TITLE
Automatically add `active` to `$translatedAttributes`

### DIFF
--- a/docs/content/2_guides/1_page-builder-with-blade/5_configuring-the-page-module.md
+++ b/docs/content/2_guides/1_page-builder-with-blade/5_configuring-the-page-module.md
@@ -55,8 +55,8 @@ Refresh the page and you now see that the slug is cleaned up.
 These changes do not affect how the model's slug is stored in the database, it just changes the visual representation of
 it.
 
-Model slugs are always saved purely based on the content you enter. If you enter 'example' in the url field when 
-creating or editing the model, that is what will be saved. 
+Model slugs are always saved purely based on the content you enter. If you enter 'example' in the url field when
+creating or editing the model, that is what will be saved.
 
 The front-end is always responsible for handling the slugs.
 :::#alert:::
@@ -166,7 +166,6 @@ class Page extends Model
     public $translatedAttributes = [
         'title',
         'description',
-        'active',
     ];
 
     public $slugAttributes = [

--- a/docs/content/2_guides/building_a_multilingual_site_with_twill_and_laravel_localization/Article.php
+++ b/docs/content/2_guides/building_a_multilingual_site_with_twill_and_laravel_localization/Article.php
@@ -22,7 +22,6 @@ class Article extends Model implements LocalizedUrlRoutable
     public $translatedAttributes = [
         'title',
         'description',
-        'active',
     ];
 
     public $slugAttributes = [

--- a/examples/basic-page-builder/app/Models/Page.php
+++ b/examples/basic-page-builder/app/Models/Page.php
@@ -22,7 +22,6 @@ class Page extends Model
     public $translatedAttributes = [
         'title',
         'description',
-        'active',
     ];
 
     public $slugAttributes = [

--- a/examples/portfolio/app/Models/Partner.php
+++ b/examples/portfolio/app/Models/Partner.php
@@ -22,7 +22,6 @@ class Partner extends Model
     public $translatedAttributes = [
         'title',
         'description',
-        'active',
     ];
 
     public $slugAttributes = [

--- a/examples/portfolio/app/Models/Project.php
+++ b/examples/portfolio/app/Models/Project.php
@@ -25,7 +25,6 @@ class Project extends Model
     public $translatedAttributes = [
         'title',
         'description',
-        'active',
     ];
 
     public $slugAttributes = [

--- a/examples/tests-capsules/app/Twill/Capsules/Homepages/Models/Homepage.php
+++ b/examples/tests-capsules/app/Twill/Capsules/Homepages/Models/Homepage.php
@@ -9,7 +9,7 @@ use A17\Twill\Models\Behaviors\HasFiles;
 use A17\Twill\Models\Behaviors\HasRevisions;
 use A17\Twill\Models\Model;
 
-class Homepage extends Model 
+class Homepage extends Model
 {
     use HasBlocks, HasTranslation, HasMedias, HasFiles, HasRevisions;
 
@@ -18,11 +18,10 @@ class Homepage extends Model
         'title',
         'description',
     ];
-    
+
     public $translatedAttributes = [
         'title',
         'description',
-        'active',
     ];
-    
+
 }

--- a/examples/tests-capsules/app/Twill/Capsules/Posts/Models/Post.php
+++ b/examples/tests-capsules/app/Twill/Capsules/Posts/Models/Post.php
@@ -24,7 +24,7 @@ class Post extends Model implements Sortable
 
     protected $fillable = ['published', 'title', 'description', 'position'];
 
-    public $translatedAttributes = ['title', 'description', 'active'];
+    public $translatedAttributes = ['title', 'description'];
 
     public $slugAttributes = ['title'];
 

--- a/examples/tests-modules/app/Models/Author.php
+++ b/examples/tests-modules/app/Models/Author.php
@@ -53,7 +53,7 @@ class Author extends Model implements Sortable
     ];
 
     // uncomment and modify this as needed if you use the HasTranslation trait
-    public $translatedAttributes = ['name', 'description', 'active', 'bio'];
+    public $translatedAttributes = ['name', 'description', 'bio'];
 
     // uncomment and modify this as needed if you use the HasSlug trait
     public $slugAttributes = ['name'];

--- a/examples/tests-modules/app/Models/Category.php
+++ b/examples/tests-modules/app/Models/Category.php
@@ -22,7 +22,7 @@ class Category extends Model
     protected $fillable = ['published', 'title', 'description', 'position'];
 
     // uncomment and modify this as needed if you use the HasTranslation trait
-    public $translatedAttributes = ['title', 'active'];
+    public $translatedAttributes = ['title'];
 
     // uncomment and modify this as needed if you use the HasSlug trait
     public $slugAttributes = ['title'];

--- a/examples/tests-singleton/app/Models/ContactPage.php
+++ b/examples/tests-singleton/app/Models/ContactPage.php
@@ -23,7 +23,6 @@ class ContactPage extends Model
     public $translatedAttributes = [
         'title',
         'description',
-        'active',
     ];
 
     public $slugAttributes = [

--- a/examples/tests-subdomain-routing/app/Models/Page.php
+++ b/examples/tests-subdomain-routing/app/Models/Page.php
@@ -22,17 +22,16 @@ class Page extends Model implements Sortable
         'description',
         'position',
     ];
-    
+
     public $translatedAttributes = [
         'title',
         'description',
-        'active',
     ];
-    
+
     public $slugAttributes = [
         'title',
     ];
-    
+
     public $mediasParams = [
         'cover' => [
             'default' => [

--- a/src/Commands/stubs/model.stub
+++ b/src/Commands/stubs/model.stub
@@ -19,7 +19,6 @@ class {{modelClassName}} extends Model {{modelImplements}}
     public $translatedAttributes = [
         'title',
         'description',
-        'active',
     ];
     {{/hasTranslation}}{{hasSlug}}
     public $slugAttributes = [

--- a/src/Models/Behaviors/IsTranslatable.php
+++ b/src/Models/Behaviors/IsTranslatable.php
@@ -29,12 +29,12 @@ trait IsTranslatable
         // If it's a check on certain columns
         // They must be present in the translatedAttributes
         if (filled($columns)) {
-            return collect($this->translatedAttributes)
+            return collect($this->getTranslatedAttributes())
                 ->intersect(collect($columns))
                 ->isNotEmpty();
         }
 
         // The translatedAttributes property must be filled
-        return collect($this->translatedAttributes)->isNotEmpty();
+        return collect($this->getTranslatedAttributes())->isNotEmpty();
     }
 }

--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -158,7 +158,9 @@ abstract class Model extends BaseModel implements TaggableInterface, TwillModelC
 
     public function getTranslatedAttributes(): array
     {
-        return $this->translatedAttributes ?? [];
+        return $this->translatedAttributes
+            ? [...$this->translatedAttributes, 'active']
+            : [];
     }
 
     protected static function bootTaggableTrait(): void

--- a/src/Models/Setting.php
+++ b/src/Models/Setting.php
@@ -21,7 +21,6 @@ class Setting extends Model
     public $translatedAttributes = [
         'value',
         'locale',
-        'active',
     ];
 
     public function getTranslationModelNameDefault()

--- a/src/Repositories/Behaviors/HandleTranslations.php
+++ b/src/Repositories/Behaviors/HandleTranslations.php
@@ -19,7 +19,7 @@ trait HandleTranslations
         if ($this->model->isTranslatable()) {
             $locales = getLocales();
             $localesCount = count($locales);
-            $attributes = Collection::make($this->model->translatedAttributes);
+            $attributes = Collection::make($this->model->getTranslatedAttributes());
 
             $submittedLanguages = Collection::make($fields['languages'] ?? []);
 
@@ -67,9 +67,9 @@ trait HandleTranslations
         $slug = $fields['translations']['slug'] ?? null;
         unset($fields['translations']);
 
-        if ($object->translations !== null && $object->translatedAttributes != null) {
+        if ($object->translations !== null && $object->getTranslatedAttributes() != null) {
             foreach ($object->translations as $translation) {
-                foreach ($object->translatedAttributes as $attribute) {
+                foreach ($object->getTranslatedAttributes() as $attribute) {
                     unset($fields[$attribute]);
                     if (array_key_exists($attribute, $this->fieldsGroups) && is_array($translation->{$attribute})) {
                         foreach ($this->fieldsGroups[$attribute] as $field_name) {
@@ -100,7 +100,7 @@ trait HandleTranslations
     public function orderHandleTranslations(Builder $query, array &$orders): void
     {
         if ($this->model->isTranslatable()) {
-            $attributes = $this->model->translatedAttributes;
+            $attributes = $this->model->getTranslatedAttributes();
             $table = $this->model->getTable();
             $tableTranslation = $this->model->translations()->getRelated()->getTable();
             $foreignKeyMethod = method_exists($this->model->translations(), 'getQualifiedForeignKeyName') ? 'getQualifiedForeignKeyName' : 'getForeignKey';

--- a/src/Repositories/ModuleRepository.php
+++ b/src/Repositories/ModuleRepository.php
@@ -156,7 +156,7 @@ abstract class ModuleRepository
     {
         $builder = $this->model->latest();
 
-        $translatedAttributes = $this->model->translatedAttributes ?? [];
+        $translatedAttributes = $this->model->getTranslatedAttributes() ?? [];
 
         foreach ($fields as $field) {
             if (in_array($field, $translatedAttributes, true)) {


### PR DESCRIPTION
## Description

This PR updates `$translatedAttributes` to automatically add `active`.
`Module` was already adding it to the `getFillable()` method. 

Previously, if you were missing `active` in `$translatedAttributes`, the translations would be saved and would appear as active in the database but would appear as inactive in the admin panel. Adding `active` fixes this issue.

As someone new to Twill it took me a while to understand the connection between `$translatedAttributes` and `active` since this column was added to the migration through the `createDefaultTranslationsTableFields()` helper. 