### PR TITLE
fix: Allow file fields to be non translatable

### DIFF
--- a/frontend/js/mixins/block.js
+++ b/frontend/js/mixins/block.js
@@ -18,8 +18,9 @@ export default {
     open: function () {
       this.opened = true
     },
-    fieldName: function (id) {
-      return this.name + '[' + id + ']' // output : nameOfBlock[UniqID][name]
+    fieldName: function (id, extra = null) {
+      const fieldName = this.name + '[' + id + ']' // output : nameOfBlock[UniqID][name]
+      return extra ? fieldName + extra : fieldName
     },
     repeaterName: function (id) {
       return this.name.replace('[', '-').replace(']', '') + '|' + id // nameOfBlock-UniqID|name

--- a/src/Services/Forms/Fields/Files.php
+++ b/src/Services/Forms/Fields/Files.php
@@ -2,6 +2,7 @@
 
 namespace A17\Twill\Services\Forms\Fields;
 
+use A17\Twill\Services\Forms\Fields\Traits\CanDisableTranslate;
 use A17\Twill\Services\Forms\Fields\Traits\CanHaveButtonOnTop;
 use A17\Twill\Services\Forms\Fields\Traits\HasFieldNote;
 use A17\Twill\Services\Forms\Fields\Traits\HasMax;
@@ -14,6 +15,7 @@ class Files extends BaseFormField
     use HasMax;
     use HasFieldNote;
     use CanHaveButtonOnTop;
+    use CanDisableTranslate;
 
     protected ?string $itemLabel = null;
 

--- a/src/Services/Forms/Fields/Traits/CanDisableTranslate.php
+++ b/src/Services/Forms/Fields/Traits/CanDisableTranslate.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace A17\Twill\Services\Forms\Fields\Traits;
+
+trait CanDisableTranslate
+{
+    /**
+     * @var bool
+     */
+    protected bool $disableTranslate = false;
+
+    /**
+     * Disables translate
+     *
+     * @return $this
+     */
+    public function disableTranslate(): static
+    {
+        $this->disableTranslate = true;
+
+        return $this;
+    }
+}

--- a/src/View/Components/Fields/Files.php
+++ b/src/View/Components/Fields/Files.php
@@ -13,6 +13,7 @@ class Files extends TwillFormComponent
         bool $renderForBlocks = false,
         bool $renderForModal = false,
         string $note = null,
+        bool $translated = false,
         // Component specific
         public int $max = 1,
         public int $filesizeMax = 0,
@@ -28,7 +29,8 @@ class Files extends TwillFormComponent
             label: $label,
             note: $note ?? 'Add' . ($max > 1 ? " up to $max $itemLabel" : ' one ' . Str::singular($itemLabel)),
             renderForBlocks: $renderForBlocks,
-            renderForModal: $renderForModal
+            renderForModal: $renderForModal,
+            translated: $translated
         );
     }
 

--- a/src/View/Components/Fields/Files.php
+++ b/src/View/Components/Fields/Files.php
@@ -13,13 +13,13 @@ class Files extends TwillFormComponent
         bool $renderForBlocks = false,
         bool $renderForModal = false,
         string $note = null,
-        bool $translated = false,
         // Component specific
         public int $max = 1,
         public int $filesizeMax = 0,
         public bool $buttonOnTop = false,
         public ?string $itemLabel = null,
         public ?string $fieldNote = null,
+        public bool $disableTranslate = false
     ) {
         $itemLabel = $itemLabel ?? strtolower($label);
         $this->itemLabel = $itemLabel;
@@ -30,12 +30,16 @@ class Files extends TwillFormComponent
             note: $note ?? 'Add' . ($max > 1 ? " up to $max $itemLabel" : ' one ' . Str::singular($itemLabel)),
             renderForBlocks: $renderForBlocks,
             renderForModal: $renderForModal,
-            translated: $translated
         );
     }
 
     public function render(): View
     {
         return view('twill::partials.form._files', $this->data());
+    }
+
+    public function getExtraName(): string
+    {
+        return $this->disableTranslate ? '[' . config('app.locale') . ']' : '';
     }
 }

