### PR TITLE
retrieve slug from slugs table if the $slugAttribute field was not changed

### DIFF
--- a/src/Models/Behaviors/HasSlug.php
+++ b/src/Models/Behaviors/HasSlug.php
@@ -124,9 +124,9 @@ trait HasSlug
      */
     public function handleSlugsOnSave(): void
     {
-        $this->disableLocaleSlugs();
-
         $slugParams = $this->twillSlugData !== [] ? $this->twillSlugData : $this->getSlugParams();
+
+        $this->disableLocaleSlugs();
 
         foreach ($slugParams as $params) {
             if (in_array($params['locale'], config('twill.slug_utf8_languages', []))) {
@@ -358,9 +358,13 @@ trait HasSlug
                     throw new \Exception("You must define the field {$slugAttribute} in your model");
                 }
 
+                $slug = $this->getSlugValue($slugAttribute, $translation->locale)
+                    ?? $translation->$slugAttribute
+                    ?? $this->$slugAttribute;
+
                 $slugParam = [
                         'active' => $translation->active ?? true,
-                        'slug' => $translation->$slugAttribute ?? $this->$slugAttribute,
+                        'slug' => $slug,
                         'locale' => $translation->locale,
                     ] + $slugDependenciesAttributes;
 
@@ -400,7 +404,7 @@ trait HasSlug
 
                 $slugParam = [
                         'active' => 1,
-                        'slug' => $this->$slugAttribute,
+                        'slug' => $this->getSlugValue($slugAttribute, $appLocale) ?? $this->$slugAttribute,
                         'locale' => $appLocale,
                     ] + $slugDependenciesAttributes;
 
@@ -413,6 +417,21 @@ trait HasSlug
         }
 
         return $locale === null ? $slugParams : null;
+    }
+
+    /**
+     * Returns changed value of slugAttribute field or previous slug value
+     *
+     * @param $slugAttribute
+     * @param $locale
+     * @return mixed|null
+     */
+    private function getSlugValue($slugAttribute, $locale): mixed
+    {
+        return $this->wasChanged($slugAttribute)
+            ? $this->$slugAttribute
+            : $this->slugs()->where('locale', $locale)
+                ->where('active', true)->value('slug');
     }
 
     /**


### PR DESCRIPTION

<!--
  Thanks for opening a PR! Your contribution is much appreciated.
  Do you have any questions? Check out the contributing docs at https://github.com/area17/twill/blob/3.x/CONTRIBUTING.md, or ask in this Pull Request and a Twill maintainer will be happy to help :)
-->

## Description
The changes made here was to use the previous slug value if the `$slugAttribute` field was not changed. By doing this, we won't have duplicate slug entries when a model is not updated via the repository.

```
/**
 * Returns changed value of slugAttribute field or previous slug value
 */
private function getSlugValue($slugAttribute, $locale): mixed
{
    return $this->wasChanged($slugAttribute)
        ? $this->$slugAttribute
        : $this->slugs()->where('locale', $locale)
            ->where('active', true)->value('slug');
}
```

<!-- Write a description of the changes introduced by this PR -->
<!-- If this is introducing a new feature, it would be great if you can create a stub for documentation including bullet points for how to use the feature, code snippets, etc. -->

## Related Issues
Fixes #2681 