### PR TITLE
Allow case-insensitive search for translated models for postgres

### DIFF
--- a/src/Models/Behaviors/HasTranslation.php
+++ b/src/Models/Behaviors/HasTranslation.php
@@ -97,13 +97,6 @@ trait HasTranslation
             ->with('translations');
     }
 
-    /**
-     * @param Builder $query
-     * @param string $translationField
-     * @param $value
-     * @param string|null $locale
-     * @return Builder
-     */
     public function scopeOrWhereTranslationLike(Builder $query, string $translationField, $value, ?string $locale = null): Builder
     {
         return $this->scopeWhereTranslation($query, $translationField, $value, $locale, 'orWhereHas', getLikeOperator());

--- a/src/Models/Behaviors/HasTranslation.php
+++ b/src/Models/Behaviors/HasTranslation.php
@@ -98,6 +98,18 @@ trait HasTranslation
     }
 
     /**
+     * @param Builder $query
+     * @param string $translationField
+     * @param $value
+     * @param string|null $locale
+     * @return Builder
+     */
+    public function scopeOrWhereTranslationLike(Builder $query, string $translationField, $value, ?string $locale = null): Builder
+    {
+        return $this->scopeWhereTranslation($query, $translationField, $value, $locale, 'orWhereHas', getLikeOperator());
+    }
+
+    /**
      * Checks if this model has active translations.
      *
      * @param string|null $locale


### PR DESCRIPTION
## Description

This PR overrides the `scopeOrWhereTranslationLike` method of `astrotomic/laravel-translatable` to select the like operator based on the database driver used.
```
public function scopeOrWhereTranslationLike(Builder $query, string $translationField, $value, ?string $locale = null): Builder
{
    return $this->scopeWhereTranslation($query, $translationField, $value, $locale, 'orWhereHas', getLikeOperator());
}
```

## Related Issues

Fixes #2112

