### PR TITLE
feat: add searchQuery method to controller for finer control over the search

### DIFF
--- a/docs/content/1_docs/3_modules/5_controllers.md
+++ b/docs/content/1_docs/3_modules/5_controllers.md
@@ -63,6 +63,8 @@ Below is a list of the methods and their purpose:
 - **setModuleName**('`yourModuleName`'): Set the name of the module you are working with.
 - **setFeatureField**('`fieldname`'): Set the field to use for featuring content.
 - **setSearchColumns**(`['title', 'year']`): Set the columns to search in.
+- **setSearchQuery**(`
+  fn (Builder $q, string $search) => $q->orWhereHas('profile', fn (Builder $q) => $q->where('first_name', 'like', "$search%")->orWhere('last_name', 'like', "$search%"))`): For finer controller over the search
 - **setPermalinkBase**('`example`'): The static permalink base to your module. Defaults to `setModuleName` when empty.
 - **setTitleColumnKey**('`title`'): Sets the field to use as title, defaults to `title`.
 - **setModelName**('`Project`'): Usually not required, but in case customization is needed you can use this method to set
@@ -240,4 +242,3 @@ protected function formData($request)
     return [];
 }
 ```
-

--- a/src/Http/Controllers/Admin/ModuleController.php
+++ b/src/Http/Controllers/Admin/ModuleController.php
@@ -369,6 +369,14 @@ abstract class ModuleController extends Controller
      */
     protected ?array $searchColumns = null;
 
+
+    /**
+     * If you need more fine control over the search query
+     *
+     * Do not modify this directly but use the method setSearchQuery().
+     */
+    protected mixed $searchQuery = null;
+
     /**
      * Default label translation keys that can be overridden in the labels array.
      *
@@ -625,6 +633,15 @@ abstract class ModuleController extends Controller
     protected function setSearchColumns(array $searchColumns): void
     {
         $this->searchColumns = $searchColumns;
+    }
+
+    /**
+     * If you need finer control over the search query, you may provide a callback
+     * @param callable $query With the following signature: fn (Builder $query, string $searchString, array $translatedAttributes): void => $query
+     */
+    protected function setSearchQuery(callable $query): void
+    {
+        $this->searchQuery = $query;
     }
 
     /**
@@ -1841,6 +1858,7 @@ abstract class ModuleController extends Controller
             } elseif ($filterKey === 'search') {
                 $appliedFilters[] = FreeTextSearch::make()
                     ->searchFor($filterValue)
+                    ->searchQuery($this->searchQuery)
                     ->searchColumns($this->searchColumns);
             }
         }

--- a/tests/integration/Controllers/Tables/Filters/FilterTestBase.php
+++ b/tests/integration/Controllers/Tables/Filters/FilterTestBase.php
@@ -41,6 +41,11 @@ class FilterTestBase extends ModulesTestBase
                 $this->setSearchColumns(...$args);
             }
 
+            public function setSearchQueryTest(...$args): void
+            {
+                $this->setSearchQuery(...$args);
+            }
+
             public function quickFilters(): QuickFilters
             {
                 if ($this->testQuickFilters !== []) {

--- a/tests/integration/Controllers/Tables/Filters/SearchTest.php
+++ b/tests/integration/Controllers/Tables/Filters/SearchTest.php
@@ -2,6 +2,8 @@
 
 namespace A17\Twill\Tests\Integration\Controllers\Tables\Filters;
 
+use Illuminate\Contracts\Database\Eloquent\Builder;
+
 class SearchTest extends FilterTestBase
 {
     public function setUp(): void
@@ -41,7 +43,8 @@ class SearchTest extends FilterTestBase
 
         // Set the search columns.
         $controller = $this->controllerWithFiltersAndQuickFilters(active: ['search' => '2022']);
-        $controller->setSearchColumnsTest(['name', 'year']);
+        $controller->setSearchColumnsTest(['name']);
+        $controller->setSearchQueryTest(fn (Builder $q, string $search) => $q->orWhere('year', $search));
 
         $data = $controller->index()->getData();
         $this->assertCount(1, $data['tableData']);


### PR DESCRIPTION
<!--
  Thanks for opening a PR! Your contribution is much appreciated.
  Do you have any questions? Check out the contributing docs at https://github.com/area17/twill/blob/3.x/CONTRIBUTING.md, or ask in this Pull Request and a Twill maintainer will be happy to help :)
-->

## Description

Sometimes we need to be able to customize how the search works in a controller to search in a relation, or maybe to run a specific search, or to run a search that uses indexes 

Now we can do just that and it's compatible with searchColumns:

```php
        $this->setSearchColumns(['email', 'phone']);
        $this->setSearchQuery(
            fn (Builder $q, string $search) => $q
            ->orWhereHas('profile', fn (Builder $q) => $q
                ->where('first_name', 'like', "$search%")
                ->orWhere('last_name', 'like', "$search%")
            )
        );
```