### PR TITLE
Fix trim function to get corresponding input

### DIFF
--- a/src/Services/Listings/TableColumn.php
+++ b/src/Services/Listings/TableColumn.php
@@ -243,7 +243,7 @@ abstract class TableColumn
                         'slot' => $this->getRenderValue($model),
                         'isEditLink' => $this->linkToEdit,
                         'link' => $link,
-                    ])
+                    ])->render()
                 );
             }
         }


### PR DESCRIPTION
The trim function is expecting string as parameter, but get View Class insted of string. Strict types also coud brake at this point.

<!--
  Thanks for opening a PR! Your contribution is much appreciated.
  Do you have any questions? Check out the contributing docs at https://github.com/area17/twill/blob/3.x/CONTRIBUTING.md, or ask in this Pull Request and a Twill maintainer will be happy to help :)
-->

## Description

<!-- Write a description of the changes introduced by this PR -->
<!-- If this is introducing a new feature, it would be great if you can create a stub for documentation including bullet points for how to use the feature, code snippets, etc. -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
