### PR TITLE
Fix deleted users causes error 500

### DIFF
--- a/src/Http/Controllers/Admin/DashboardController.php
+++ b/src/Http/Controllers/Admin/DashboardController.php
@@ -233,6 +233,10 @@ class DashboardController extends Controller
 
     private function formatActivity(Activity $activity): ?array
     {
+        if (is_null($activity->subject)) {
+            return null;
+        }
+
         if ($activity->subject_type === config('twill.auth_activity_causer', 'users')) {
             return $this->formatAuthActivity($activity);
         }
@@ -240,10 +244,6 @@ class DashboardController extends Controller
         $dashboardModule = $this->config->get('twill.dashboard.modules.' . $activity->subject_type);
 
         if (! $dashboardModule || ! $dashboardModule['activity'] ?? false) {
-            return null;
-        }
-
-        if (is_null($activity->subject)) {
             return null;
         }
 


### PR DESCRIPTION
When a twill user that previously logged in gets deleted, any user after that, that tries to access the dashboard will get an error 500, because `subject` is pointing to null (a user that doesn't exist anymore)