### PR TITLE
fix: Clicking cancel in the block editor deletes all the unsaved blocks

### DIFF
--- a/views/partials/form/utils/_block_editor_store.blade.php
+++ b/views/partials/form/utils/_block_editor_store.blade.php
@@ -1,4 +1,4 @@
-window['{{ config('twill.js_namespace') }}'].STORE.form.blocks = {!! json_encode($form_fields['blocks'] ?? []) !!}
+window['{{ config('twill.js_namespace') }}'].STORE.form.blocks = {!! json_encode($form_fields['blocks'] ?? (object)[]) !!}
 
 @foreach ($form_fields['blocksFields'] ?? [] as $field)
     window['{{ config('twill.js_namespace') }}'].STORE.form.fields.push({!! json_encode($field) !!})


### PR DESCRIPTION
## Description

When the block editor contains no blocks, window[process.env.VUE_APP_NAME].STORE.form.blocks currently defaults to an empty array instead of the required empty object. This discrepancy leads to improper saving of the state

## Related Issues

Fixes #2571
