### PR TITLE
fix: Datatable and buckets filters error caused by Axios breaking changes

### DIFF
--- a/frontend/js/store/modules/buckets.js
+++ b/frontend/js/store/modules/buckets.js
@@ -66,7 +66,7 @@ const actions = {
       content_type: state.dataSources.selected.value,
       page: state.page,
       offset: state.offset,
-      filter: state.filter
+      filter: JSON.stringify(state.filter)
     }, resp => {
       commit(BUCKETS.UPDATE_BUCKETS_DATA, resp.source)
       commit(BUCKETS.UPDATE_BUCKETS_MAX_PAGE, resp.maxPage)

--- a/frontend/js/store/modules/datatable.js
+++ b/frontend/js/store/modules/datatable.js
@@ -231,7 +231,7 @@ const actions = {
         page: state.page,
         offset: state.offset,
         columns: getters.visibleColumnsNames,
-        filter: state.filter
+        filter: JSON.stringify(state.filter)
       }
 
       api.get(params, function (resp) {


### PR DESCRIPTION
## Description

This PR fixes the breaking changes caused by Axios update to v0.28.0, where the filters query param is provided in a bracket style instead of an object style.

## Related Issues

Fixes #2518
