### PR TITLE
fix: error with time-picker when allowInput is true

### DIFF
--- a/frontend/js/components/DatePicker.vue
+++ b/frontend/js/components/DatePicker.vue
@@ -160,6 +160,11 @@
               return parse(date, fullFormatNoTime, Date.UTC());
             }
 
+            if (self.isValidTime(date)) {
+              const currentDate = new Date();
+              date = `${currentDate.toDateString()} ${date}`;
+            }
+
             // Hope for the best..
             return new Date(date);
           },
@@ -209,6 +214,10 @@
         this.saveIntoStore()
 
         this.$emit('input', this.date)
+      },
+      isValidTime: function (string) {
+        const timeRegex = /^(0?[1-9]|1[0-2]):[0-5][0-9](?: (AM|PM))?$/i;
+        return timeRegex.test(string);
       }
     },
     mounted: function () {


### PR DESCRIPTION
## Description

The error occurs because the `parseDate` function cannot return a valid date for a time string e.g `12:00 AM`. The change introduced in this PR appends the time to the current date string so that the function can return a valid date.

```
if (self.isValidTime(date)) {
  const currentDate = new Date();
  date = `${currentDate.toDateString()} ${date}`;
}
```

## Related Issues

Fixes #2557 
