### PR TITLE
fix: Non-translated media fields display as empty

### DIFF
--- a/frontend/js/mixins/block.js
+++ b/frontend/js/mixins/block.js
@@ -18,8 +18,9 @@ export default {
     open: function () {
       this.opened = true
     },
-    fieldName: function (id) {
-      return this.name + '[' + id + ']' // output : nameOfBlock[UniqID][name]
+    fieldName: function (id, extra = null) {
+      const fieldName = this.name + '[' + id + ']' // output : nameOfBlock[UniqID][name]
+      return extra ? fieldName + extra : fieldName
     },
     repeaterName: function (id) {
       return this.name.replace('[', '-').replace(']', '') + '|' + id // nameOfBlock-UniqID|name

--- a/src/Services/Forms/Fields/Medias.php
+++ b/src/Services/Forms/Fields/Medias.php
@@ -32,6 +32,8 @@ class Medias extends BaseFormField
 
     protected bool $activeCrop = true;
 
+    protected bool $disableTranslate = false;
+
     public static function make(): static
     {
         $instance = new self(
@@ -134,6 +136,13 @@ class Medias extends BaseFormField
     public function hideActiveCrop(bool $hideActiveCrop = true): static
     {
         $this->activeCrop = !$hideActiveCrop;
+
+        return $this;
+    }
+
+    public function disableTranslate(): static
+    {
+        $this->disableTranslate = true;
 
         return $this;
     }

--- a/src/View/Components/Fields/Medias.php
+++ b/src/View/Components/Fields/Medias.php
@@ -30,7 +30,8 @@ class Medias extends TwillFormComponent
         public int $widthMin = 0,
         public int $heightMin = 0,
         public bool $buttonOnTop = false,
-        public bool $activeCrop = true
+        public bool $activeCrop = true,
+        public bool $disableTranslate = false
     ) {
         parent::__construct(
             name: $name,
@@ -58,5 +59,13 @@ class Medias extends TwillFormComponent
                 ]
             )
         );
+    }
+
+    public function getExtraName(): string
+    {
+        return config('twill.media_library.translated_form_fields', false)
+            && $this->disableTranslate
+            && !$this->translated
+            ? '[' . config('app.locale') . ']' : '';
     }
 }

--- a/src/View/Components/Fields/TwillFormComponent.php
+++ b/src/View/Components/Fields/TwillFormComponent.php
@@ -51,11 +51,12 @@ abstract class TwillFormComponent extends Component
     {
         $name = $customName ?? $this->name;
         if ($this->renderForBlocks) {
+            $extra = $this->getExtraName();
             if ($asAttributes) {
-                return "name: fieldName('$name')";
+                return "name: fieldName('$name', '$extra')";
             }
 
-            return ":name=\"fieldName('$name')\"";
+            return ":name=\"fieldName('$name', '$extra')\"";
         }
 
         if ($asAttributes) {
@@ -66,4 +67,9 @@ abstract class TwillFormComponent extends Component
     }
 
     abstract public function render(): View;
+
+    public function getExtraName(): string
+    {
+        return '';
+    }
 }

--- a/views/partials/form/_medias.blade.php
+++ b/views/partials/form/_medias.blade.php
@@ -57,7 +57,9 @@
 
     @unless($renderForBlocks)
     @push('vuexStore')
-        @if (isset($form_fields['medias']) && isset($form_fields['medias'][$name]))
+        @if(config('twill.media_library.translated_form_fields', false) && ($disableTranslate ?? false) && isset($form_fields['medias']) && isset($form_fields['medias'][config('app.locale')]) && isset($form_fields['medias'][config('app.locale')][$name]))
+            window['{{ config('twill.js_namespace') }}'].STORE.medias.selected["{{ $name }}"] = {!! json_encode($form_fields['medias'][config('app.locale')][$name]) !!}
+        @elseif(isset($form_fields['medias']) && isset($form_fields['medias'][$name]))
             window['{{ config('twill.js_namespace') }}'].STORE.medias.selected["{{ $name }}"] = {!! json_encode($form_fields['medias'][$name]) !!}
         @endif
     @endpush


### PR DESCRIPTION

## Description

This PR adds a new form field property `disableTranslate()` to force the field to disable translation when `twill.media_library.translated_form_fields
` is set to `true`.

Usage:

FormBuilder
```
Medias::make()
    ->name('cover')
    ->label('Cover image')
    ->disableTranslate()
    ->max(5)
```
Directive
```
@formField('medias', [
    'name' => 'cover',
    'label' => 'Cover image',
    'note' => 'Also used in listings',
    'fieldNote' => 'Minimum image width: 1500px',
    'disableTranslate' => true
])
```
FormView
```
<x-twill::medias
    name="cover"
    label="Cover image"
    note="Also used in listings"
    field-note="Minimum image width: 1500px"
    disable-translate
/>
```


## Related Issues

Fixes #483