### PR TITLE
Timepicker only variant of the Datepicker is broken in twill 3.

### DIFF
--- a/frontend/js/components/DatePicker.vue
+++ b/frontend/js/components/DatePicker.vue
@@ -132,7 +132,7 @@
           wrap: true,
           altInput: true,
           altFormat: self.altFormatComputed,
-          dateFormat: self.enableTime ? 'Z' : 'Y-m-d', // This is the universal format that will be parsed by the back-end.
+          dateFormat: (self.enableTime && self.noCalendar) ? 'H:i:S' : (self.enableTime ? 'Z' : 'Y-m-d'), // This is the universal format that will be parsed by the back-end.
           static: self.staticMode,
           appendTo: self.staticMode ? self.$refs[self.refs.flatPicker] : undefined,
           enableTime: self.enableTime,
@@ -217,7 +217,8 @@
       },
       isValidTime: function (string) {
         const timeRegex = /^(0?[1-9]|1[0-2]):[0-5][0-9](?: (AM|PM))?$/i;
-        return timeRegex.test(string);
+        const time24HrRegex = /^([01]\d|2[0-3]):[0-5]\d(?::[0-5]\d)?$/;
+        return timeRegex.test(string) || time24HrRegex.test(string);
       }
     },
     mounted: function () {


### PR DESCRIPTION
This PR fixes format supplied by backend for timepicker only and also validate 24HR times when parsing dates.

When using the Timepicker only variant of the Datepicker, the date format supplied by the backend is in ISO 8601 format which is not compatible with the documented time migration  recommended for the timepicker (expects `H:i:S`).

24 HR times also do not pass `isValidTime` as this expects the time in AM, PM format.


