### PR TITLE
Use model configuration in the relationship morph map

### DIFF
--- a/src/TwillServiceProvider.php
+++ b/src/TwillServiceProvider.php
@@ -143,11 +143,11 @@ class TwillServiceProvider extends ServiceProvider
         }
 
         Relation::morphMap([
-            'users' => User::class,
+            'users' => config('twill.models.user', User::class),
             'media' => Media::class,
             'files' => File::class,
-            'blocks' => Block::class,
-            'groups' => Group::class,
+            'blocks' => config('twill.models.block', Block::class),
+            'groups' => config('twill.models.group', Group::class),
         ]);
 
         config(['twill.version' => $this->version()]);


### PR DESCRIPTION
There is a bug in the package in case you change the model configuration and you already have relational data in the database.

In my case, I had an app setting that saves a relation to a page. After changing the block class through the model configuration, I got some strange errors. This adjustment in the package resolved the errors.