### PR TITLE
Disable heading extension if it's not in the toolbar

### DIFF
--- a/frontend/js/components/WysiwygTiptap.vue
+++ b/frontend/js/components/WysiwygTiptap.vue
@@ -630,6 +630,7 @@
         code: this.toolbar.code ?? false,
         codeBlock: this.toolbar.codeBlock ?? false,
         horizontalRule: this.toolbar.hr ?? false,
+        heading: this.toolbar.header ? { levels: this.headingOptions } : false,
       }))
 
       this.editor = new Editor({


### PR DESCRIPTION
## Description

Since tiptap still allows html based on the extensions configured, if we disallow headings we need to let the extension know as well that it shouldn't load

 Fixes #2489