### PR TITLE
Crop tool - set and then re-set crop properties

### DIFF
--- a/frontend/js/components/Cropper.vue
+++ b/frontend/js/components/Cropper.vue
@@ -189,13 +189,12 @@
         //
         // from my testing it seems to be a little inconsistent and unpredictable
         // I guess you just need for the rounding error to happen
-        // But, it seems setting the properties individually avoids this...
+        // But, it seems re-setting the properties individually avoids this...
         //
         // -- Mike (mike@area17.com)
+        this.cropper.setData(crop)
         this.cropper.setData({ x: crop.x })
         this.cropper.setData({ y: crop.y })
-        this.cropper.setData({ width: crop.width })
-        this.cropper.setData({ height: crop.height })
       },
       test: function () {
         const crop = this.toNaturalCrop({ x: 0, y: 0, width: 380, height: 475 })


### PR DESCRIPTION
## Description

When swapping between cropping ratios, the x/y positions were getting rest to unexpected values. It seems that setting crop props and then re-setting the x/y positions fixes this.

## Related Issues

- PR https://github.com/area17/twill/pull/2297
- Issue https://github.com/area17/twill/issues/1194