### PR TITLE
Glide image rendering service improvements

### DIFF
--- a/config/glide.php
+++ b/config/glide.php
@@ -12,8 +12,12 @@ return [
      */
 
     'source' => env('GLIDE_SOURCE', storage_path('app/public/' . config('twill.media_library.local_path'))),
+    'use_source_disk' => env('GLIDE_USE_SOURCE_DISK', false),
+    'source_disk' => env('GLIDE_SOURCE_DISK', 'twill_media_library'),
     'source_path_prefix' => env('GLIDE_SOURCE_PATH_PREFIX', null),
     'cache' => env('GLIDE_CACHE', storage_path('app')),
+    'use_cache_disk' => env('GLIDE_USE_CACHE_DISK', false),
+    'cache_disk' => env('GLIDE_CACHE_DISK', 'twill_media_library'),
     'cache_path_prefix' => env('GLIDE_CACHE_PATH_PREFIX', 'glide_cache'),
     'base_url' => env('GLIDE_BASE_URL', config('app.url')),
     'base_path' => env('GLIDE_BASE_PATH', 'img'),
@@ -43,4 +47,8 @@ return [
     ],
     'presets' => [],
     'original_media_for_extensions' => ['svg'],
+    'use_streamed_response_for_original_media' => env('GLIDE_USE_STREAMED_RESPONSE_FOR_ORIGINAL_MEDIA', false),
+    'use_temporary_url_for_original_media' => env('GLIDE_USE_TEMPORARY_URL_FOR_ORIGINAL_MEDIA', false),
+    'temporary_url_expiration' => env('GLIDE_TEMPORARY_URL_EXPIRATION', 3600), // seconds
+    'keep_transparency' => env('GLIDE_KEEP_TRANSPARENCY', false),
 ];

--- a/src/Http/Controllers/Front/GlideController.php
+++ b/src/Http/Controllers/Front/GlideController.php
@@ -2,13 +2,27 @@
 
 namespace A17\Twill\Http\Controllers\Front;
 
+use Illuminate\Config\Repository as Config;
 use A17\Twill\Services\MediaLibrary\Glide;
 use Illuminate\Foundation\Application;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
 
 class GlideController
 {
-    public function __invoke($path, Application $app)
+    public function __invoke($path, Application $app, Config $config)
     {
+        if (
+            $config->get('twill.glide.use_streamed_response_for_original_media', false) &&
+            Str::endsWith($path, $config->get('twill.glide.original_media_for_extensions'))
+        ) {
+            $disk = $config->get('twill.glide.use_source_disk')
+                ? $config->get('twill.glide.source_disk')
+                : $config->get('twill.media_library.disk');
+
+            return Storage::disk($disk)->response($path);
+        }
+
         return $app->make(Glide::class)->render($path);
     }
 }

--- a/src/Services/MediaLibrary/Glide.php
+++ b/src/Services/MediaLibrary/Glide.php
@@ -2,12 +2,14 @@
 
 namespace A17\Twill\Services\MediaLibrary;
 
+use Carbon\Carbon;
 use Illuminate\Config\Repository as Config;
 use Illuminate\Foundation\Application;
 use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Support\Facades\Storage;
+use League\Flysystem\Filesystem;
 use League\Glide\Responses\LaravelResponseFactory;
 use League\Glide\ServerFactory;
 use League\Glide\Signatures\SignatureFactory;
@@ -66,11 +68,29 @@ class Glide implements ImageServiceInterface
             $baseUrl = $this->request->getScheme() . '://' . $baseUrl;
         }
 
