### PR TITLE
Fix relative path traversal in twill:staticdocs:serve

### DIFF
--- a/docs/generator/server.php
+++ b/docs/generator/server.php
@@ -11,18 +11,19 @@ $uri = urldecode(
     parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH)
 );
 
-if ($uri === '/' || $uri === '') {
-    $uri = 'index.html';
+$base = realpath(__DIR__ . '/../_build/');
+if (is_dir($base . $uri)) {
+    $uri .= "/index.html";
 }
+$target = realpath($base . $uri);
 
-if (file_exists(__DIR__ . '/../_build/' . $uri)) {
-    if (str_ends_with($uri, '.css')) {
+if ($target && str_starts_with($target, $base) && file_exists($target)) {
+    if (str_ends_with($target, '.css')) {
         header("Content-Type: text/css");
     } else {
-        if (str_ends_with($uri, '/')) {
-            $uri .= '/index.html';
-        }
-        header('Content-Type: ' . mime_content_type(__DIR__ . '/../_build/' . $uri));
+        header('Content-Type: ' . mime_content_type($target));
     }
-    echo file_get_contents(__DIR__ . '/../_build/' . $uri);
+    echo file_get_contents($target);
+} else {
+    http_response_code(404);
 }


### PR DESCRIPTION
## Description

This fixes the relative path traversal vulnerability in the `twill:staticdocs:serve` command, which allows remote attackers to access any file on the host filesystem.

However, in reality, no one uses this command to host the docs while exposing it to the Internet.

## Related Issues

Rejected as a security vulnerability in https://github.com/area17/twill/security/advisories/GHSA-9wwx-w6vv-q72c

> this is not a vulnerability in the area17/twill software published on Packagist, as the command you are referring to is made for project maintainers in a local environnement, to contribute to the docs.