### PR TITLE
Don't load relation for each column and allow dot notation in field name for index table

### DIFF
--- a/src/Services/Listings/Columns/Boolean.php
+++ b/src/Services/Listings/Columns/Boolean.php
@@ -9,6 +9,6 @@ class Boolean extends TableColumn
 {
     protected function getRenderValue(TwillModelContract $model): string
     {
-        return $model->{$this->field} ? "✅" : "❌";
+        return parent::getRenderValue($model) ? "✅" : "❌";
     }
 }

--- a/src/Services/Listings/Columns/Relation.php
+++ b/src/Services/Listings/Columns/Relation.php
@@ -44,9 +44,9 @@ class Relation extends TableColumn
             throw new ColumnMissingPropertyException('Relation column missing relation value: ' . $this->field);
         }
 
-        // @todo: I feel this can be optimized.
         /** @var \Illuminate\Database\Eloquent\Collection $relation */
-        $relation = $model->{$this->relation}()->get();
+        $model->loadMissing($this->relation);
+        $relation = $model->getRelation($this->relation);
 
         return $relation->pluck($this->field)->join(', ');
     }

--- a/src/Services/Listings/TableColumn.php
+++ b/src/Services/Listings/TableColumn.php
@@ -257,6 +257,6 @@ abstract class TableColumn
             return $renderFunction($model);
         }
 
-        return data_get($model, $this->field) ?? '';
+        return empty($this->field) ? '' : (data_get($model, $this->field) ?? '');
     }
 }

--- a/src/Services/Listings/TableColumn.php
+++ b/src/Services/Listings/TableColumn.php
@@ -257,6 +257,6 @@ abstract class TableColumn
             return $renderFunction($model);
         }
 
-        return $model->{$this->field} ?? '';
+        return data_get($model, $this->field) ?? '';
     }
 }


### PR DESCRIPTION
We can eager load attributes using `eagerLoadListingRelations([])` in the `setUp` of the controller, however the `Relation` column doesn't actually use the loaded relation (and doesn't work with one to one relation) it currently runs a query for each column and each model and the default `Text` also cannot use it because it does not use dot notation traversal

This PR aims to greatly improve this by only loading the relation once and allowing dot notation in text column to allow to retrieve fields in one to one relations or json 
