### PR TITLE
Changed hardcoded namespace for singleton models to retrieve the actual namespace

### DIFF
--- a/src/Http/Controllers/Admin/SingletonModuleController.php
+++ b/src/Http/Controllers/Admin/SingletonModuleController.php
@@ -18,7 +18,7 @@ abstract class SingletonModuleController extends ModuleController
 
     public function editSingleton()
     {
-        $model = "App\\Models\\{$this->getModelName()}";
+        $model = $this->getRepository()->getBaseModel()::class;
 
         if (!class_exists($model)) {
             $model = TwillCapsules::getCapsuleForModel($this->modelName)->getModel();


### PR DESCRIPTION
## Description

Currently, SingletonModuleController.php method editSingleton() has the model namespace hardcoded, and makes it impossible to place the model files in any subdirectory/namespace for better code organization. This can be fixed by retrieving the repository, from which we then retrieve the full base model namespace + class name.