### PR TITLE
Refactor endpoints initialization for Browser component

### DIFF
--- a/src/View/Components/Fields/Browser.php
+++ b/src/View/Components/Fields/Browser.php
@@ -50,8 +50,8 @@ class Browser extends TwillFormComponent
             default: $default
         );
 
-        if (!$this->endpoints) {
-            $endpointsFromModules = isset($this->modules) ? collect($this->modules)->map(function ($module) {
+        if (!$this->endpoints && isset($this->modules)) {
+            $this->endpoints = collect($this->modules)->map(function ($module) {
                 return [
                     'label' => $module['label'] ?? ucfirst($module['name']),
                     'value' => moduleRoute(
@@ -62,16 +62,14 @@ class Browser extends TwillFormComponent
                         false
                     ),
                 ];
-            })->toArray() : null;
+            })->toArray();
         }
 
-        $this->endpoints = $this->endpoints === [] ? $endpointsFromModules ?? [] : [];
-
         if (empty($this->endpoints)) {
-            $routeEndpoint = $this->moduleName;
-            if ($this->routePrefix) {
-                $routeEndpoint = Str::replaceFirst($this->routePrefix . '.', '', $this->moduleName);
-            }
+            $routeEndpoint = $this->routePrefix
+                ? Str::replaceFirst($this->routePrefix . '.', '', $this->moduleName)
+                : $this->moduleName;
+
             $this->endpoint = $this->endpoint ?? (empty($endpoints) ? moduleRoute(
             // Remove the route prefix from the moduleName.
                 $routeEndpoint,


### PR DESCRIPTION
<!--
  Thanks for opening a PR! Your contribution is much appreciated.
  Do you have any questions? Check out the contributing docs at https://github.com/area17/twill/blob/3.x/CONTRIBUTING.md, or ask in this Pull Request and a Twill maintainer will be happy to help :)
-->

## Description

<!-- Write a description of the changes introduced by this PR -->
<!-- If this is introducing a new feature, it would be great if you can create a stub for documentation including bullet points for how to use the feature, code snippets, etc. -->
This change aims to fix the initialization of the `endpoints` property when passed to the Browser component. Initially, we have
```
$this->endpoints = $this->endpoints === [] ? $endpointsFromModules ?? [] : [];
```
which always sets `$endpoints` to an empty array when a value is passed. The changes made here includes

- Removed the extra variable `$endpointsFromModules`, simplifying the assignment.
- and only re-assigning the `$endpoints` property if it is empty and if `$this->modules` exists.

## Related Issues

Fixes #2717 
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