+        $sourceFileSystem = $this->config->get('twill.glide.source');
+        $cacheFileSystem = $this->config->get('twill.glide.cache');
+
+        if (
+            $this->config->get('twill.glide.use_source_disk', false) ||
+            $this->config->get('twill.glide.use_cache_disk', false)
+        ) {
+            if ($this->config->get('twill.glide.use_source_disk', false)) {
+                $sourceDiskInstance = Storage::disk($this->config->get('twill.glide.source_disk'));
+                $sourceFileSystem = new Filesystem($sourceDiskInstance->getAdapter());
+            }
+
+            if ($this->config->get('twill.glide.use_cache_disk', false)) {
+                $cacheDiskInstance = Storage::disk($this->config->get('twill.glide.cache_disk'));
+                $cacheFileSystem = new Filesystem($cacheDiskInstance->getAdapter());
+            }
+        }
+
         $this->server = ServerFactory::create([
             'response' => new LaravelResponseFactory($this->request),
-            'source' => $this->config->get('twill.glide.source'),
+            'source' => $sourceFileSystem,
             'source_path_prefix' => $this->config->get('twill.glide.source_path_prefix'),
-            'cache' => $this->config->get('twill.glide.cache'),
+            'cache' => $cacheFileSystem,
             'cache_path_prefix' => $this->config->get('twill.glide.cache_path_prefix'),
             'base_url' => $baseUrl,
             'presets' => $this->config->get('twill.glide.presets', []),
@@ -103,6 +123,12 @@ class Glide implements ImageServiceInterface
     public function getUrl($id, array $params = [])
     {
         $defaultParams = config('twill.glide.default_params');
+
+        $keepTransparency = config('twill.glide.keep_transparency', false);
+
+        if ($keepTransparency && Str::endsWith($id, ['.png', '.gif'])) {
+            $defaultParams['fm'] = null;
+        }
 
         return $this->getOriginalMediaUrl($id) ??
             $this->urlBuilder->getUrl($id, array_replace($defaultParams, $params));
@@ -264,7 +290,7 @@ class Glide implements ImageServiceInterface
 
     /**
      * @param string $id
-     * @return string
+     * @return ?string
      */
     private function getOriginalMediaUrl($id)
     {
@@ -275,6 +301,24 @@ class Glide implements ImageServiceInterface
             return null;
         }
 
-        return Storage::disk(config('twill.media_library.disk'))->url($id);
+        if ($this->config->get('twill.glide.use_streamed_response_for_original_media', false)) {
+            return $this->urlBuilder->getUrl($id);
+        }
+
+        if (
+            $this->config->get('twill.glide.use_source_disk', false) &&
+            $this->config->get('twill.glide.use_temporary_url_for_original_media', false)
+        ) {
+            if (Storage::disk(config('twill.glide.source_disk'))->providesTemporaryUrls()) {
+                return Storage::disk(config('twill.glide.source_disk'))->temporaryUrl(
+                    $id,
+                    Carbon::now()->addSeconds($this->config->get('twill.glide.temporary_url_expiration', 3600))
+                );
+            }
+
+            return Storage::disk($this->config->get('twill.glide.source_disk'))->url($id);
+        }
+
+        return Storage::disk($this->config->get('twill.media_library.disk'))->url($id);
     }
 }


### PR DESCRIPTION
This non-breaking PR introduces new configuration and environment variables to help with Glide's integration with remote disks like S3, media library default ACL's, SVGs and transparent PNGs/GIFs support:

- `GLIDE_USE_SOURCE_DISK`: specify that the disk name provided in `GLIDE_SOURCE_DISK` should be used as the Glide source

- `GLIDE_SOURCE_DISK`: name of the disk to use as source, defaults to `twill_media_library`, which is an S3 disk when `MEDIA_LIBRARY_ENDPOINT_TYPE=s3`

- `GLIDE_USE_CACHE_DISK`: specify that the disk name provided in `GLIDE_CACHE_DISK` should be used as the Glide cache

- `GLIDE_CACHE_DISK`: name of the disk to use as cache, defaults to `twill_media_library`, which is an S3 disk when `MEDIA_LIBRARY_ENDPOINT_TYPE=s3`

- `GLIDE_USE_STREAMED_RESPONSE_FOR_ORIGINAL_MEDIA`: Glide doesn't support SVG rendering (with both gd and imagick drivers), so we previously allowed an array of extension to bypass the Glide rendering. The problem is that by default the media library uploads are set to `private` ACL on S3, so the S3 URL returned doesn't work. With this new setting, SVG will be returned as a streamed response from the remote disk in the Glide controller

- `GLIDE_USE_TEMPORARY_URL_FOR_ORIGINAL_MEDIA`: Alternatively, with compatible Flysystem disks, like S3, it is now possible to return a temporary URL with an expiring token instead of a URL that would return a 403 AccessDenied when `twill.media_library.acl` is set to `private`. Of course, be mindful that if you are using a CDN or any sort of cache where you cache your HTML responses, you should make sure to set `GLIDE_TEMPORARY_URL_EXPIRATION` to a longer duration than your cache TTL. If not, you are going to end up with expired temporary URLs in your cached HTML responses.

- `GLIDE_TEMPORARY_URL_EXPIRATION`: Expiration in seconds for temporary URLs

- `GLIDE_KEEP_TRANSPARENCY`: Preserves transparency for PNG and GIF files, while keeping the default `JPG` format for everything else