### PR TITLE
Fix incorrect method argument order when registering twill capsule translation

### DIFF
--- a/src/Helpers/Capsule.php
+++ b/src/Helpers/Capsule.php
@@ -101,7 +101,7 @@ class Capsule
     public function loadTranslations(): void
     {
         $callback = function (Translator $translator) {
-            $translator->addNamespace($this->getLanguagesPath(), 'twill:capsules:' . $this->getModule());
+            $translator->addNamespace('twill:capsules:' . $this->getModule(), $this->getLanguagesPath());
         };
 
         App()->afterResolving('translator', $callback);


### PR DESCRIPTION
## Description

Fix the arguments order when registering the translation namespace of Twill capsules.

More information and detailed bug explanation can be found in #2476 

## Related Issues
 Fixes #2476 