### PR TITLE
fix: Tags in media library are not refreshed while updating & browsing images

### DIFF
--- a/frontend/js/components/media-library/MediaSidebar.vue
+++ b/frontend/js/components/media-library/MediaSidebar.vue
@@ -427,6 +427,10 @@
                 return mediaFromResp.id === media.id
               })
             })
+          } else if (!this.hasMultipleMedias && resp.data.item) {
+            this.medias.forEach(function (media) {
+              media.tags = resp.data.item.tags;
+            })
           }
         }, (error) => {
           this.loading = false

--- a/src/Http/Controllers/Admin/MediaLibraryController.php
+++ b/src/Http/Controllers/Admin/MediaLibraryController.php
@@ -234,8 +234,10 @@ class MediaLibraryController extends ModuleController implements SignUploadListe
      */
     public function singleUpdate()
     {
+        $id = $this->request->input('id');
+
         $this->repository->update(
-            $this->request->input('id'),
+            $id,
             array_merge([
                 'alt_text' => $this->request->get('alt_text', null),
                 'caption' => $this->request->get('caption', null),
@@ -243,7 +245,10 @@ class MediaLibraryController extends ModuleController implements SignUploadListe
             ], $this->getExtraMetadatas()->toArray())
         );
 
+        $items = $this->getIndexItems(['id' => $id]);
+
         return $this->responseFactory->json([
+            'item' => $items->first()->toCmsArray(),
             'tags' => $this->repository->getTagsList(),
         ], 200);
     }


### PR DESCRIPTION
## Description

This PR adds the updated tags to the media item after the tags are updated. This allows the updated tags to be present in the sidebar after navigating away and returning to the media

## Related Issues

Fixes #2407
