### PR TITLE
Fix: js error if you grab a block but don't move it anywhere

### DIFF
--- a/frontend/js/components/blocks/Blocks.vue
+++ b/frontend/js/components/blocks/Blocks.vue
@@ -214,6 +214,7 @@
         }
       },
       handleOnEnd (moveFn, moveBlockToEditorFn) {
+        if (!this.nextMove) return
         const {
           block,
           editorName,


### PR DESCRIPTION
## Description

Grabbing a block to move it but not actually moving it anywhere causes a js error

```txt
chunk-vendors.a68a3d70.js:31 TypeError: Cannot destructure property 'block' of 'this.nextMove' as it is undefined.
    at a.handleOnEnd (chunk-common.2efbae60.js:1:52456)
```

This PR fixes that