### PR TITLE
fix: Relation field of datatable does not allow sorting

### DIFF
--- a/src/Http/Controllers/Admin/ModuleController.php
+++ b/src/Http/Controllers/Admin/ModuleController.php
@@ -918,6 +918,7 @@ abstract class ModuleController extends Controller
                         ->sortKey($indexColumn['sortKey'] ?? null)
                         ->optional($indexColumn['optional'] ?? false)
                         ->relation($indexColumn['relationship'])
+                        ->sortable($indexColumn['sort'] ?? false)
                 );
             } elseif ($indexColumn['present'] ?? false) {
                 $columns->add(


### PR DESCRIPTION
## Description

This pull request addresses the issue where sorting relation fields in a datatable fails.

