### PR TITLE
add error reporting to block

### DIFF
--- a/config/twill.php
+++ b/config/twill.php
@@ -285,7 +285,7 @@ return [
     /*
     |--------------------------------------------------------------------------
     | This parameter will throw errors if some error occurs instead of failing
-    | silently
+    | silently (eg. when rendering blocks)
     |--------------------------------------------------------------------------
     */
     'strict' => env('TWILL_STRICT', false),

--- a/config/twill.php
+++ b/config/twill.php
@@ -284,6 +284,14 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | This parameter will throw errors if some error occurs instead of failing
+    | silently
+    |--------------------------------------------------------------------------
+    */
+    'strict' => env('TWILL_STRICT', false),
+
+    /*
+    |--------------------------------------------------------------------------
     | Base classes for automatic generation of Modules and Capsules
     |--------------------------------------------------------------------------
     |

--- a/src/Services/Blocks/Block.php
+++ b/src/Services/Blocks/Block.php
@@ -686,11 +686,15 @@ class Block
         try {
             return view($view, $data)->render();
         } catch (Exception $e) {
+            if (config('twill.strict')) {
+                throw $e;
+            }
             if (config('twill.debug')) {
                 $error = $e->getMessage() . ' in ' . $e->getFile();
 
                 return View::make('twill::errors.block', ['view' => $view, 'error' => $error])->render();
             }
+            report($e);
         }
 
         return '';


### PR DESCRIPTION
Errors are not reported and displayed on production. This mr is based on https://github.com/area17/twill/issues/2540 issue and based on a discussion on discord https://discord.com/channels/811936425858695198/811986440569356308/1219656775125700748

Heads up, after this MR is merged, existing users should expect errors flowing due to  added `report($e);`. IMO it's a good thing since errors will get fixed.