### PR TITLE
`twill:refresh-crops` Fix wrong crops for Blocks

### DIFF
--- a/src/Commands/RefreshCrops.php
+++ b/src/Commands/RefreshCrops.php
@@ -106,9 +106,10 @@ class RefreshCrops extends Command
 
         $this->roleName = $this->argument('roleName');
 
-        $mediasParams = app($this->modelName)->getMediasParams();
-        if (empty($mediasParams)) {
+        if (app($this->modelName) instanceof \A17\Twill\Models\Block) {
             $mediasParams = TwillBlocks::getAllCropConfigs();
+        } else {
+            $mediasParams = app($this->modelName)->getMediasParams();
         }
 
         if (! isset($mediasParams[$this->roleName])) {


### PR DESCRIPTION
## Description

`php artisan twill:refresh-crops \\A17\\Twill\\Models\\Block block-image` was returning an error "roleName not found" becasue `getMediaParams()` it returning `config('twill.default_crops')` preventing from getting to the TwillBlock line. The returned array is then wrong for Blocks.

This change checks is the model is an instance of blocks and then return the appropriate arrays of media params.

## Related Issues

none