### PR TITLE
Disable controlLanguagesPublication for settings page

### DIFF
--- a/src/Http/Controllers/Admin/AppSettingsController.php
+++ b/src/Http/Controllers/Admin/AppSettingsController.php
@@ -116,6 +116,7 @@ class AppSettingsController extends ModuleController
         $base['publish'] = false;
         $base['editableTitle'] = false;
         $base['translate'] = true;
+        $base['controlLanguagesPublication'] = false;
 
         return $base;
     }


### PR DESCRIPTION
## Description

Since the language publishing control in the settings module is not affecting anything, it's better to hide UI elements related to it. 
There also is a reference for such disabling in the legacy implementation (see [settings.blade.php](https://github.com/area17/twill/blob/3.x/views/layouts/settings.blade.php#L3)), but for some reason, it wasn't implemented in the newer one.

See before and after:

![image](https://github.com/area17/twill/assets/76988528/a1d231a3-793a-4f77-833a-e47676ea2e39)
![image](https://github.com/area17/twill/assets/76988528/1859947a-d720-4f61-9cdb-8692815ed0d2)
