### PR TITLE
fix: allow deleting media after records bulk destroy

### DIFF
--- a/src/Repositories/ModuleRepository.php
+++ b/src/Repositories/ModuleRepository.php
@@ -374,9 +374,8 @@ abstract class ModuleRepository
                 $query = $this->model->onlyTrashed()->whereIn('id', $ids);
                 $objects = $query->get();
 
-                $query->forceDelete();
-
                 $objects->each(function ($object) {
+                    $object->forceDelete();
                     $this->afterDelete($object);
                 });
             } catch (Exception $exception) {


### PR DESCRIPTION
## Description

This PR fixes the issue when media attached to a record doesn't allow deleting after the records have been destroyed

