### PR TITLE
Update migration stub and existing migrations to use anonymous class

### DIFF
--- a/docs/content/1_docs/3_modules/12_nested-modules.md
+++ b/docs/content/1_docs/3_modules/12_nested-modules.md
@@ -68,13 +68,13 @@ Route::get('{slug}', function ($slug) {
 })->where('slug', '.*');
 ```
 
-For more information on how to work with nested items in your application, you can refer to the 
+For more information on how to work with nested items in your application, you can refer to the
 [laravel-nestedset package documentation](https://github.com/lazychaser/laravel-nestedset#retrieving-nodes).
 
 ### Setting a maximum nested depth
 
 You can also define the maximum depth allowed for the module changing the following:
-```php 
+```php
 protected $nestedItemsDepth = 1;
 ```
 Note: a depth of 1 means parent and child.
@@ -100,23 +100,20 @@ We'll use the `slug` and `position` features in this example but you can customi
 
 ```
 php artisan twill:make:module issues -SP
-php artisan twill:make:module issueArticles -SP --parentModel=Issue 
+php artisan twill:make:module issueArticles -SP --parentModel=Issue
 ```
 
 Add the `issue_id` foreign key to the child module's migration:
 
 ```php
-class CreateIssueArticlesTables extends Migration
+public function up()
 {
-    public function up()
-    {
-        Schema::create('issue_articles', function (Blueprint $table) {
-            // ...
-            $table->foreignIdFor(Issue::class);
-        });
-        
+    Schema::create('issue_articles', function (Blueprint $table) {
         // ...
-    }
+        $table->foreignIdFor(Issue::class);
+    });
+
+    // ...
 }
 ```
 
@@ -137,7 +134,7 @@ class IssueArticle extends Model implements Sortable
         // ...
         'issue_id',
     ];
