### PR TITLE
fix 2641: Inline repeater updates

### DIFF
--- a/docs/content/1_docs/4_form-fields/11_repeater.md
+++ b/docs/content/1_docs/4_form-fields/11_repeater.md
@@ -29,13 +29,15 @@ Repeater::make()
 :::#tab:::
 :::#tabs:::
 
-| Option       | Description                                  | Type    | Default value    |
-|:-------------|:---------------------------------------------|:--------|:-----------------|
-| type         | Type of repeater items                       | string  |                  |
-| name         | Name of the field                            | string  | same as `type`   |
-| max          | Maximum amount that can be created           | number  | null (unlimited) |
-| buttonAsLink | Displays the `Add` button as a centered link | boolean | false            |
-| reorder      | Allow reordering of repeater items           | boolean | true             |
+| Option         | Description                                  | Type    | Default value    |
+|:---------------|:---------------------------------------------|:--------|:-----------------|
+| type           | Type of repeater items                       | string  |                  |
+| name           | Name of the field                            | string  | same as `type`   |
+| max            | Maximum amount that can be created           | number  | null (unlimited) |
+| buttonAsLink   | Displays the `Add` button as a centered link | boolean | false            |
+| disableCreate  | Disables ability to add new items            | boolean | false            |
+| disableActions | Removes row item actions                     | boolean | false            |
+| disableReorder | Disables reordering of repeater items        | boolean | false            |
 
 <br/>
 

--- a/docs/content/1_docs/4_form-fields/11_repeater.md
+++ b/docs/content/1_docs/4_form-fields/11_repeater.md
@@ -35,9 +35,9 @@ Repeater::make()
 | name           | Name of the field                            | string  | same as `type`   |
 | max            | Maximum amount that can be created           | number  | null (unlimited) |
 | buttonAsLink   | Displays the `Add` button as a centered link | boolean | false            |
-| disableCreate  | Disables ability to add new items            | boolean | false            |
-| disableActions | Removes row item actions                     | boolean | false            |
-| disableReorder | Disables reordering of repeater items        | boolean | false            |
+| disableCreate  | Disables ability to add new items            | boolean | true             |
+| disableActions | Removes row item actions                     | boolean | true             |
+| disableReorder | Disables reordering of repeater items        | boolean | true             |
 
 <br/>
 

--- a/frontend/js/components/Repeater.vue
+++ b/frontend/js/components/Repeater.vue
@@ -12,7 +12,7 @@
               :opened="opened"
           >
             <a17-button slot="block-actions" variant="icon" data-action @click="duplicateBlock(index)"
-                        v-if="hasRemainingBlocks">
+                        v-if="hasRemainingBlocks && allowCreate">
               <span v-svg symbol="add"></span>
             </a17-button>
             <div slot="dropdown-action">

--- a/frontend/js/components/Repeater.vue
+++ b/frontend/js/components/Repeater.vue
@@ -8,6 +8,7 @@
               :block="block"
               :index="index"
               :withHandle="allowSortable && draggable"
+              :withActions="allowActions"
               :size="blockSize"
               :opened="opened"
           >
@@ -111,6 +112,10 @@
         default: true
       },
       allowSortable: {
+        type: Boolean,
+        default: true
+      },
+      allowActions: {
         type: Boolean,
         default: true
       },

--- a/frontend/js/components/Repeater.vue
+++ b/frontend/js/components/Repeater.vue
@@ -7,8 +7,8 @@
               ref="blockList"
               :block="block"
               :index="index"
-              :withHandle="allowSortable && draggable"
-              :withActions="allowActions"
+              :withHandle="reorder && draggable"
+              :withActions="displayActions"
               :size="blockSize"
               :opened="opened"
           >
@@ -111,11 +111,7 @@
         type: Boolean,
         default: true
       },
