### PR TITLE
fix: missing step method on input field

### DIFF
--- a/src/Services/Forms/Fields/Input.php
+++ b/src/Services/Forms/Fields/Input.php
@@ -58,6 +58,8 @@ class Input extends BaseFormField
 
     protected ?int $rows;
 
+    protected ?float $step;
+
     public static function make(): static
     {
         return new self(
@@ -105,6 +107,16 @@ class Input extends BaseFormField
     public function rows(int $rows): static
     {
         $this->rows = $rows;
+
+        return $this;
+    }
+
+    /**
+     * Sets the step size.
+     */
+    public function step(float $step): static
+    {
+        $this->step = $step;
 
         return $this;
     }

--- a/tests/unit/Components/InputFieldTest.php
+++ b/tests/unit/Components/InputFieldTest.php
@@ -16,5 +16,6 @@ class InputFieldTest extends ComponentTestBase
     public string $field = \A17\Twill\Services\Forms\Fields\Input::class;
     public array $fieldSetters = [
         'name' => 'name',
+        'step' => 5.0
     ];
 }


### PR DESCRIPTION
<!--
  Thanks for opening a PR! Your contribution is much appreciated.
  Do you have any questions? Check out the contributing docs at https://github.com/area17/twill/blob/3.x/CONTRIBUTING.md, or ask in this Pull Request and a Twill maintainer will be happy to help :)
-->

## Description

This allows the `step` method to be available on the Input field of the form builder.

Usage:
```
$form->add(
    Input::make()->name('length')->type('number')->label("length")->step(1)
);
```

## Related Issues

Fixes #2380
