### PR TITLE
Fix #2674

### DIFF
--- a/src/Services/Listings/Columns/Relation.php
+++ b/src/Services/Listings/Columns/Relation.php
@@ -46,7 +46,7 @@ class Relation extends TableColumn
 
         /** @var \Illuminate\Database\Eloquent\Collection $relation */
         $model->loadMissing($this->relation);
-        $relation = $model->getRelation($this->relation);
+        $relation = collect($model->getRelation($this->relation));
 
         return $relation->pluck($this->field)->join(', ');
     }


### PR DESCRIPTION
In the case of one to one getRelation returns a model and the pluck call invokes a query instead of invoking pluck on the collection

So instead wrap it to make sure we always get a collection

Fixes #2674 
