### PR TITLE
Fix dbal 4 conflict

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,7 @@ jobs:
         run: vendor/bin/phpcs
 
   test:
-    name: PHP ${{ matrix.php }} - LARAVEL ${{ matrix.laravel }}
+    name: PHP ${{ matrix.php }} - LARAVEL ${{ matrix.laravel }} - DBAL ${{ matrix.dbal }}
     timeout-minutes: 30
     runs-on: ${{ matrix.os }}
     services:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,6 +72,8 @@ jobs:
           - laravel: 9.*
             dbal: 4.*
           - laravel: 10.*
+            dbal: 4.*
+          - laravel: 10.*
             php: 8.0
           - laravel: 11.*
             php: 8.0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,13 +67,18 @@ jobs:
         os: [ubuntu-latest]
         php: [8.3, 8.2, 8.1, 8.0]
         laravel: [9.*, 10.*, 11.*]
+        dbal: [3.*, 4.*]
         exclude:
+          - laravel: 9.*
+            dbal: 4.*
           - laravel: 10.*
             php: 8.0
           - laravel: 11.*
             php: 8.0
           - laravel: 11.*
             php: 8.1
+          - laravel: 11.*
+            dbal: 3.*
         include:
           - laravel: 9.*
             testbench: 7.*
@@ -112,13 +117,13 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ matrix.os }}-${{ matrix.laravel }}-${{ matrix.php }}-composer-${{ hashFiles('**/composer.lock') }}
+          key: ${{ matrix.os }}-${{ matrix.laravel }}-${{ matrix.php }}-${{ matrix.dbal }}-composer-${{ hashFiles('**/composer.lock') }}
           restore-keys: |
-            ${{ matrix.os }}-${{ matrix.laravel }}-${{ matrix.php }}-composer-
+            ${{ matrix.os }}-${{ matrix.laravel }}-${{ matrix.php }}-${{ matrix.dbal }}-composer-
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "doctrine/dbal:${{ matrix.dbal }}" --no-interaction --no-update
           composer install --prefer-dist --no-interaction --no-plugins
 
       - name: Patch TestCase files for PHP < 8.1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:10.*" "doctrine/dbal:^3.0" --no-interaction --no-update
+          composer require "laravel/framework:11.*" --no-interaction --no-update
           composer install
 
       - name: Execute tests
@@ -118,7 +118,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "doctrine/dbal:^3.0" --no-interaction --no-update
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
           composer install --prefer-dist --no-interaction --no-plugins
 
       - name: Patch TestCase files for PHP < 8.1
@@ -133,7 +133,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: '18.x'
+          node-version: '20.x'
 
       - name: Build npm dependencies.
         run: |

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "ext-pdo": "*",
     "astrotomic/laravel-translatable": "^v11.12",
     "cartalyst/tags": "^12.0 || ^13.0 || ^14.0",
-    "doctrine/dbal": "^3.0",
+    "doctrine/dbal": "^3.0 || ^4.0",
     "guzzlehttp/guzzle": "^7.0",
     "imgix/imgix-php": "^3.0",
     "kalnoy/nestedset": "^6.0",


### PR DESCRIPTION
Allow dbal 4 to be installed to prevent conflicts when installing Twill. FWIW, deleting the `composer.lock` file before installing Twill doesn't currently produce any conflict, but we of course want a clean install in any Laravel app, so we're adding dbal 4.0 even though we don't need it anymore in Twill due to Laravel itself not needing it anymore since Laravel 11. It would be a breaking change to drop it for now, so we'll do that in Twill 4.

Fixes #2594 