### PR TITLE
Limits Access Key exposition to S3 storage

### DIFF
--- a/src/Http/ViewComposers/FilesUploaderConfig.php
+++ b/src/Http/ViewComposers/FilesUploaderConfig.php
@@ -70,7 +70,7 @@ class FilesUploaderConfig
             'endpointBucket' => $this->config->get('filesystems.disks.' . $libraryDisk . '.bucket', 'none'),
             'endpointRegion' => $this->config->get('filesystems.disks.' . $libraryDisk . '.region', 'none'),
             'endpointRoot' => $endpointType === 'local' ? '' : $this->config->get('filesystems.disks.' . $libraryDisk . '.root', ''),
-            'accessKey' => $this->config->get('filesystems.disks.' . $libraryDisk . '.key', 'none'),
+            'accessKey' => $endpointType === 's3' ? $this->config->get('filesystems.disks.' . $libraryDisk . '.key', '') : '',
             'csrfToken' => $this->sessionStore->token(),
             'acl' => $this->config->get('twill.file_library.acl'),
             'filesizeLimit' => $this->config->get('twill.file_library.filesize_limit'),

--- a/src/Http/ViewComposers/MediasUploaderConfig.php
+++ b/src/Http/ViewComposers/MediasUploaderConfig.php
@@ -70,7 +70,7 @@ class MediasUploaderConfig
             'endpointBucket' => $this->config->get('filesystems.disks.' . $libraryDisk . '.bucket', 'none'),
             'endpointRegion' => $this->config->get('filesystems.disks.' . $libraryDisk . '.region', 'none'),
             'endpointRoot' => $endpointType === 'local' ? '' : $this->config->get('filesystems.disks.' . $libraryDisk . '.root', ''),
-            'accessKey' => $this->config->get('filesystems.disks.' . $libraryDisk . '.key', 'none'),
+            'accessKey' => $endpointType === 's3' ? $this->config->get('filesystems.disks.' . $libraryDisk . '.key', '') : '',
             'csrfToken' => $this->sessionStore->token(),
             'acl' => $this->config->get('twill.media_library.acl'),
             'filesizeLimit' => $this->config->get('twill.media_library.filesize_limit'),


### PR DESCRIPTION
## Description

Contrary to S3 that provides both access key and secret key, Azure only provides a single access key.

`FineUploaderAzure` does not need it since it leverages on the signing endpoint and the generation of the SAS (Shared Access Signature) that was generated.