--- a/src/View/Components/Fields/TwillFormComponent.php
+++ b/src/View/Components/Fields/TwillFormComponent.php
@@ -51,11 +51,12 @@ abstract class TwillFormComponent extends Component
     {
         $name = $customName ?? $this->name;
         if ($this->renderForBlocks) {
+            $extra = $this->getExtraName();
             if ($asAttributes) {
-                return "name: fieldName('$name')";
+                return "name: fieldName('$name', '$extra')";
             }
 
-            return ":name=\"fieldName('$name')\"";
+            return ":name=\"fieldName('$name', '$extra')\"";
         }
 
         if ($asAttributes) {
@@ -66,4 +67,9 @@ abstract class TwillFormComponent extends Component
     }
 
     abstract public function render(): View;
+
+    public function getExtraName(): string
+    {
+        return '';
+    }
 }

--- a/views/partials/form/_files.blade.php
+++ b/views/partials/form/_files.blade.php
@@ -1,23 +1,45 @@
-<a17-locale
-    type="a17-filefield"
-    :attributes="{
-        label: '{{ $label }}',
-        itemLabel: '{{ $itemLabel }}',
-        note: '{{ $note }}',
-        fieldNote: '{{ $fieldNote }}',
-        max: {{ $max }},
-        filesizeMax: {{ $filesizeMax }},
-        @if ($buttonOnTop) buttonOnTop: true, @endif
-        {!! $formFieldName(true) !!}
-    }"
-></a17-locale>
+@if ($translated ?? true)
+    <a17-locale
+        type="a17-filefield"
+        :attributes="{
+            label: '{{ $label }}',
+            itemLabel: '{{ $itemLabel }}',
+            note: '{{ $note }}',
+            fieldNote: '{{ $fieldNote }}',
+            max: {{ $max }},
+            filesizeMax: {{ $filesizeMax }},
+            @if ($buttonOnTop) buttonOnTop: true, @endif
+            {!! $formFieldName(true) !!}
+        }"
+    ></a17-locale>
 
-@unless($renderForBlocks)
-@push('vuexStore')
-    @foreach(getLocales() as $locale)
-        @if (isset($form_fields['files']) && isset($form_fields['files'][$locale][$name]))
-            window['{{ config('twill.js_namespace') }}'].STORE.medias.selected["{{ $name }}[{{ $locale }}]"] = {!! json_encode($form_fields['files'][$locale][$name]) !!}
-        @endif
-    @endforeach
-@endpush
-@endunless
+    @unless($renderForBlocks)
+    @push('vuexStore')
+        @foreach(getLocales() as $locale)
+            @if (isset($form_fields['files']) && isset($form_fields['files'][$locale][$name]))
+                window['{{ config('twill.js_namespace') }}'].STORE.medias.selected["{{ $name }}[{{ $locale }}]"] = {!! json_encode($form_fields['files'][$locale][$name]) !!}
+            @endif
+        @endforeach
+    @endpush
+    @endunless
+@else
+    <a17-filefield
+        {!! $formFieldName() !!}
+        :max="{{ $max }}"
+        label="{{ $label }}"
+        item-label="{{ $itemLabel }}"
+        note="{{ $note }}"
+        field-note="{{ $fieldNote }}"
+        :filesize-max="{{ $filesizeMax }}"
+        @if ($buttonOnTop) :button-on-top="true", @endif
+    ></a17-filefield>
+
+    @unless($renderForBlocks)
+        @push('vuexStore')
+            @if (isset($form_fields['files']) && isset($form_fields['files'][config('app.locale')]) && isset($form_fields['files'][config('app.locale')][$name]))
+                window['{{ config('twill.js_namespace') }}'].STORE.medias.selected["{{ $name }}"] = {!! json_encode($form_fields['files'][config('app.locale')][$name]) !!}
+            @endif
+        @endpush
+    @endunless
+@endif
+

--- a/views/partials/form/_files.blade.php
+++ b/views/partials/form/_files.blade.php
@@ -1,4 +1,4 @@
-@if ($translated ?? true)
+@if (!$disableTranslate ?? true)
     <a17-locale
         type="a17-filefield"
         :attributes="{


### PR DESCRIPTION
## Description

This addresses the issue where setting the `translatable(false)` method on a file field does not affect the field (i.e. Always translated) by adding a new `disableTranslate()` method on the file field.

Usage:
```
Files::make()
    ->name('single_file')
    ->label(twillTrans('Single file'))
    ->disableTranslate();
```

## Related Issues

Fixes #1712
