### PR TITLE
fix: #2657 adds missing VUE draggable deprecations

### DIFF
--- a/frontend/js/components/editor/EditorSidebarBlockList.vue
+++ b/frontend/js/components/editor/EditorSidebarBlockList.vue
@@ -4,7 +4,7 @@
     <draggable class="editorSidebar__blocks"
                :class="editorSidebarClasses"
                v-model="blocks"
-               :options="{
+               v-bind="{
                     group: {
                       name: 'editorBlocks',
                       pull: 'clone',


### PR DESCRIPTION
Fixes #2657, follows on from PR #2491

Fixes VueDraggable deprecation in the console on the block editor "content editor" modal

https://github.com/SortableJS/Vue.Draggable/blob/master/documentation/migrate.md#options-props

