### PR TITLE
Fix for one to one relation column in index table

### DIFF
--- a/src/Services/Listings/Columns/Relation.php
+++ b/src/Services/Listings/Columns/Relation.php
@@ -46,7 +46,8 @@ class Relation extends TableColumn
 
         /** @var \Illuminate\Database\Eloquent\Collection $relation */
         $model->loadMissing($this->relation);
-        $relation = collect($model->getRelation($this->relation));
+        $relation = $model->getRelation($this->relation);
+        if(!$relation instanceof \Illuminate\Database\Eloquent\Collection) $relation = collect([$relation]);
 
         return $relation->pluck($this->field)->join(', ');
     }


### PR DESCRIPTION
<!--
  Thanks for opening a PR! Your contribution is much appreciated.
  Do you have any questions? Check out the contributing docs at https://github.com/area17/twill/blob/3.x/CONTRIBUTING.md, or ask in this Pull Request and a Twill maintainer will be happy to help :)
-->

## Description

Not sure if this is the best solution, but this way works for both relation types that I use (belongsTo and belongsToMany).
Before this change, `collect($model->getRelation($this->relation));` for belongsToMany, and worked:
![authors](https://github.com/user-attachments/assets/5bf149c4-8085-4924-9240-d281f098220a)

but this for a belongsTo relation:
![category](https://github.com/user-attachments/assets/1026c294-8995-4fc5-b81a-e8905cf18f0b)
I had something like ", , , , , , , , , , ," on that column.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
