### PR TITLE
Allow per-model permission level management

### DIFF
--- a/docs/content/1_docs/10_user-management/2_advanced-permissions.md
+++ b/docs/content/1_docs/10_user-management/2_advanced-permissions.md
@@ -29,6 +29,9 @@ In addition to this we have to configure the permissions' system. There are 3 le
 Set the `twill.permissions.level` to the desired type. And also set the modules to manage in
 the `twill.permissions.modules` key.
 
+Beside setting global `twill.permissions.level` it is also possible to set per-module level by adding
+it to `twill.permissions.modules` as keyed item as shown for model `pages` in example below.
+
 ```php {7-10}
 <?php
 
@@ -37,8 +40,11 @@ return [
     'permissions-management'
   ],
   'permissions' => [
-      'level' => \A17\Twill\Enums\PermissionLevel::LEVEL_ROLE,
-      'modules' => ['blogs'],
+      'level' => \A17\Twill\Enums\PermissionLevel::LEVEL_ROLE_GROUP,
+      'modules' => [
+        'blogs',
+        'pages' => \A17\Twill\Enums\PermissionLevel::LEVEL_ROLE_GROUP_ITEM
+      ],
   ],
 ]
 ```

--- a/src/Http/Controllers/Admin/GroupController.php
+++ b/src/Http/Controllers/Admin/GroupController.php
@@ -2,6 +2,7 @@
 
 namespace A17\Twill\Http\Controllers\Admin;
 
+use A17\Twill\Enums\PermissionLevel;
 use A17\Twill\Facades\TwillPermissions;
 use A17\Twill\Models\Contracts\TwillModelContract;
 use A17\Twill\Services\Listings\Columns\Text;
@@ -67,8 +68,10 @@ class GroupController extends ModuleController
 
     protected function formData($request): array
     {
+        // Divide permissions based on level to minimize instance fetching
         return [
-            'permissionModules' => Permission::permissionableParentModuleItems(),
+            'permissionModulesLevelGroup' => Permission::permissionableModulesForLevel([PermissionLevel::LEVEL_ROLE_GROUP, PermissionLevel::LEVEL_ROLE_GROUP_ITEM]),
+            'permissionModulesLevelItem' => Permission::permissionableParentModuleItemsForLevel(PermissionLevel::LEVEL_ROLE_GROUP_ITEM),
         ];
     }
 

--- a/src/Http/Controllers/Admin/UserController.php
+++ b/src/Http/Controllers/Admin/UserController.php
@@ -201,12 +201,7 @@ class UserController extends ModuleController
             $titleThumbnail = $user->cmsImage($role, $crop, $params);
         }
 
