### PR TITLE
Filter - Select : expand to the longest option

### DIFF
--- a/frontend/scss/vendor/_vselect.scss
+++ b/frontend/scss/vendor/_vselect.scss
@@ -25,6 +25,8 @@ $multiSelectHeight: 45px;
     }
 
     .vs__dropdown-menu {
+      // make sure the content expand to the longest option
+      --vs-dropdown-min-width: fit-content;
       padding:15px 0;
       border-top:1px solid $color__border--light;
       box-shadow: 0px 1px 3.5px 0px rgba(0, 0, 0, 0.30);


### PR DESCRIPTION
## Description

This fix the content into filter dropdown being cut while there is room to display the options.
Default min-width is set to 160px, I updated to fit to the longest content instead.

Before :
![Capture d’écran 2024-06-28 à 17 00 29](https://github.com/area17/twill/assets/546129/3f7f5068-d4f3-4d69-906b-5a440306f824)

After :
![Capture d’écran 2024-06-28 à 16 49 44](https://github.com/area17/twill/assets/546129/8d8e1228-56cc-4117-b036-8e97f1d11855)
