### PR TITLE
Use JS to read image dimensions on upload

### DIFF
--- a/src/Http/Controllers/Admin/MediaLibraryController.php
+++ b/src/Http/Controllers/Admin/MediaLibraryController.php
@@ -185,11 +185,11 @@ class MediaLibraryController extends ModuleController implements SignUploadListe
 
         $uploadedFile = $request->file('qqfile');
 
-        [$w, $h] = getimagesize($uploadedFile->path());
-
         if ($request->input('width') && $request->input('height')) {
             $w = $request->input('width');
             $h = $request->input('height');
+        } else {
+            [$w, $h] = getimagesize($uploadedFile->path());
         }
 
         $uploadedFile->storeAs($fileDirectory, $filename, $disk);

--- a/src/Http/Controllers/Admin/MediaLibraryController.php
+++ b/src/Http/Controllers/Admin/MediaLibraryController.php
@@ -187,6 +187,11 @@ class MediaLibraryController extends ModuleController implements SignUploadListe
 
         [$w, $h] = getimagesize($uploadedFile->path());
 
+        if ($request->input('width') && $request->input('height')) {
+            $w = $request->input('width');
+            $h = $request->input('height');
+        }
+
         $uploadedFile->storeAs($fileDirectory, $filename, $disk);
 
         $fields = [


### PR DESCRIPTION
## Description

#### The issue

Some jpegs are taken in one orientation and then rotated on a device and exported such that the display of the image doesn't seem to match the dimensions. The result is you upload what you think is a portrait image but is actually a landscape image, which EXIF data set to rotate the image. This then gives un-expected results in the image cropping tool and on the front end.  

#### The fix

Halt the fine-uploader by using a promise on the submit callback of fine-uploader, until after the image has loaded and JavaScript has had a change to grab the image dimensions. Previously the upload was completing before the image had been loaded and so image dimensions were not being sent.

And then we're using the supplied values from the front end when storing the values.