### PR TITLE
docs: update twill version during installation

### DIFF
--- a/docs/content/1_docs/2_getting-started/2_installation.md
+++ b/docs/content/1_docs/2_getting-started/2_installation.md
@@ -21,7 +21,7 @@ The starter kit setup is a basic page builder. It comes with:
 You can install it in a Laravel application using:
 
 ```bash
-composer require area17/twill:"^3.0"
+composer require area17/twill:"^3.2"
 ```
 
 :::alert=type.warning::: 
@@ -40,7 +40,7 @@ See [`examples/basic-page-builder`](https://github.com/area17/twill/tree/3.x/exa
 Twill package can be added to your application using Composer:
 
 ```bash
-composer require area17/twill:"^3.0"
+composer require area17/twill:"^3.2"
 ```
 
 :::alert=type.warning::: 

--- a/docs/content/2_guides/1_page-builder-with-blade/3_installing-twill.md
+++ b/docs/content/2_guides/1_page-builder-with-blade/3_installing-twill.md
@@ -4,7 +4,7 @@ Twill is a standard Laravel package, that means, we only have to require it (and
 
 So, before we get to the process of building our CMS, let's install Twill.
 
-We can do this using `composer require area17/twill:"^3.0"`.
+We can do this using `composer require area17/twill:"^3.2"`.
 
 This will install Twill 3 alongside all other required packages.
 

--- a/examples/basic-page-builder/README.md
+++ b/examples/basic-page-builder/README.md
@@ -34,7 +34,7 @@ The [Laravel documentation](https://laravel.com/docs/10.x) is far more extensive
 Lets require Twill:
 
 ```
-composer require area17/twill:"^3.0"
+composer require area17/twill:"^3.2"
 ```
 
 And then, install this example:


### PR DESCRIPTION
## Description

After installing the package into a fresh Laravel v10 project using ` composer require area17/twill:"^3.0"` I got the following notification from composer:

> The "3.0" constraint for "area17/twill" appears too strict and will likely not match what you want. See https://getcomposer.org/constraints

As the latest version of the package is 3.2 this PR will update the version in the docs to let new users add the latest stable version into their projects.