### PR TITLE
Fix issue with Relation column

### DIFF
--- a/src/Services/Listings/Columns/Relation.php
+++ b/src/Services/Listings/Columns/Relation.php
@@ -5,6 +5,7 @@ namespace A17\Twill\Services\Listings\Columns;
 use A17\Twill\Exceptions\ColumnMissingPropertyException;
 use A17\Twill\Models\Contracts\TwillModelContract;
 use A17\Twill\Services\Listings\TableColumn;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Str;
 
 class Relation extends TableColumn
@@ -44,9 +45,9 @@ class Relation extends TableColumn
             throw new ColumnMissingPropertyException('Relation column missing relation value: ' . $this->field);
         }
 
-        /** @var \Illuminate\Database\Eloquent\Collection $relation */
         $model->loadMissing($this->relation);
-        $relation = collect($model->getRelation($this->relation));
+        /** @var \Illuminate\Database\Eloquent\Collection $relation */
+        $relation = Collection::wrap($model->getRelation($this->relation));
 
         return $relation->pluck($this->field)->join(', ');
     }


### PR DESCRIPTION
## Description
The Relation column does not properly display the value of fields on *-to-one related models. When `collect()` receives an individual object (such as an Eloquent model) it will convert it to a `Collection`. However, when `Collection::wrap()` receives an individual object it *wraps* it in a `Collection`, which is the desired behavior.

## Related Issues
Fixes #2719
Fixes #2682 