### PR TITLE
bug fix where 'php artisan migrate:reset' would error.

### DIFF
--- a/migrations/default/2023_03_24_125122_add_id_to_related.php
+++ b/migrations/default/2023_03_24_125122_add_id_to_related.php
@@ -27,8 +27,10 @@ return new class extends Migration {
 
     public function down(): void
     {
-        Schema::table(config('twill.related_table', 'twill_related'), function (Blueprint $table) {
-            $table->dropColumn('id');
-        });
+      if (Schema::hasColumn(config('twill.related_table', 'twill_related'), 'id')) {
+            Schema::table(config('twill.related_table', 'twill_related'), function (Blueprint $table) {
+                $table->dropColumn('id');
+            });
+        }
     }
 };

--- a/migrations/default/2023_03_24_125122_add_id_to_related.php
+++ b/migrations/default/2023_03_24_125122_add_id_to_related.php
@@ -27,7 +27,7 @@ return new class extends Migration {
 
     public function down(): void
     {
-      if (Schema::hasColumn(config('twill.related_table', 'twill_related'), 'id')) {
+        if (Schema::hasColumn(config('twill.related_table', 'twill_related'), 'id')) {
             Schema::table(config('twill.related_table', 'twill_related'), function (Blueprint $table) {
                 $table->dropColumn('id');
             });


### PR DESCRIPTION
<!--
  Thanks for opening a PR! Your contribution is much appreciated.
  Do you have any questions? Check out the contributing docs at https://github.com/area17/twill/blob/3.x/CONTRIBUTING.md, or ask in this Pull Request and a Twill maintainer will be happy to help :)
-->

## Description

<!-- Write a description of the changes introduced by this PR -->
<!-- If this is introducing a new feature, it would be great if you can create a stub for documentation including bullet points for how to use the feature, code snippets, etc. -->

When executing `php artisan migrate:reset` an error would happen. The error would say:
> SQLSTATE[42S02]: Base table or view not found: 1146 Table 'twill-db.related' doesn't exist (SQL: alter table `related` drop `id`)

This is fixed in this PR.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
