### PR TITLE
Feature/block editor allow blocks to be excluded

### DIFF
--- a/docs/content/1_docs/5_block-editor/02_creating-a-block-editor.md
+++ b/docs/content/1_docs/5_block-editor/02_creating-a-block-editor.md
@@ -31,6 +31,17 @@ BlockEditor::make()
 <x-twill::block-editor
     :blocks="$blocks"
 />
+
+@php
+    $excludeBlocks = [
+        'title',
+        'quote'
+    ];
+@endphp
+
+<x-twill::block-editor
+    :excludeBlocks="$excludeBlocks"
+/>
 ```
 
 :::#tab:::
@@ -40,6 +51,10 @@ BlockEditor::make()
 ```blade
 @formField('block_editor', [
     'blocks' => ['title', 'quote', 'text', 'image', 'grid', 'test', 'publications', 'news']
+])
+
+@formField('block_editor', [
+    'excludeBlocks' => ['title', 'quote']
 ])
 ```
 

--- a/src/Helpers/helpers.php
+++ b/src/Helpers/helpers.php
@@ -251,9 +251,10 @@ if (! function_exists('generate_list_of_available_blocks')) {
                         return false;
                     }
 
-                    if (in_array($block->name, $excludeBlocks)) {
-                        return false;
-                    }
+                }
+
+                if (in_array($block->name, $excludeBlocks)) {
+                    return false;
                 }
 
                 return (filled($blocks) ? collect($blocks)->contains($block->name) || collect($blocks)->contains(ltrim($block->componentClass, '\\')) : true)

--- a/src/Helpers/helpers.php
+++ b/src/Helpers/helpers.php
@@ -221,7 +221,7 @@ if (! function_exists('generate_list_of_available_blocks')) {
      * @param array $groups
      * @return array
      */
-    function generate_list_of_available_blocks($blocks, $groups, bool $settingsOnly = false): array
+    function generate_list_of_available_blocks($blocks, $groups, bool $settingsOnly = false, array $excludeBlocks = []): array
     {
         if ($settingsOnly) {
             $blockList = TwillBlocks::getSettingsBlocks();
@@ -234,7 +234,7 @@ if (! function_exists('generate_list_of_available_blocks')) {
         });
 
         $finalBlockList = $blockList->filter(
-            function (Block $block) use ($blocks, $groups, $appBlocksList) {
+            function (Block $block) use ($blocks, $groups, $appBlocksList, $excludeBlocks) {
                 if ($block->group === A17\Twill\Services\Blocks\Block::SOURCE_TWILL) {
                     if (! collect(config('twill.block_editor.use_twill_blocks'))->contains($block->name)) {
                         return false;
@@ -248,6 +248,10 @@ if (! function_exists('generate_list_of_available_blocks')) {
                             }
                         )
                     ) {
+                        return false;
+                    }
+
+                    if (in_array($block->name, $excludeBlocks)) {
                         return false;
                     }
                 }

--- a/src/Helpers/helpers.php
+++ b/src/Helpers/helpers.php
@@ -250,7 +250,6 @@ if (! function_exists('generate_list_of_available_blocks')) {
                     ) {
                         return false;
                     }
-
                 }
 
                 if (in_array($block->name, $excludeBlocks)) {

--- a/src/Services/Forms/Fields/BlockEditor.php
+++ b/src/Services/Forms/Fields/BlockEditor.php
@@ -6,6 +6,8 @@ class BlockEditor extends BaseFormField
 {
     protected array $blocks = [];
 
+    protected array $excludeBlocks = [];
+
     protected bool $isSettings = false;
 
     protected bool $withoutSeparator = false;
@@ -47,6 +49,16 @@ class BlockEditor extends BaseFormField
     public function blocks(array $blocks): static
     {
         $this->blocks = $blocks;
+
+        return $this;
+    }
+
+    /**
+     * Use this method if you want to exclude any block types
+     */
+    public function excludeBlocks(array $blocks): static
+    {
+        $this->excludeBlocks = $blocks;
 
         return $this;
     }

--- a/src/View/Components/Fields/BlockEditor.php
+++ b/src/View/Components/Fields/BlockEditor.php
@@ -14,6 +14,7 @@ class BlockEditor extends TwillFormComponent
         bool $renderForModal = false,
         // Component specific
         public array $blocks = [],
+        public array $excludeBlocks = [],
         public array $groups = [],
         public bool $withoutSeparator = false,
         public ?string $group = null,
@@ -45,7 +46,8 @@ class BlockEditor extends TwillFormComponent
                 'allowedBlocks' => generate_list_of_available_blocks(
                     $this->blocks ?? null,
                     $groups,
-                    $this->isSettings
+                    $this->isSettings,
+                    $this->excludeBlocks ?? null,
                 ),
                 'editorName' => [
                     'label' => $this->label,


### PR DESCRIPTION

## Description

Currently the BlockEditor either includes all available blocks (default) or you can pass in an array of blocks you want to include.

```php
BlockEditor::make()

 
BlockEditor::make()

    ->blocks(['title', 'quote', 'text'])
```

We recently had a case where we had a large number of blocks but for a few modules we didn't want to include all of the blocks but instead we need to include all except 1 or 2 blocks.

Rather than using the above to include the blocks we wanted it seemed to make sense to also have to option to include all except ...

This PR allows us to be able to exclude specific blocks from the BlockEditor.

```php
// FormBuilder
BlockEditor::make()->excludeBlocks(['exclude-this-block'])

// Directive
@formField('block_editor', [
    'excludeBlocks' => ['exclude-this-block']
])

// Formview
@php
    $excludeBlocks = [
         'exclude-this-block'
    ];
@endphp

<x-twill::block-editor
    :excludeBlocks="$excludeBlocks"
/>
```