### PR TITLE
Use strict check for is null, as it otherwise causes empty arrays to not have any field

### DIFF
--- a/docs/content/2_guides/4_creating_custom_components_form_fields_and_blocks.md
+++ b/docs/content/2_guides/4_creating_custom_components_form_fields_and_blocks.md
@@ -430,7 +430,7 @@ npm install vue-numeric --save
     in-store="value"
 ></a17-custom-number>
 
-@unless($renderForBlocks || $renderForModal || (!isset($item->$name) && null == $formFieldsValue = getFormFieldsValue($form_fields, $name)))
+@unless($renderForBlocks || $renderForModal || (!isset($item->$name) && is_null($formFieldsValue = getFormFieldsValue($form_fields, $name))))
 @push('vuexStore')
     window['{{ config('twill.js_namespace') }}'].STORE.form.fields.push({
         name: '{{ $name }}',

--- a/views/partials/form/_checkbox.blade.php
+++ b/views/partials/form/_checkbox.blade.php
@@ -12,7 +12,7 @@
     in-store="currentValue"
 ></a17-singlecheckbox>
 
-@unless($renderForBlocks || $renderForModal || (!isset($item->$name) && null === $formFieldsValue = getFormFieldsValue($form_fields, $name)))
+@unless($renderForBlocks || $renderForModal || (!isset($item->$name) && is_null($formFieldsValue = getFormFieldsValue($form_fields, $name))))
     @push('vuexStore')
         window['{{ config('twill.js_namespace') }}'].STORE.form.fields.push({
         name: '{{ $name }}',

--- a/views/partials/form/_checkboxes.blade.php
+++ b/views/partials/form/_checkboxes.blade.php
@@ -19,7 +19,7 @@
     @endif
 </a17-multiselect>
 
-@unless($renderForBlocks || $renderForModal || (!isset($item->$name) && null == $formFieldsValue = getFormFieldsValue($form_fields, $name)))
+@unless($renderForBlocks || $renderForModal || (!isset($item->$name) && is_null($formFieldsValue = getFormFieldsValue($form_fields, $name))))
 @push('vuexStore')
     window['{{ config('twill.js_namespace') }}'].STORE.form.fields.push({
         name: '{{ $name }}',

--- a/views/partials/form/_color.blade.php
+++ b/views/partials/form/_color.blade.php
@@ -5,7 +5,7 @@
     in-store="value"
 ></a17-colorfield>
 
-@unless($renderForBlocks || $renderForModal || (!isset($item->$name) && null == $formFieldsValue = getFormFieldsValue($form_fields, $name)))
+@unless($renderForBlocks || $renderForModal || (!isset($item->$name) && is_null($formFieldsValue = getFormFieldsValue($form_fields, $name))))
 @push('vuexStore')
     window['{{ config('twill.js_namespace') }}'].STORE.form.fields.push({
         name: '{{ $name }}',

--- a/views/partials/form/_date_picker.blade.php
+++ b/views/partials/form/_date_picker.blade.php
@@ -19,7 +19,7 @@
     in-store="date"
 ></a17-datepicker>
 
-@unless($renderForBlocks || $renderForModal || (!isset($item->$name) && null == $formFieldsValue = getFormFieldsValue($form_fields, $name)))
+@unless($renderForBlocks || $renderForModal || (!isset($item->$name) && is_null($formFieldsValue = getFormFieldsValue($form_fields, $name))))
 @push('vuexStore')
     window['{{ config('twill.js_namespace') }}'].STORE.form.fields.push({
         name: '{{ $name }}',

--- a/views/partials/form/_multi_select.blade.php
+++ b/views/partials/form/_multi_select.blade.php
@@ -45,7 +45,7 @@
     </a17-vselect>
 @endif
 
-@unless($renderForBlocks || $renderForModal || (!isset($item->$name) && null == $formFieldsValue = getFormFieldsValue($form_fields, $name)))
+@unless($renderForBlocks || $renderForModal || (!isset($item->$name) && is_null($formFieldsValue = getFormFieldsValue($form_fields, $name))))
 @push('vuexStore')
     window['{{ config('twill.js_namespace') }}'].STORE.form.fields.push({
         name: '{{ $name }}',

--- a/views/partials/form/_radios.blade.php
+++ b/views/partials/form/_radios.blade.php
@@ -24,7 +24,7 @@
     @endif
 </a17-singleselect>
 
-@unless($renderForBlocks || $renderForModal || (!isset($item->$name) && null == $formFieldsValue = getFormFieldsValue($form_fields, $name, $default)))
+@unless($renderForBlocks || $renderForModal || (!isset($item->$name) && is_null($formFieldsValue = getFormFieldsValue($form_fields, $name, $default))))
 @push('vuexStore')
     @include('twill::partials.form.utils._selector_input_store')
 @endpush

--- a/views/partials/form/_select.blade.php
+++ b/views/partials/form/_select.blade.php
@@ -77,7 +77,7 @@
     </a17-vselect>
 @endif
 
-@unless($renderForBlocks || $renderForModal || (!isset($item->$name) && null == $formFieldsValue = getFormFieldsValue($form_fields, $name)))
+@unless($renderForBlocks || $renderForModal || (!isset($item->$name) && is_null($formFieldsValue = getFormFieldsValue($form_fields, $name))))
 @push('vuexStore')
     @include('twill::partials.form.utils._selector_input_store')
 @endpush

--- a/views/partials/form/_select_permissions.blade.php
+++ b/views/partials/form/_select_permissions.blade.php
@@ -34,7 +34,7 @@
             </a17-singleselect>
         </div>
 
-        @unless((!isset($item->$name) && null == $formFieldsValue = getFormFieldsValue($form_fields, $name)))
+        @unless((!isset($item->$name) && is_null($formFieldsValue = getFormFieldsValue($form_fields, $name))))
             @push('vuexStore')
                 @include('twill::partials.form.utils._selector_input_store')
             @endpush


### PR DESCRIPTION
Because `null == []` is true in php, fields which are empty arrays (for example for Checkboxes) were not present in the `TWILL.store.form.fields`

This causes issues with `connectedFields` which expect the field to always be an array if `arrayContains` is set to false and so the field does not appear when it's expected to when loading the page (until you check and uncheck a checkbox)