### PR TITLE
Fix single module browser

### DIFF
--- a/docs/content/1_docs/4_form-fields/10_browser.md
+++ b/docs/content/1_docs/4_form-fields/10_browser.md
@@ -47,8 +47,7 @@ Browser::make()
 |:----------------------|:--------------------------------------------------------------------------------|:--------|:--------------|
 | name                  | Name of the field                                                               | string  |               |
 | label                 | Label of the field                                                              | string  |               |
-| moduleName            | Name of the module (single related module)                                      | string  |               |
-| modules               | Array of modules (multiple related modules), must include _name_                | array   |               |
+| modules               | Array of modules (multiple related modules), must include _name_ or be a module class | array   |               |
 | endpoints             | Array of endpoints (multiple related modules), must include _value_ and _label_ | array   |               |
 | params                | Array of query params (key => value) to be passed to the browser endpoint       | array   |               |
 | max                   | Max number of attached items                                                    | integer | 1             |

--- a/docs/content/1_docs/4_form-fields/10_browser.md
+++ b/docs/content/1_docs/4_form-fields/10_browser.md
@@ -47,6 +47,7 @@ Browser::make()
 |:----------------------|:--------------------------------------------------------------------------------|:--------|:--------------|
 | name                  | Name of the field                                                               | string  |               |
 | label                 | Label of the field                                                              | string  |               |
+| moduleName | Name of the module (single related module) (use the `modules` method with a single class for the FormBuilder) | string | |
 | modules               | Array of modules (multiple related modules), must include _name_ or be a module class | array   |               |
 | endpoints             | Array of endpoints (multiple related modules), must include _value_ and _label_ | array   |               |
 | params                | Array of query params (key => value) to be passed to the browser endpoint       | array   |               |

--- a/src/Services/Forms/Fields/Browser.php
+++ b/src/Services/Forms/Fields/Browser.php
@@ -145,7 +145,7 @@ class Browser extends BaseFormField
      */
     public function modules(array $modules): static
     {
-        if (count($modules) === 1 && ! isset($modules[0])) {
+        if (count($modules) === 1 && is_string(current($modules))) {
             $this->moduleName = getModuleNameByModel(array_pop($modules));
 
             if (! $this->label) {

--- a/src/Services/Forms/Fields/Wysiwyg.php
+++ b/src/Services/Forms/Fields/Wysiwyg.php
@@ -188,7 +188,7 @@ class Wysiwyg extends BaseFormField
      */
     public function browserModules(?array $modules = null): static
     {
-        if (count($modules) === 1 && ! isset($modules[0])) {
+        if (count($modules) === 1 && is_string(current($modules))) {
             $this->browserModules[] = [
                 'name' => getModuleNameByModel(array_pop($modules))
             ];


### PR DESCRIPTION
[The documentation](https://twillcms.com/docs/form-fields/browser.html) refers to a `moduleName` option for a single module browser, which doesn't seem to exist on the form builder, the code suggests that it should be possible using `modules([Module::class])` and so does the doc

```php
Browser::make()
    ->modules([Publications::class])
    ->name('publications')
    ->max(4);
```


And so the previous form field should be a browser for a single module

However that's not the case as can be seen from the dropdown

![image](https://github.com/area17/twill/assets/6115458/09ae31cf-edd5-4860-9b13-48c4b13f731b)

This is due to ` count($modules) === 1 && ! isset($modules[0])` which doesn't make much logical sense


With the PR this is what becomes:
![image](https://github.com/area17/twill/assets/6115458/550d1890-34f1-43ef-b7c5-fedfbd6c3bfc)
