### PR TITLE
Docs: change admin. route to twill.

### DIFF
--- a/docs/content/1_docs/9_buckets/1_index.md
+++ b/docs/content/1_docs/9_buckets/1_index.md
@@ -66,11 +66,11 @@ Finally, add a link to your buckets page in your CMS navigation:
 return [
    'featured' => [
        'title' => 'Features',
-       'route' => 'admin.featured.homepage',
+       'route' => 'twill.featured.homepage',
        'primary_navigation' => [
            'homepage' => [
                'title' => 'Homepage',
-               'route' => 'admin.featured.homepage',
+               'route' => 'twill.featured.homepage',
            ],
        ],
    ],


### PR DESCRIPTION
## Description

Just a small docs fix, replaced the route `admin.featured.homepage` with `twill.featured.homepage`, since Twill 3.0 uses `twill.` as its default prefix.