-        if (TwillPermissions::levelIs(PermissionLevel::LEVEL_ROLE_GROUP_ITEM)) {
-            $permissionsData = [
-                'permissionModules' => $this->getPermissionModules(),
-            ];
-        }
-
+        // Fetch modules with LEVEL_ROLE_GROUP_ITEM permission level
         return [
             'roleList' => $this->getRoleList(),
             'titleThumbnail' => $titleThumbnail ?? null,
@@ -214,7 +209,8 @@ class UserController extends ModuleController
             'qrCode' => $qrCode ?? null,
             'groupPermissionMapping' => $this->getGroupPermissionMapping(),
             'groupOptions' => $this->getGroups(),
-        ] + ($permissionsData ?? []);
+            'permissionModules' => Permission::permissionableParentModuleItemsForLevel(PermissionLevel::LEVEL_ROLE_GROUP_ITEM)
+        ];
     }
 
     /**
@@ -352,15 +348,6 @@ class UserController extends ModuleController
         return collect(TwillPermissions::roles()::toArray())->map(function ($item, $key) {
             return ['value' => $key, 'label' => $item];
         })->values()->toArray();
-    }
-
-    private function getPermissionModules()
-    {
-        if (config('twill.enabled.permissions-management')) {
-            return Permission::permissionableParentModuleItems();
-        }
-
-        return [];
     }
 
     public function getSubmitOptions(Model $item): ?array

--- a/src/Repositories/Behaviors/HandleGroupPermissions.php
+++ b/src/Repositories/Behaviors/HandleGroupPermissions.php
@@ -27,13 +27,20 @@ trait HandleGroupPermissions
             }
 
             // Add active module permissions
-            foreach (Permission::permissionableModules() as $moduleName) {
+            foreach (Permission::permissionableModulesForLevel([PermissionLevel::LEVEL_ROLE_GROUP, PermissionLevel::LEVEL_ROLE_GROUP_ITEM]) as $moduleName) {
                 $modulePermission = $object->permissions()->module()->ofModuleName($moduleName)->first();
                 if ($modulePermission) {
                     $fields['module_' . $moduleName . '_permissions'] = $modulePermission->name;
                 } else {
                     $fields['module_' . $moduleName . '_permissions'] = 'none';
                 }
+            }
+
+            // Add LEVEL_ROLE_GROUP_ITEM permission level modules with items
+            foreach ($object->permissions()->moduleItem()->get() as $permission) {
+                $model = $permission->permissionable()->first();
+                $moduleName = getModuleNameByModel($model);
+                $fields[$moduleName . '_' . $model->id . '_permission'] = $permission->name;
             }
         } elseif (TwillPermissions::levelIs(PermissionLevel::LEVEL_ROLE_GROUP_ITEM)) {
             // Add active item permissions

--- a/src/Repositories/Behaviors/HandlePermissions.php
+++ b/src/Repositories/Behaviors/HandlePermissions.php
@@ -134,7 +134,7 @@ trait HandlePermissions
 
     private function shouldProcessPermissions($moduleName): bool
     {
-        return TwillPermissions::levelIs(PermissionLevel::LEVEL_ROLE_GROUP_ITEM)
+        return TwillPermissions::levelForModuleIs($moduleName, PermissionLevel::LEVEL_ROLE_GROUP_ITEM)
             && TwillPermissions::getPermissionModule($moduleName);
     }
 

--- a/src/Repositories/Behaviors/HandleUserPermissions.php
+++ b/src/Repositories/Behaviors/HandleUserPermissions.php
@@ -3,7 +3,6 @@
 namespace A17\Twill\Repositories\Behaviors;
 
 use A17\Twill\Enums\PermissionLevel;
-use A17\Twill\Facades\TwillPermissions;
 use A17\Twill\Models\Model;
 use A17\Twill\Models\Permission;
 use A17\Twill\Models\User;
@@ -23,7 +22,7 @@ trait HandleUserPermissions
     {
         if (
             !config('twill.enabled.permissions-management') ||
-            !TwillPermissions::levelIs(PermissionLevel::LEVEL_ROLE_GROUP_ITEM)
+            Permission::permissionableModulesForLevel(PermissionLevel::LEVEL_ROLE_GROUP_ITEM)->isEmpty()
         ) {
             return $fields;
         }
@@ -58,7 +57,7 @@ trait HandleUserPermissions
 
         $this->addOrRemoveUserToEveryoneGroup($object);
 
-        if (TwillPermissions::levelIs(PermissionLevel::LEVEL_ROLE_GROUP_ITEM)) {
+        if (Permission::permissionableModulesForLevel(PermissionLevel::LEVEL_ROLE_GROUP_ITEM)->isNotEmpty()) {
             $this->updateUserItemPermissions($object, $fields);
         }
     }

--- a/src/TwillPermissions.php
+++ b/src/TwillPermissions.php
@@ -64,6 +64,23 @@ class TwillPermissions
         return $this->enabled() && config('twill.permissions.level') === $level;
     }
 
+    /**
+     * Check specific permission level for module
+     *
+     * @param string $module
+     * @param string $level
+     * @return bool
+     * @throws \Exception
+     */
+    public function levelForModuleIs(string $module, string $level): bool
+    {
+        if (!PermissionLevel::isValid($level)) {
+            throw new \Exception('Invalid permission level. Check TwillPermissions for available levels');
+        }
+
+        return $this->enabled() && Permission::permissionableModulesWithLevel()->get($module) === $level;
+    }
+
     public function levelIsOneOf(array $levels): bool
     {
         foreach ($levels as $level) {

--- a/views/groups/form.blade.php
+++ b/views/groups/form.blade.php
@@ -17,8 +17,22 @@
         :max="999"
     />
 
-    @if(\A17\Twill\Facades\TwillPermissions::levelIs(\A17\Twill\Enums\PermissionLevel::LEVEL_ROLE_GROUP))
-        <x-twill::fieldRows title="Content permissions">
+    @if(config('twill.support_subdomain_admin_routing'))
+        <x-twill::fieldRows title="Subdomain access">
+            @foreach(config('twill.app_names') as $subdomain => $subdomainTitle)
+                <x-twill::checkbox
+                    :name="'subdomain_access_' . $subdomain"
+                    :label="$subdomainTitle"
+                />
+            @endforeach
+        </x-twill::fieldRows>
+    @endif
+@stop
+
+
+@section('fieldsets')
+    @if($permissionModulesLevelGroup->isNotEmpty())
+        <a17-fieldset title='Per-module permissions' id='modules'>
             <x-twill::checkbox
                 name="manage-modules"
                 label="Manage all modules"
@@ -27,7 +41,7 @@
             <x-twill::formConnectedFields field-name="manage-modules"
                                           :fieldValues="false"
             >
-                @foreach($permissionModules as $moduleName => $moduleItems)
+                @foreach($permissionModulesLevelGroup as $moduleName)
                     <x-twill::select
                         :name="'module_' . $moduleName . '_permissions'"
                         :label="ucfirst($moduleName) . ' permissions'"
@@ -49,25 +63,12 @@
                     />
                 @endforeach
             </x-twill::formConnectedFields>
-        </x-twill::fieldRows>
+        </a17-fieldset>
     @endif
 
-    @if(config('twill.support_subdomain_admin_routing'))
-        <x-twill::fieldRows title="Subdomain access">
-            @foreach(config('twill.app_names') as $subdomain => $subdomainTitle)
-                <x-twill::checkbox
-                    :name="'subdomain_access_' . $subdomain"
-                    :label="$subdomainTitle"
-                />
-            @endforeach
-        </x-twill::fieldRows>
-    @endif
-@stop
-
-@if(\A17\Twill\Facades\TwillPermissions::levelIs(\A17\Twill\Enums\PermissionLevel::LEVEL_ROLE_GROUP_ITEM))
-    @can('edit-user-groups')
-        @section('fieldsets')
-            @foreach($permissionModules as $moduleName => $moduleItems)
+    @if($permissionModulesLevelItem->isNotEmpty())
+        @can('edit-user-groups')
+            @foreach($permissionModulesLevelItem as $moduleName => $moduleItems)
                 <a17-fieldset title='{{ ucfirst($moduleName) . " Permissions"}}' id='{{ $moduleName }}'>
                     <x-twill::select-permissions
                         :items-in-selects-tables="$moduleItems"
@@ -76,6 +77,6 @@
                     />
                 </a17-fieldset>
             @endforeach
-        @stop
-    @endcan
-@endif
+        @endcan
+    @endif
+@stop

--- a/views/layouts/form.blade.php
+++ b/views/layouts/form.blade.php
@@ -126,7 +126,7 @@
                             @yield('fieldsets')
                         @endif
 
-                        @if(\A17\Twill\Facades\TwillPermissions::levelIs(\A17\Twill\Enums\PermissionLevel::LEVEL_ROLE_GROUP_ITEM))
+                        @if(\A17\Twill\Facades\TwillPermissions::levelForModuleIs(getModuleNameByModel($item), \A17\Twill\Enums\PermissionLevel::LEVEL_ROLE_GROUP_ITEM))
                             @if($showPermissionFieldset ?? null)
                                 @can('manage-item', isset($item) ? $item : null)
                                     <x-twill::formFieldset id="permissions"

--- a/views/roles/form.blade.php
+++ b/views/roles/form.blade.php
@@ -64,7 +64,7 @@
                                 'label' => 'Edit ' . $module_name
                             ]
                         ],