-      allowSortable: {
-        type: Boolean,
-        default: true
-      },
-      allowActions: {
+      displayActions: {
         type: Boolean,
         default: true
       },
@@ -123,7 +119,11 @@
         type: [Number, null],
         required: false,
         default: null
-      }
+      },
+      reorder: {
+        type: Boolean,
+        default: true
+      },
     },
     data: function () {
       return {

--- a/frontend/js/components/Repeater.vue
+++ b/frontend/js/components/Repeater.vue
@@ -7,7 +7,7 @@
               ref="blockList"
               :block="block"
               :index="index"
-              :withHandle="draggable"
+              :withHandle="allowSortable && draggable"
               :size="blockSize"
               :opened="opened"
           >
@@ -107,6 +107,10 @@
         required: false,
       },
       allowCreate: {
+        type: Boolean,
+        default: true
+      },
+      allowSortable: {
         type: Boolean,
         default: true
       },

--- a/src/Services/Forms/Fields/Repeater.php
+++ b/src/Services/Forms/Fields/Repeater.php
@@ -4,17 +4,17 @@ namespace A17\Twill\Services\Forms\Fields;
 
 use A17\Twill\Services\Forms\Fields\Traits\CanReorder;
 use A17\Twill\Services\Forms\Fields\Traits\HasMax;
+use A17\Twill\Services\Forms\Fields\Traits\DisableActions;
 
 class Repeater extends BaseFormField
 {
     use HasMax;
     use CanReorder;
+    use DisableActions;
 
     protected ?string $type = null;
     protected bool $buttonAsLink = false;
     protected bool $allowCreate = true;
-    protected bool $allowSortable = true;
-    protected bool $allowActions = true;
     protected ?string $relation = null;
     protected ?array $browserModule = null;
 
@@ -61,20 +61,6 @@ class Repeater extends BaseFormField
     public function allowCreate(bool $allowCreate = true): static
     {
         $this->allowCreate = $allowCreate;
-
-        return $this;
-    }
-
-    public function allowSortable(bool $allowSortable = true): static
-    {
-        $this->allowSortable = $allowSortable;
-
-        return $this;
-    }
-
-    public function allowActions(bool $allowActions = true): static
-    {
-        $this->allowActions = $allowActions;
 
         return $this;
     }

--- a/src/Services/Forms/Fields/Repeater.php
+++ b/src/Services/Forms/Fields/Repeater.php
@@ -13,6 +13,7 @@ class Repeater extends BaseFormField
     protected ?string $type = null;
     protected bool $buttonAsLink = false;
     protected bool $allowCreate = true;
+    protected bool $allowSortable = true;
     protected ?string $relation = null;
     protected ?array $browserModule = null;
 
@@ -59,6 +60,13 @@ class Repeater extends BaseFormField
     public function allowCreate(bool $allowCreate = true): static
     {
         $this->allowCreate = $allowCreate;
+
+        return $this;
+    }
+
+    public function allowSortable(bool $allowSortable = true): static
+    {
+        $this->allowSortable = $allowSortable;
 
         return $this;
     }

--- a/src/Services/Forms/Fields/Repeater.php
+++ b/src/Services/Forms/Fields/Repeater.php
@@ -14,6 +14,7 @@ class Repeater extends BaseFormField
     protected bool $buttonAsLink = false;
     protected bool $allowCreate = true;
     protected bool $allowSortable = true;
+    protected bool $allowActions = true;
     protected ?string $relation = null;
     protected ?array $browserModule = null;
 
@@ -67,6 +68,13 @@ class Repeater extends BaseFormField
     public function allowSortable(bool $allowSortable = true): static
     {
         $this->allowSortable = $allowSortable;
+
+        return $this;
+    }
+
+    public function allowActions(bool $allowActions = true): static
+    {
+        $this->allowActions = $allowActions;
 
         return $this;
     }

--- a/src/Services/Forms/Fields/Traits/DisableActions.php
+++ b/src/Services/Forms/Fields/Traits/DisableActions.php
@@ -4,14 +4,14 @@ namespace A17\Twill\Services\Forms\Fields\Traits;
 
 trait DisableActions
 {
-    protected bool $actions = true;
+    protected bool $displayActions = true;
 
     /**
      * Adds a border around the options.
      */
-    public function disableActions(bool $actions = true): static
+    public function disableActions(bool $displayActions = true): static
     {
-        $this->displayActions = !$actions;
+        $this->displayActions = !$displayActions;
 
         return $this;
     }

--- a/src/Services/Forms/Fields/Traits/DisableActions.php
+++ b/src/Services/Forms/Fields/Traits/DisableActions.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace A17\Twill\Services\Forms\Fields\Traits;
+
+trait DisableActions
+{
+    protected bool $actions = true;
+
+    /**
+     * Adds a border around the options.
+     */
+    public function disableActions(bool $actions = true): static
+    {
+        $this->displayActions = !$actions;
+
+        return $this;
+    }
+}

--- a/src/Services/Forms/InlineRepeater.php
+++ b/src/Services/Forms/InlineRepeater.php
@@ -9,6 +9,8 @@ use A17\Twill\Services\Forms\Contracts\CanRenderForBlocks;
 use A17\Twill\Services\Forms\Fields\Repeater;
 use A17\Twill\Services\Forms\Traits\HasSubFields;
 use A17\Twill\Services\Forms\Traits\RenderForBlocks;
+use A17\Twill\Services\Forms\Fields\Traits\CanReorder;
+use A17\Twill\Services\Forms\Fields\Traits\DisableActions;
 use Illuminate\Contracts\View\View;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
@@ -17,6 +19,8 @@ class InlineRepeater implements CanHaveSubfields, CanRenderForBlocks
 {
     use RenderForBlocks;
     use HasSubFields;
+    use CanReorder;
+    use DisableActions;
 
     protected function __construct(
         private ?string $name = null,
@@ -25,8 +29,6 @@ class InlineRepeater implements CanHaveSubfields, CanRenderForBlocks
         private ?Collection $fields = null,
         private ?string $label = null,
         private bool $allowCreate = true,
-        private bool $allowSortable = true,
-        private bool $allowActions = true,
         private ?string $relation = null,
         private ?bool $allowBrowse = false,
         private ?array $browser = null,
@@ -34,6 +36,7 @@ class InlineRepeater implements CanHaveSubfields, CanRenderForBlocks
         private ?string $titleField = null,
         private ?bool $hideTitlePrefix = false,
         private ?bool $buttonAsLink = false,
+        private ?bool $displayActions = true,
         protected ?array $connectedTo = null,
     ) {
     }
@@ -93,20 +96,6 @@ class InlineRepeater implements CanHaveSubfields, CanRenderForBlocks
     public function disableCreate(bool $disableCreate = true): static
     {
         $this->allowCreate = ! $disableCreate;
-
-        return $this;
-    }
-
-    public function disableSortable(bool $disableSortable = true): static
-    {
-        $this->allowSortable = ! $disableSortable;
-
-        return $this;
-    }
-
-    public function disableActions(bool $disableActions = true): static
-    {
-        $this->allowActions = ! $disableActions;
 
         return $this;
     }
@@ -223,8 +212,8 @@ class InlineRepeater implements CanHaveSubfields, CanRenderForBlocks
             ->name($this->name)
             ->type($this->getRenderName())
             ->allowCreate($this->allowCreate)
-            ->allowSortable($this->allowSortable)
-            ->allowActions($this->allowActions)
+            ->disableReorder(!$this->reorder)
+            ->disableActions(!$this->displayActions)
             ->relation($this->relation ?? null)
             ->browserModule($this->allowBrowse ? $this->browser : null);
 

--- a/src/Services/Forms/InlineRepeater.php
+++ b/src/Services/Forms/InlineRepeater.php
@@ -36,7 +36,6 @@ class InlineRepeater implements CanHaveSubfields, CanRenderForBlocks
         private ?string $titleField = null,
         private ?bool $hideTitlePrefix = false,
         private ?bool $buttonAsLink = false,
-        private ?bool $displayActions = true,
         protected ?array $connectedTo = null,
     ) {
     }

--- a/src/Services/Forms/InlineRepeater.php
+++ b/src/Services/Forms/InlineRepeater.php
@@ -26,6 +26,7 @@ class InlineRepeater implements CanHaveSubfields, CanRenderForBlocks
         private ?string $label = null,
         private bool $allowCreate = true,
         private bool $allowSortable = true,
+        private bool $allowActions = true,
         private ?string $relation = null,
         private ?bool $allowBrowse = false,
         private ?array $browser = null,
@@ -99,6 +100,13 @@ class InlineRepeater implements CanHaveSubfields, CanRenderForBlocks
     public function disableSortable(bool $disableSortable = true): static
     {
         $this->allowSortable = ! $disableSortable;
+
+        return $this;
+    }
+
+    public function disableActions(bool $disableActions = true): static
+    {
+        $this->allowActions = ! $disableActions;
 
         return $this;
     }
@@ -216,6 +224,7 @@ class InlineRepeater implements CanHaveSubfields, CanRenderForBlocks
             ->type($this->getRenderName())
             ->allowCreate($this->allowCreate)
             ->allowSortable($this->allowSortable)
+            ->allowActions($this->allowActions)
             ->relation($this->relation ?? null)
             ->browserModule($this->allowBrowse ? $this->browser : null);
 

--- a/src/Services/Forms/InlineRepeater.php
+++ b/src/Services/Forms/InlineRepeater.php
@@ -25,6 +25,7 @@ class InlineRepeater implements CanHaveSubfields, CanRenderForBlocks
         private ?Collection $fields = null,
         private ?string $label = null,
         private bool $allowCreate = true,
+        private bool $allowSortable = true,
         private ?string $relation = null,
         private ?bool $allowBrowse = false,
         private ?array $browser = null,
@@ -91,6 +92,13 @@ class InlineRepeater implements CanHaveSubfields, CanRenderForBlocks
     public function disableCreate(bool $disableCreate = true): static
     {
         $this->allowCreate = ! $disableCreate;
+
+        return $this;
+    }
+
+    public function disableSortable(bool $disableSortable = true): static
+    {
+        $this->allowSortable = ! $disableSortable;
 
         return $this;
     }
@@ -207,6 +215,7 @@ class InlineRepeater implements CanHaveSubfields, CanRenderForBlocks
             ->name($this->name)
             ->type($this->getRenderName())
             ->allowCreate($this->allowCreate)
+            ->allowSortable($this->allowSortable)
             ->relation($this->relation ?? null)
             ->browserModule($this->allowBrowse ? $this->browser : null);
 

--- a/src/View/Components/Fields/Repeater.php
+++ b/src/View/Components/Fields/Repeater.php
@@ -11,10 +11,9 @@ class Repeater extends TwillFormComponent
         public string $type,
         public bool $buttonAsLink = false,
         public bool $reorder = true,
+        public bool $displayActions = true,
         public ?int $max = null,
         public bool $allowCreate = true,
-        public bool $allowSortable = true,
-        public bool $allowActions = true,
         public ?string $relation = null,
         public ?array $browserModule = null,
         // Generic

--- a/src/View/Components/Fields/Repeater.php
+++ b/src/View/Components/Fields/Repeater.php
@@ -13,6 +13,7 @@ class Repeater extends TwillFormComponent
         public bool $reorder = true,
         public ?int $max = null,
         public bool $allowCreate = true,
+        public bool $allowSortable = true,
         public ?string $relation = null,
         public ?array $browserModule = null,
         // Generic

--- a/src/View/Components/Fields/Repeater.php
+++ b/src/View/Components/Fields/Repeater.php
@@ -14,6 +14,7 @@ class Repeater extends TwillFormComponent
         public ?int $max = null,
         public bool $allowCreate = true,
         public bool $allowSortable = true,
+        public bool $allowActions = true,
         public ?string $relation = null,
         public ?array $browserModule = null,
         // Generic

--- a/views/partials/form/_repeater.blade.php
+++ b/views/partials/form/_repeater.blade.php
@@ -8,6 +8,7 @@
     @if ($relation) relation="{{$relation}}" @endif
     :allow-create="{{$allowCreate ? 'true' : 'false'}}"
     :allow-sortable="{{$allowSortable ? 'true' : 'false'}}"
+    :allow-actions="{{$allowActions ? 'true' : 'false' }}"
 ></a17-repeater>
 
 @unless($renderForBlocks)

--- a/views/partials/form/_repeater.blade.php
+++ b/views/partials/form/_repeater.blade.php
@@ -7,6 +7,7 @@
     @if ($buttonAsLink) :button-as-link="true" @endif
     @if ($relation) relation="{{$relation}}" @endif
     :allow-create="{{$allowCreate ? 'true' : 'false'}}"
+    :allow-sortable="{{$allowSortable ? 'true' : 'false'}}"
 ></a17-repeater>
 
 @unless($renderForBlocks)

--- a/views/partials/form/_repeater.blade.php
+++ b/views/partials/form/_repeater.blade.php
@@ -7,8 +7,7 @@
     @if ($buttonAsLink) :button-as-link="true" @endif
     @if ($relation) relation="{{$relation}}" @endif
     :allow-create="{{$allowCreate ? 'true' : 'false'}}"
-    :allow-sortable="{{$allowSortable ? 'true' : 'false'}}"
-    :allow-actions="{{$allowActions ? 'true' : 'false' }}"
+    :display-actions="{{$displayActions ? 'true' : 'false'}}"
 ></a17-repeater>
 
 @unless($renderForBlocks)


### PR DESCRIPTION
## Description

Attending to items reported in #2641.

- added `disableReorder()`
- added `disableActions()`
- fixed `disableCreate()` not hiding add buttons
- updated documentation for these methods