### PR TITLE
fix: allow single deletion in form builder inline repeater

### DIFF
--- a/src/Repositories/Behaviors/HandleRepeaters.php
+++ b/src/Repositories/Behaviors/HandleRepeaters.php
@@ -243,7 +243,7 @@ trait HandleRepeaters
 
                 $object->{$relation}()->attach($newRelation['id'], $pivotFieldData);
 
-                $latestAttached = $object->{$relation}()->withPivot('id')->orderByPivot('id', 'desc')->get()->last();
+                $latestAttached = $object->{$relation}()->withPivot('id')->orderByPivot('id', 'asc')->get()->last();
 
                 $currentIdList[] = $latestAttached->pivot->id;
 

--- a/src/Repositories/Behaviors/HandleRepeaters.php
+++ b/src/Repositories/Behaviors/HandleRepeaters.php
@@ -239,13 +239,13 @@ trait HandleRepeaters
                     $newRelation = $relationRepository->create($relationField);
                 }
 
-                $currentIdList[] = (int)$newRelation['id'];
-
                 $pivotFieldData = $this->encodePivotFields(collect($relationField)->only($pivotFields)->all());
 
                 $object->{$relation}()->attach($newRelation['id'], $pivotFieldData);
 
                 $latestAttached = $object->{$relation}()->withPivot('id')->orderByPivot('id', 'desc')->get()->last();
+
+                $currentIdList[] = $latestAttached->pivot->id;
 
                 TwillUtil::registerRepeaterId($frontEndId, $latestAttached->pivot->id);
             }
@@ -256,7 +256,7 @@ trait HandleRepeaters
             foreach ($current as $existingRelation) {
                 if (! in_array((int)$existingRelation->pivot->id, $currentIdList, true)) {
                     // The pivot table is treated differently.
-                    $object->{$relation}()->detach($existingRelation->pivot->id);
+                    $object->{$relation}()->detach($existingRelation->id);
                 }
             }
         }

--- a/tests/integration/Repositories/RepositoryRepeatersTest.php
+++ b/tests/integration/Repositories/RepositoryRepeatersTest.php
@@ -231,4 +231,38 @@ class RepositoryRepeatersTest extends ModulesTestBase
                 ]
             );
     }
+
+    public function testCanDetachPartnerWhenDeleted(): void
+    {
+        $this->project->partners()->attach($this->partner->id, ['position' => 1]);
+
+        $fields = [
+            'repeaters' => [
+                'project_partners' => [
+                    [
+                        'role' => ['The partner role'],
+                        'repeater_target_id' => null,
+                        'title' => ['en' => 'Partner name'],
+                        'id' => time(),
+                    ],
+                ],
+            ],
+        ];
+
+        app(ProjectRepository::class)->updateRepeaterWithPivot(
+            $this->project,
+            $fields,
+            'partners',
+            ['role'],
+            'partner',
+            'project_partners'
+        );
+
+        $partners = $this->project->partners()->withPivot('role')->get();
+
+        $this->assertEquals(1, $partners->count());
+
+        $this->assertEquals('Partner name', $partners[0]->title);
+        $this->assertEquals('["The partner role"]', $partners[0]->pivot->role);
+    }
 }


### PR DESCRIPTION
<!--
  Thanks for opening a PR! Your contribution is much appreciated.
  Do you have any questions? Check out the contributing docs at https://github.com/area17/twill/blob/3.x/CONTRIBUTING.md, or ask in this Pull Request and a Twill maintainer will be happy to help :)
-->

## Description

This addresses the issue where deleting a single repeater item when you have more than one doesn't work.

<!-- Write a description of the changes introduced by this PR -->
<!-- If this is introducing a new feature, it would be great if you can create a stub for documentation including bullet points for how to use the feature, code snippets, etc. -->

## Related Issues

Fixes #2353
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
