### PR TITLE
 Preview - Update default width value for the mobile preview (to a more realistic value)

### DIFF
--- a/frontend/js/components/Previewer.vue
+++ b/frontend/js/components/Previewer.vue
@@ -92,7 +92,7 @@
             name: 'preview-tablet-v'
           },
           {
-            size: 320,
+            size: 390,
             name: 'preview-mobile'
           }
         ]


### PR DESCRIPTION
## Description

 Preview - Update default width value for the mobile preview (to a more realistic value 390px)

## Related Issues

320px is not widely used anymore.
https://gs.statcounter.com/screen-resolution-stats/mobile/united-states-of-america
