### PR TITLE
fix: Table builder Browser column overrides parent module field

### DIFF
--- a/src/Services/Listings/Columns/Browser.php
+++ b/src/Services/Listings/Columns/Browser.php
@@ -27,4 +27,17 @@ class Browser extends TableColumn
             ->pluck($this->field)
             ->join(', ');
     }
+
+    public function getKey(): string
+    {
+        if ($this->key === null) {
+            throw new ColumnMissingPropertyException();
+        }
+
+        if (null === $this->browser) {
+            throw new ColumnMissingPropertyException('Browser column missing browser value: ' . $this->field);
+        }
+
+        return "$this->browser.$this->key";
+    }
 }


### PR DESCRIPTION

## Description

This PR overrides the base `TableColumn` class `getKey()` to prepend the browser's name to the browser key.

```
public function getKey(): string
    {
        if ($this->key === null) {
            throw new ColumnMissingPropertyException();
        }

        if (null === $this->browser) {
            throw new ColumnMissingPropertyException('Browser column missing browser value: ' . $this->field);
        }

        return "$this->browser.$this->key";
    }
```

## Related Issues

Fixes #2284