-                        (\A17\Twill\Facades\TwillPermissions::levelIs(\A17\Twill\Enums\PermissionLevel::LEVEL_ROLE_GROUP_ITEM) ? [['value' => 'manage-module', 'label' => 'Manage ' . $module_name ]] : []))"
+                        (\A17\Twill\Facades\TwillPermissions::levelForModuleIs($module_name, \A17\Twill\Enums\PermissionLevel::LEVEL_ROLE_GROUP_ITEM) ? [['value' => 'manage-module', 'label' => 'Manage ' . $module_name ]] : []))"
                 />
             @endforeach
         </x-twill::formConnectedFields>

--- a/views/users/form.blade.php
+++ b/views/users/form.blade.php
@@ -156,7 +156,7 @@
 
 
 @section('fieldsets')
-    @if(\A17\Twill\Facades\TwillPermissions::levelIs(\A17\Twill\Enums\PermissionLevel::LEVEL_ROLE_GROUP_ITEM))
+    @if($permissionModules->isNotEmpty())
         @can('edit-users')
             @unless($item->isSuperAdmin() || $item->id === $currentUser->id)
                 <x-twill::formConnectedFields


### PR DESCRIPTION
## Description
This PR modifies advance permission managements so it is possible to set permission level per module, not only on global level. This is useful when there is no need for per-item management except for few specific modules, fe. `pages` where we want to allow users to edit only specific page(s).

This change should be backwards compatible and can be used by adding a level to `twill.permissions.modules` array:

```php
'permissions' => [
    'level' => \A17\Twill\Enums\PermissionLevel::LEVEL_ROLE_GROUP,
    'modules' => [
        'pages' => \A17\Twill\Enums\PermissionLevel::LEVEL_ROLE_GROUP_ITEM,
        'posts'
    ]
]
```

## Tests
I was not able to run tests on locale machine, but I did test it manually :) 