### PR TITLE
Fix getBaseNamespace

### DIFF
--- a/src/Helpers/Capsule.php
+++ b/src/Helpers/Capsule.php
@@ -142,7 +142,7 @@ class Capsule
     {
         $explodedNamespace = explode('\\', $this->namespace);
 
-        return implode('\\', array_pop($explodedNamespace));
+        return implode('\\', array_slice($explodedNamespace, 0, -1));
     }
 
     public function getDatabaseNamespace(): string

--- a/src/Helpers/Capsule.php
+++ b/src/Helpers/Capsule.php
@@ -111,13 +111,6 @@ class Capsule
         }
     }
 
-    public function getBasePath(string $path): string
-    {
-        $exploded = explode(DIRECTORY_SEPARATOR, $path);
-
-        return implode(DIRECTORY_SEPARATOR, array_pop($exploded));
-    }
-
     public function getModule(): string
     {
         return Str::camel($this->name);

--- a/tests/integration/Capsules/CapsulesTest.php
+++ b/tests/integration/Capsules/CapsulesTest.php
@@ -90,8 +90,8 @@ class CapsulesTest extends TestCase
         $capsule = TwillCapsules::getCapsuleForModule($this->capsuleName);
         
         $this->assertTrue(class_exists("{$capsule->getModelNamespace()}\\{$this->capsuleModelName}"));
-        $this->assertEquals($capsule->getBaseNamespace(), 'App\\Twill\\Capsules');
-        $this->assertEquals($capsule->namespace, "App\\Twill\\Capsules\\".$this->capsuleName);
+        $this->assertEquals("App\\Twill\\Capsules", $capsule->getBaseNamespace());
+        $this->assertEquals("App\\Twill\\Capsules\\".$this->capsuleClassName, $capsule->namespace);
     }
 
     /**

--- a/tests/integration/Capsules/CapsulesTest.php
+++ b/tests/integration/Capsules/CapsulesTest.php
@@ -87,13 +87,12 @@ class CapsulesTest extends TestCase
      */
     public function testCapsuleProviderWasRegistered()
     {
-        class_exists(
-            "App\Twill\Capsules\{$this->capsuleClassName}\Models\{$this->capsuleModelName}"
-        );
-
-        class_exists('A17\Twill\Services\Modules\HasModules');
-
-        // @todo: Validate this test.
+        $capsule = TwillCapsules::getCapsuleForModule($this->capsuleName);
+        
+        $this->assertTrue(class_exists("{$capsule->namespace}\Models\{$this->capsuleModelName}"));
+        $this->assertTrue(class_exists('A17\Twill\Services\Modules\HasModules'));
+        
+        $this->assertEquals($capsule->getBaseNamespace(), 'App\Twill\Capsules');
     }
 
     /**

--- a/tests/integration/Capsules/CapsulesTest.php
+++ b/tests/integration/Capsules/CapsulesTest.php
@@ -89,10 +89,9 @@ class CapsulesTest extends TestCase
     {
         $capsule = TwillCapsules::getCapsuleForModule($this->capsuleName);
         
-        $this->assertTrue(class_exists("{$capsule->namespace}\Models\{$this->capsuleModelName}"));
-        $this->assertTrue(class_exists('A17\Twill\Services\Modules\HasModules'));
-        
-        $this->assertEquals($capsule->getBaseNamespace(), 'App\Twill\Capsules');
+        $this->assertTrue(class_exists("{$capsule->getModelNamespace()}\\{$this->capsuleModelName}"));
+        $this->assertEquals($capsule->getBaseNamespace(), 'App\\Twill\\Capsules');
+        $this->assertEquals($capsule->namespace, "App\\Twill\\Capsules\\".$this->capsuleName);
     }
 
     /**


### PR DESCRIPTION
Currently running getBaseNameSpace on a capsule will throw an error `implode(): Argument #2 ($array) must be of type ?array, string given` because array_pop returns the last element of the array which is given to implode, but the name of the function means that we instead want the namespace without the last element

This function is not used anywhere though in the core, I only caught it while doing some tinkering

Maybe we should add phpstan to the project for static analysis which would catch exactly this kind of issues