-    
+
     public function issue()
     {
         return $this->belongsTo(Issue::class);

--- a/docs/content/1_docs/4_form-fields/11_repeater.md
+++ b/docs/content/1_docs/4_form-fields/11_repeater.md
@@ -179,19 +179,16 @@ php artisan twill:make:module TeamMember -P
   relationship:
 
 ```php
-class CreateTeamMembersTables extends Migration
+public function up()
 {
-    public function up()
-    {
-        Schema::create('team_members', function (Blueprint $table) {
-            /* ... */
+    Schema::create('team_members', function (Blueprint $table) {
+        /* ... */
 
-            $table->foreignId('team_id')
-                ->constrained()
-                ->onUpdate('cascade')
-                ->onDelete('cascade');
-        });
-    }
+        $table->foreignId('team_id')
+            ->constrained()
+            ->onUpdate('cascade')
+            ->onDelete('cascade');
+    });
 }
 ```
 
@@ -306,5 +303,3 @@ of the repeater items. This directive also accepts a `hidePrefix` option to hide
     :required="true"
 />
 ```
-
-

--- a/docs/content/1_docs/7_media-library/05_custom-metadata.md
+++ b/docs/content/1_docs/7_media-library/05_custom-metadata.md
@@ -1,6 +1,6 @@
 # Custom metadata
 
-By default, media comes with a few metadata attributes that can be filled in from the media managers: 
+By default, media comes with a few metadata attributes that can be filled in from the media managers:
 Tags, Alt text and caption.
 
 Say we want to add more metadata, some of which might be translatable. To do this we have to go through a few
@@ -41,7 +41,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class AddFieldsToMedia extends Migration
+return new class extends Migration
 {
     public function up()
     {
@@ -58,7 +58,7 @@ class AddFieldsToMedia extends Migration
             $table->dropColumn('attribution');
         });
     }
-}
+};
 ```
 
 And that is all. The most important part is to make sure your migration fields are named the same as your custom metadata values in the twill config.

--- a/docs/content/2_guides/1_page-builder-with-blade/4_creating-the-page-module.md
+++ b/docs/content/2_guides/1_page-builder-with-blade/4_creating-the-page-module.md
@@ -129,7 +129,7 @@ We can see that `Route::module('pages');` has been added to `routes/twill.php`.
 
 This is automatic, because it is simple enough to do.
 
-The `routes/twill.php` file is a Twill specific list of routes. These routes are protected and loaded specifically for 
+The `routes/twill.php` file is a Twill specific list of routes. These routes are protected and loaded specifically for
 the CMS.
 
 In standard Laravel there is no `module` method on a `Route` object, this is something Twill provides and it will build
@@ -139,7 +139,7 @@ many routes for your module, these are then used by the cms, controllers and req
 
 The second step, we have to do ourself. So let's open `app/Providers/AppServiceProvider.php`.
 
-We will not go into detail about what a service provider is, for that you can check the 
+We will not go into detail about what a service provider is, for that you can check the
 [official documentation](https://laravel.com/docs/10.x/providers).
 
 In our `boot` method we will add the suggested snippet:
@@ -214,14 +214,14 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreatePagesTables extends Migration
+return new class extends Migration
 {
     public function up()
     {
         Schema::create('pages', function (Blueprint $table) {
             // this will create an id, a "published" column, and soft delete and timestamps columns
             createDefaultTableFields($table);
-            
+
             // add those 2 columns to enable publication timeframe fields
             // (you can use publish_start_date only if you don't need to provide the ability to specify an end date)
             // $table->timestamp('publish_start_date')->nullable();
@@ -250,7 +250,7 @@ class CreatePagesTables extends Migration
         Schema::dropIfExists('page_slugs');
         Schema::dropIfExists('pages');
     }
-}
+};
 ```
 
 This file will create the minimum required tables and columns that Twill uses to provide the CMS functionality. Later in

--- a/docs/content/2_guides/1_page-builder-with-blade/9_adding-navigation.md
+++ b/docs/content/2_guides/1_page-builder-with-blade/9_adding-navigation.md
@@ -62,7 +62,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateMenuLinksTables extends Migration
+return new class extends Migration
 {
     public function up()
     {
@@ -83,7 +83,7 @@ class CreateMenuLinksTables extends Migration
     {
         Schema::dropIfExists('menu_links');
     }
-}
+};
 ```
 
 Now you can run the migration: `php artisan migrate`
@@ -223,7 +223,7 @@ use App\Models\MenuLink;
 class MenuLinkRepository extends ModuleRepository
 {
     protected $relatedBrowsers = ['page'];
-    
+
     use HandleNesting;
 
     public function __construct(MenuLink $model)
@@ -367,7 +367,7 @@ We will change the contents of `resources/views/components/menu.blade.php` to th
 ```
 
 We add just a minimal amount of styling as we will not spend too much time on that during this guide. But this will
-build a navigation tree that is slightly indented so that you can see the proper structure. 
+build a navigation tree that is slightly indented so that you can see the proper structure.
 
 You cannot see it in action yet, for that we have to add the component to the main template file.
 
@@ -389,7 +389,7 @@ But, for this guide, we will simply open `resources/views/site/page.blade.php` a
 </head>
 <body>
 <x-menu/> <!-- [tl! ++] -->
-<div class="mx-auto max-w-2xl">
+<div class="max-w-2xl mx-auto">
     {!! $item->renderBlocks() !!}
 </div>
 </body>
@@ -402,4 +402,3 @@ Wherever you will put `<x-menu/>` it will render the menu. That's useful because
 Now that we have pages and a menu, we have one last thing we need to do.
 
 [We need a frontpage](./10_setup-the-frontpage.md)!
-

--- a/docs/content/2_guides/json_repeaters/migration.php
+++ b/docs/content/2_guides/json_repeaters/migration.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateProjectsTables extends Migration
+return new class extends Migration
 {
     public function up()
     {
@@ -20,4 +20,4 @@ class CreateProjectsTables extends Migration
     {
         Schema::dropIfExists('projects');
     }
-}
+};

--- a/docs/content/2_guides/manage_frontend_user_profiles_from_twill/2021_08_01_204153_create_profiles_tables.php
+++ b/docs/content/2_guides/manage_frontend_user_profiles_from_twill/2021_08_01_204153_create_profiles_tables.php
@@ -3,7 +3,7 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 
-class CreateProfilesTables extends Migration
+return new class extends Migration
 {
     public function up()
     {
@@ -27,4 +27,4 @@ class CreateProfilesTables extends Migration
     {
         Schema::dropIfExists('profiles');
     }
-}
+};

--- a/docs/content/2_guides/prefill-block-editor-from-template/2021_09_19_131244_create_articles_tables.php
+++ b/docs/content/2_guides/prefill-block-editor-from-template/2021_09_19_131244_create_articles_tables.php
@@ -3,7 +3,7 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 
-class CreateArticlesTables extends Migration
+return new class extends Migration
 {
     public function up()
     {
@@ -31,4 +31,4 @@ class CreateArticlesTables extends Migration
         Schema::dropIfExists('article_slugs');
         Schema::dropIfExists('articles');
     }
-}
+};

--- a/examples/portfolio/database/migrations/2022_04_01_071515_create_projects_tables.php
+++ b/examples/portfolio/database/migrations/2022_04_01_071515_create_projects_tables.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateProjectsTables extends Migration
+return new class extends Migration
 {
     public function up(): void
     {
@@ -34,4 +34,4 @@ class CreateProjectsTables extends Migration
         Schema::dropIfExists('project_slugs');
         Schema::dropIfExists('projects');
     }
-}
+};

--- a/examples/portfolio/database/migrations/2022_04_01_071748_create_partners_tables.php
+++ b/examples/portfolio/database/migrations/2022_04_01_071748_create_partners_tables.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreatePartnersTables extends Migration
+return new class extends Migration
 {
     public function up(): void
     {
@@ -44,4 +44,4 @@ class CreatePartnersTables extends Migration
         Schema::dropIfExists('partner_slugs');
         Schema::dropIfExists('partners');
     }
-}
+};

--- a/examples/portfolio/database/migrations/2022_04_06_070334_create_comments_tables.php
+++ b/examples/portfolio/database/migrations/2022_04_06_070334_create_comments_tables.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateCommentsTables extends Migration
+return new class extends Migration
 {
     public function up(): void
     {
@@ -21,4 +21,4 @@ class CreateCommentsTables extends Migration
     {
         Schema::dropIfExists('comments');
     }
-}
+};

--- a/examples/portfolio/database/migrations/2022_05_30_074255_create_links_tables.php
+++ b/examples/portfolio/database/migrations/2022_05_30_074255_create_links_tables.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateLinksTables extends Migration
+return new class extends Migration
 {
     public function up(): void
     {
@@ -23,4 +23,4 @@ class CreateLinksTables extends Migration
     {
         Schema::dropIfExists('links');
     }
-}
+};

--- a/examples/tests-browsers/database/migrations/2021_08_10_0001_create_writers_tables_for_browsers.php
+++ b/examples/tests-browsers/database/migrations/2021_08_10_0001_create_writers_tables_for_browsers.php
@@ -3,7 +3,7 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 
-class CreateWritersTablesForBrowsers extends Migration
+return new class extends Migration
 {
     public function up()
     {
@@ -23,4 +23,4 @@ class CreateWritersTablesForBrowsers extends Migration
         Schema::dropIfExists('writer_revisions');
         Schema::dropIfExists('writers');
     }
-}
+};

--- a/examples/tests-browsers/database/migrations/2021_08_10_0002_create_letters_tables_for_browsers.php
+++ b/examples/tests-browsers/database/migrations/2021_08_10_0002_create_letters_tables_for_browsers.php
@@ -3,7 +3,7 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 
-class CreateLettersTablesForBrowsers extends Migration
+return new class extends Migration
 {
     public function up()
     {
@@ -23,4 +23,4 @@ class CreateLettersTablesForBrowsers extends Migration
         Schema::dropIfExists('letter_revisions');
         Schema::dropIfExists('letters');
     }
-}
+};

--- a/examples/tests-browsers/database/migrations/2021_08_10_0003_create_letter_writer_table_for_browsers.php
+++ b/examples/tests-browsers/database/migrations/2021_08_10_0003_create_letter_writer_table_for_browsers.php
@@ -3,7 +3,7 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 
-class CreateLetterWriterTableForBrowsers extends Migration
+return new class extends Migration
 {
     public function up()
     {
@@ -19,4 +19,4 @@ class CreateLetterWriterTableForBrowsers extends Migration
     {
         Schema::dropIfExists('letter_writer');
     }
-}
+};

--- a/examples/tests-browsers/database/migrations/2021_08_10_0004_create_bios_tables_for_browsers.php
+++ b/examples/tests-browsers/database/migrations/2021_08_10_0004_create_bios_tables_for_browsers.php
@@ -3,7 +3,7 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 
-class CreateBiosTablesForBrowsers extends Migration
+return new class extends Migration
 {
     public function up()
     {
@@ -25,4 +25,4 @@ class CreateBiosTablesForBrowsers extends Migration
         Schema::dropIfExists('bio_revisions');
         Schema::dropIfExists('bios');
     }
-}
+};

--- a/examples/tests-browsers/database/migrations/2021_08_10_0005_create_books_tables_for_browsers.php
+++ b/examples/tests-browsers/database/migrations/2021_08_10_0005_create_books_tables_for_browsers.php
@@ -3,7 +3,7 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 
-class CreateBooksTablesForBrowsers extends Migration
+return new class extends Migration
 {
     public function up()
     {
@@ -23,4 +23,4 @@ class CreateBooksTablesForBrowsers extends Migration
         Schema::dropIfExists('book_revisions');
         Schema::dropIfExists('books');
     }
-}
+};

--- a/examples/tests-capsules/app/Twill/Capsules/Homepages/database/migrations/2023_01_02_082723_create_homepages_tables.php
+++ b/examples/tests-capsules/app/Twill/Capsules/Homepages/database/migrations/2023_01_02_082723_create_homepages_tables.php
@@ -4,14 +4,14 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateHomepagesTables extends Migration
+return new class extends Migration
 {
     public function up()
     {
         Schema::create('homepages', function (Blueprint $table) {
             // this will create an id, a "published" column, and soft delete and timestamps columns
             createDefaultTableFields($table);
-            
+
             // add those 2 columns to enable publication timeframe fields (you can use publish_start_date only if you don't need to provide the ability to specify an end date)
             // $table->timestamp('publish_start_date')->nullable();
             // $table->timestamp('publish_end_date')->nullable();
@@ -34,4 +34,4 @@ class CreateHomepagesTables extends Migration
         Schema::dropIfExists('homepage_translations');
         Schema::dropIfExists('homepages');
     }
-}
+};

--- a/examples/tests-capsules/app/Twill/Capsules/Posts/database/migrations/2020_08_14_205624_create_posts_tables.php
+++ b/examples/tests-capsules/app/Twill/Capsules/Posts/database/migrations/2020_08_14_205624_create_posts_tables.php
@@ -3,7 +3,7 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 
-class CreatePostsTables extends Migration
+return new class extends Migration
 {
     public function up()
     {
@@ -40,4 +40,4 @@ class CreatePostsTables extends Migration
         Schema::dropIfExists('post_slugs');
         Schema::dropIfExists('posts');
     }
-}
+};

--- a/examples/tests-deep-nested/database/migrations/2022_11_25_113826_create_clients_tables.php
+++ b/examples/tests-deep-nested/database/migrations/2022_11_25_113826_create_clients_tables.php
@@ -4,35 +4,35 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateClientsTables extends Migration
+return new class extends Migration
 {
     public function up()
     {
         Schema::create('clients', function (Blueprint $table) {
             // this will create an id, a "published" column, and soft delete and timestamps columns
             createDefaultTableFields($table);
-            
+
             // feel free to modify the name of this column, but title is supported by default (you would need to specify the name of the column Twill should consider as your "title" column in your module controller if you change it)
             $table->string('title', 200)->nullable();
 
             // your generated model and form include a description field, to get you started, but feel free to get rid of it if you don't need it
             $table->text('description')->nullable();
-            
+
             // add those 2 columns to enable publication timeframe fields (you can use publish_start_date only if you don't need to provide the ability to specify an end date)
             // $table->timestamp('publish_start_date')->nullable();
             // $table->timestamp('publish_end_date')->nullable();
         });
 
-        
 
-        
 
-        
+
+
+
     }
 
     public function down()
     {
-        
+
         Schema::dropIfExists('clients');
     }
-}
+};

--- a/examples/tests-deep-nested/database/migrations/2022_11_25_114216_create_client_projects_tables.php
+++ b/examples/tests-deep-nested/database/migrations/2022_11_25_114216_create_client_projects_tables.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateClientProjectsTables extends Migration
+return new class extends Migration
 {
     public function up()
     {
@@ -36,4 +36,4 @@ class CreateClientProjectsTables extends Migration
 
         Schema::dropIfExists('client_projects');
     }
-}
+};

--- a/examples/tests-deep-nested/database/migrations/2022_11_25_114233_create_client_project_applications_tables.php
+++ b/examples/tests-deep-nested/database/migrations/2022_11_25_114233_create_client_project_applications_tables.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateClientProjectApplicationsTables extends Migration
+return new class extends Migration
 {
     public function up()
     {
@@ -23,17 +23,10 @@ class CreateClientProjectApplicationsTables extends Migration
             // $table->timestamp('publish_start_date')->nullable();
             // $table->timestamp('publish_end_date')->nullable();
         });
-
-
-
-
-
-
     }
 
     public function down()
     {
-
         Schema::dropIfExists('client_project_applications');
     }
-}
+};

--- a/examples/tests-modules/database/migrations/2021_10_17_174613_create_categories_tables.php
+++ b/examples/tests-modules/database/migrations/2021_10_17_174613_create_categories_tables.php
@@ -4,7 +4,7 @@ use Kalnoy\Nestedset\NestedSet;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 
-class CreateCategoriesTables extends Migration
+return new class extends Migration
 {
     public function up()
     {
@@ -54,4 +54,4 @@ class CreateCategoriesTables extends Migration
 
         Schema::dropIfExists('categories');
     }
-}
+};

--- a/examples/tests-modules/database/migrations/2021_10_18_193753_create_authors_tables.php
+++ b/examples/tests-modules/database/migrations/2021_10_18_193753_create_authors_tables.php
@@ -3,7 +3,7 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 
-class CreateAuthorsTables extends Migration
+return new class extends Migration
 {
     public function up()
     {
@@ -75,4 +75,4 @@ class CreateAuthorsTables extends Migration
 
         Schema::dropIfExists('authors');
     }
-}
+};

--- a/examples/tests-modules/database/migrations/2022_05_25_083741_create_revision_limited_contents_tables.php
+++ b/examples/tests-modules/database/migrations/2022_05_25_083741_create_revision_limited_contents_tables.php
@@ -4,20 +4,20 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateRevisionLimitedContentsTables extends Migration
+return new class extends Migration
 {
     public function up()
     {
         Schema::create('revision_limiteds', function (Blueprint $table) {
             // this will create an id, a "published" column, and soft delete and timestamps columns
             createDefaultTableFields($table);
-            
+
             // feel free to modify the name of this column, but title is supported by default (you would need to specify the name of the column Twill should consider as your "title" column in your module controller if you change it)
             $table->string('title', 200)->nullable();
 
             // your generated model and form include a description field, to get you started, but feel free to get rid of it if you don't need it
             $table->text('description')->nullable();
-            
+
             // add those 2 columns to enable publication timeframe fields (you can use publish_start_date only if you don't need to provide the ability to specify an end date)
             // $table->timestamp('publish_start_date')->nullable();
             // $table->timestamp('publish_end_date')->nullable();
@@ -33,4 +33,4 @@ class CreateRevisionLimitedContentsTables extends Migration
         Schema::dropIfExists('revision_limited_revisions');
         Schema::dropIfExists('revision_limited');
     }
-}
+};

--- a/examples/tests-nestedmodules/database/migrations/2021_09_16_230238_create_nodes_tables.php
+++ b/examples/tests-nestedmodules/database/migrations/2021_09_16_230238_create_nodes_tables.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateNodesTables extends Migration
+return new class extends Migration
 {
     public function up()
     {
@@ -25,4 +25,4 @@ class CreateNodesTables extends Migration
     {
         Schema::dropIfExists('nodes');
     }
-}
+};

--- a/examples/tests-permissions/database/migrations/2021_07_20_132405_create_postings_tables.php
+++ b/examples/tests-permissions/database/migrations/2021_07_20_132405_create_postings_tables.php
@@ -3,7 +3,7 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 
-class CreatePostingsTables extends Migration
+return new class extends Migration
 {
     public function up()
     {
@@ -18,4 +18,4 @@ class CreatePostingsTables extends Migration
     {
         Schema::dropIfExists('postings');
     }
-}
+};

--- a/examples/tests-singleton/database/migrations/2021_09_30_202102_create_contact_pages_tables.php
+++ b/examples/tests-singleton/database/migrations/2021_09_30_202102_create_contact_pages_tables.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateContactPagesTables extends Migration
+return new class extends Migration
 {
     public function up()
     {
@@ -34,4 +34,4 @@ class CreateContactPagesTables extends Migration
         Schema::dropIfExists('contact_page_slugs');
         Schema::dropIfExists('contact_pages');
     }
-}
+};

--- a/examples/tests-subdomain-routing/database/migrations/2022_08_17_112843_create_pages_tables.php
+++ b/examples/tests-subdomain-routing/database/migrations/2022_08_17_112843_create_pages_tables.php
@@ -4,16 +4,16 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreatePagesTables extends Migration
+return new class extends Migration
 {
     public function up()
     {
         Schema::create('pages', function (Blueprint $table) {
             // this will create an id, a "published" column, and soft delete and timestamps columns
             createDefaultTableFields($table);
-            
+
             $table->integer('position')->unsigned()->nullable();
-            
+
             // add those 2 columns to enable publication timeframe fields (you can use publish_start_date only if you don't need to provide the ability to specify an end date)
             // $table->timestamp('publish_start_date')->nullable();
             // $table->timestamp('publish_end_date')->nullable();
@@ -41,4 +41,4 @@ class CreatePagesTables extends Migration
         Schema::dropIfExists('page_slugs');
         Schema::dropIfExists('pages');
     }
-}
+};

--- a/migrations/default/2020_02_09_000001_create_twill_default_users_tables.php
+++ b/migrations/default/2020_02_09_000001_create_twill_default_users_tables.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateTwillDefaultUsersTables extends Migration
+return new class extends Migration
 {
     /**
      * Run the migrations.
@@ -49,4 +49,4 @@ class CreateTwillDefaultUsersTables extends Migration
         Schema::dropIfExists(config('twill.password_resets_table', 'twill_password_resets'));
         Schema::dropIfExists(config('twill.users_table', 'twill_users'));
     }
-}
+};

--- a/migrations/default/2020_02_09_000002_create_twill_default_blocks_table.php
+++ b/migrations/default/2020_02_09_000002_create_twill_default_blocks_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateTwillDefaultBlocksTable extends Migration
+return new class extends Migration
 {
     /**
      * Run the migrations.
@@ -41,4 +41,4 @@ class CreateTwillDefaultBlocksTable extends Migration
 
         Schema::dropIfExists($twillBlocksTable);
     }
-}
+};

--- a/migrations/default/2020_02_09_000003_create_twill_default_medias_tables.php
+++ b/migrations/default/2020_02_09_000003_create_twill_default_medias_tables.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateTwillDefaultMediasTables extends Migration
+return new class extends Migration
 {
     /**
      * Run the migrations.
@@ -66,4 +66,4 @@ class CreateTwillDefaultMediasTables extends Migration
         Schema::dropIfExists($twillMediablesTable);
         Schema::dropIfExists($twillMediasTable);
     }
-}
+};

--- a/migrations/default/2020_02_09_000004_create_twill_default_files_tables.php
+++ b/migrations/default/2020_02_09_000004_create_twill_default_files_tables.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateTwillDefaultFilesTables extends Migration
+return new class extends Migration
 {
     /**
      * Run the migrations.
@@ -56,4 +56,4 @@ class CreateTwillDefaultFilesTables extends Migration
         Schema::dropIfExists($twillFileablesTable);
         Schema::dropIfExists($twillFilesTable);
     }
-}
+};

--- a/migrations/default/2020_02_09_000005_create_twill_default_settings_table.php
+++ b/migrations/default/2020_02_09_000005_create_twill_default_settings_table.php
@@ -5,7 +5,7 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
 
-class CreateTwillDefaultSettingsTable extends Migration
+return new class extends Migration
 {
     /**
      * Run the migrations.
@@ -46,4 +46,4 @@ class CreateTwillDefaultSettingsTable extends Migration
         Schema::dropIfExists(Str::singular($twillSettingsTable) . '_translations');
         Schema::dropIfExists($twillSettingsTable);
     }
-}
+};

--- a/migrations/default/2020_02_09_000006_create_twill_default_tags_tables.php
+++ b/migrations/default/2020_02_09_000006_create_twill_default_tags_tables.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateTwillDefaultTagsTables extends Migration
+return new class extends Migration
 {
     /**
      * Run the migrations.
@@ -49,4 +49,4 @@ class CreateTwillDefaultTagsTables extends Migration
         Schema::dropIfExists(config('twill.tags_table', 'twill_tags'));
         Schema::dropIfExists(config('twill.tagged_table', 'twill_tagged'));
     }
-}
+};

--- a/migrations/default/2020_02_09_000007_create_twill_default_activity_log_table.php
+++ b/migrations/default/2020_02_09_000007_create_twill_default_activity_log_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateTwillDefaultActivityLogTable extends Migration
+return new class extends Migration
 {
     /**
      * Run the migrations.
@@ -35,4 +35,4 @@ class CreateTwillDefaultActivityLogTable extends Migration
     {
         Schema::dropIfExists(config('activitylog.table_name'));
     }
-}
+};

--- a/migrations/default/2020_02_09_000008_create_twill_default_features_table.php
+++ b/migrations/default/2020_02_09_000008_create_twill_default_features_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateTwillDefaultFeaturesTable extends Migration
+return new class extends Migration
 {
     /**
      * Run the migrations.
@@ -40,4 +40,4 @@ class CreateTwillDefaultFeaturesTable extends Migration
 
         Schema::dropIfExists($twillFeaturesTable);
     }
-}
+};

--- a/migrations/default/2020_02_09_000010_create_twill_default_related_table.php
+++ b/migrations/default/2020_02_09_000010_create_twill_default_related_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateTwillDefaultRelatedTable extends Migration
+return new class extends Migration
 {
     /**
      * Run the migrations.
@@ -44,4 +44,4 @@ class CreateTwillDefaultRelatedTable extends Migration
 
         Schema::dropIfExists($twillRelatedTable);
     }
-}
+};

--- a/migrations/default/2020_02_09_000011_add_locale_column_to_twill_default-mediables.php
+++ b/migrations/default/2020_02_09_000011_add_locale_column_to_twill_default-mediables.php
@@ -3,7 +3,7 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 
-class AddLocaleColumnToTwillDefaultMediables extends Migration
+return new class extends Migration
 {
     public function up()
     {
@@ -30,4 +30,4 @@ class AddLocaleColumnToTwillDefaultMediables extends Migration
     {
         return getLocales()[0] ?? config('app.locale');
     }
-}
+};

--- a/migrations/default/2020_02_09_000012_change_locale_column_in_twill_default_fileables.php
+++ b/migrations/default/2020_02_09_000012_change_locale_column_in_twill_default_fileables.php
@@ -3,7 +3,7 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 
-class ChangeLocaleColumnInTwillDefaultFileables extends Migration
+return new class extends Migration
 {
     public function up()
     {
@@ -22,4 +22,4 @@ class ChangeLocaleColumnInTwillDefaultFileables extends Migration
             });
         }
     }
-}
+};

--- a/migrations/default/2020_02_09_000013_add_language_column_to_twill_default_users.php
+++ b/migrations/default/2020_02_09_000013_add_language_column_to_twill_default_users.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class AddLanguageColumnToTwillDefaultUsers extends Migration
+return new class extends Migration
 {
     /**
      * Run the migrations.
@@ -37,4 +37,4 @@ class AddLanguageColumnToTwillDefaultUsers extends Migration
             });
         }
     }
-}
+};

--- a/migrations/default/2020_02_09_000014_add_editor_name_column_to_blocks_table.php
+++ b/migrations/default/2020_02_09_000014_add_editor_name_column_to_blocks_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class AddEditorNameColumnToBlocksTable extends Migration
+return new class extends Migration
 {
     /**
      * Run the migrations.
@@ -37,4 +37,4 @@ class AddEditorNameColumnToBlocksTable extends Migration
             });
         }
     }
-}
+};

--- a/migrations/default/2021_07_08_000001_update_twill_default_users_table.php
+++ b/migrations/default/2021_07_08_000001_update_twill_default_users_table.php
@@ -5,7 +5,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class UpdateTwillDefaultUsersTable extends Migration
+return new class extends Migration
 {
     /**
      * Run the migrations.
@@ -57,4 +57,4 @@ class UpdateTwillDefaultUsersTable extends Migration
             }
         });
     }
-}
+};

--- a/migrations/default/2022_01_25_000015_add_columns_to_activity_log_table.php
+++ b/migrations/default/2022_01_25_000015_add_columns_to_activity_log_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class AddColumnsToActivityLogTable extends Migration
+return new class extends Migration
 {
     /**
      * Run the migrations.
@@ -57,4 +57,4 @@ class AddColumnsToActivityLogTable extends Migration
             );
         }
     }
-}
+};

--- a/migrations/default/2022_04_05_000015_update_activity_log_morph_size.php
+++ b/migrations/default/2022_04_05_000015_update_activity_log_morph_size.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class UpdateActivityLogMorphSize extends Migration
+return new class extends Migration
 {
     /**
      * Run the migrations.
@@ -57,4 +57,4 @@ class UpdateActivityLogMorphSize extends Migration
             );
         }
     }
-}
+};

--- a/migrations/default/2022_08_29_110837_create_app_settings_tables.php
+++ b/migrations/default/2022_08_29_110837_create_app_settings_tables.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class() extends Migration {
+return new class extends Migration {
     public function up(): void
     {
         Schema::create('app_settings', function (Blueprint $table) {

--- a/migrations/optional/permissions-management/2020_04_20_000001_support_permission.php
+++ b/migrations/optional/permissions-management/2020_04_20_000001_support_permission.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 
-class SupportPermission extends Migration
+return new class extends Migration
 {
     /**
      * Run the migrations.
@@ -188,4 +188,4 @@ class SupportPermission extends Migration
         $everyoneGroup->is_everyone_group = true;
         $everyoneGroup->save();
     }
-}
+};

--- a/migrations/optional/permissions-management/2020_06_17_000002_add_subdomains_access_column_to_groups_table.php
+++ b/migrations/optional/permissions-management/2020_06_17_000002_add_subdomains_access_column_to_groups_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class AddSubdomainsAccessColumnToGroupsTable extends Migration
+return new class extends Migration
 {
     /**
      * Run the migrations.
@@ -33,4 +33,4 @@ class AddSubdomainsAccessColumnToGroupsTable extends Migration
             });
         }
     }
-}
+};

--- a/migrations/optional/permissions-management/2021_07_08_000002_update_twill_users_role_fields.php
+++ b/migrations/optional/permissions-management/2021_07_08_000002_update_twill_users_role_fields.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 
-class UpdateTwillUsersRoleFields extends Migration
+return new class extends Migration
 {
     /**
      * Run the migrations.
@@ -113,4 +113,4 @@ class UpdateTwillUsersRoleFields extends Migration
             }
         });
     }
-}
+};

--- a/migrations/optional/users-2fa/2020_02_09_000013_add_two_factor_auth_columns_to_twill_default_users.php
+++ b/migrations/optional/users-2fa/2020_02_09_000013_add_two_factor_auth_columns_to_twill_default_users.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class AddTwoFactorAuthColumnsToTwillDefaultUsers extends Migration
+return new class extends Migration
 {
     /**
      * Run the migrations.
@@ -53,4 +53,4 @@ class AddTwoFactorAuthColumnsToTwillDefaultUsers extends Migration
         }
     }
 
-}
+};

--- a/migrations/optional/users-oauth/2020_02_09_000014_create_twill_default_users_oauth_table.php
+++ b/migrations/optional/users-oauth/2020_02_09_000014_create_twill_default_users_oauth_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateTwillDefaultUsersOauthTable extends Migration
+return new class extends Migration
 {
     /**
      * Run the migrations.
@@ -41,4 +41,4 @@ class CreateTwillDefaultUsersOauthTable extends Migration
     {
         Schema::dropIfExists(config('twill.users_oauth_table', 'twill_users_oauth'));
     }
-}
+};

--- a/src/Commands/ModuleMake.php
+++ b/src/Commands/ModuleMake.php
@@ -481,7 +481,6 @@ PHP;
     private function createMigration($moduleName = 'items')
     {
         $table = Str::snake($moduleName);
-        $tableClassName = Str::studly($table);
 
         $migrationName = 'create_' . $table . '_tables';
 
@@ -493,8 +492,8 @@ PHP;
             $fullPath = $this->laravel['migration.creator']->create($migrationName, $migrationPath);
 
             $stub = str_replace(
-                ['{{table}}', '{{singularTableName}}', '{{tableClassName}}'],
-                [$table, Str::singular($table), $tableClassName],
+                ['{{table}}', '{{singularTableName}}'],
+                [$table, Str::singular($table)],
                 $this->files->get(__DIR__ . '/stubs/migration.stub')
             );
 

--- a/src/Commands/stubs/migration.stub
+++ b/src/Commands/stubs/migration.stub
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class Create{{tableClassName}}Tables extends Migration
+return new class extends Migration
 {
     public function up()
     {
@@ -50,4 +50,4 @@ class Create{{tableClassName}}Tables extends Migration
         Schema::dropIfExists('{{singularTableName}}_slugs');{{/hasSlug}}
         Schema::dropIfExists('{{table}}');
     }
-}
+};


### PR DESCRIPTION
## Description

This PR updates the migration stub to return an anonymous class.
Released in [Laravel 8.37](https://github.com/laravel/framework/pull/36906) it solves an issue with migration class name collisions (see https://github.com/area17/twill/commit/74173acd0b750243c2d3bab382ed842f36efdce9)

- Updates migration stub
- Updates docs
- Updates existing migrations

[Updating the existing migrations](https://github.com/area17/twill/commit/bcff48ca22533edc104018e6456089864598c6ce) is not required and can be reverted to reduce the number of files modified with this PR. 

