### PR TITLE
Fix: changing twill user password in admin to use the laravel algo

### DIFF
--- a/src/Repositories/UserRepository.php
+++ b/src/Repositories/UserRepository.php
@@ -14,6 +14,7 @@ use Illuminate\Config\Repository as Config;
 use Illuminate\Contracts\Auth\Factory as AuthFactory;
 use Illuminate\Database\DatabaseManager as DB;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\Hash;
 
 class UserRepository extends ModuleRepository
 {
@@ -128,7 +129,7 @@ class UserRepository extends ModuleRepository
         $this->sendWelcomeEmail($user);
 
         if (!empty($fields['reset_password']) && !empty($fields['new_password'])) {
-            $user->password = bcrypt($fields['new_password']);
+            $user->password = Hash::make($fields['new_password']);
 
             if (!$user->isActivated()) {
                 $user->registered_at = Carbon::now();


### PR DESCRIPTION
When changing password via admin or in the profile this creates a hash with the wrong algo resulting in the following error on login if the default laravel algo has been changed, this is not the case via the `twill:superadmin` command

![image](https://github.com/area17/twill/assets/6115458/70c0b06e-e632-4570-bfca-8e5f1cda7741)
