### PR TITLE
Fix: malformed model when creating a module using php artisan twill:make:module and selecting no traits

### DIFF
--- a/src/Commands/ModuleMake.php
+++ b/src/Commands/ModuleMake.php
@@ -388,7 +388,7 @@ class ModuleMake extends Command
     'list' => [
         ...
         [
-            
+
             'name' => '$name',
             'enabled' => true,
         ],
@@ -420,7 +420,7 @@ use A17\Twill\View\Components\Navigation\NavigationLink;
 public function boot()
 {
     ...
-    
+
     TwillNavigation::addLink(
         NavigationLink::make()->forModule('$key')
     );
@@ -434,7 +434,7 @@ use A17\Twill\View\Components\Navigation\NavigationLink;
 public function boot()
 {
     ...
-    
+
     TwillNavigation::addLink(
         NavigationLink::make()->forSingleton('$key')
     );
@@ -666,7 +666,7 @@ PHP;
             '{{baseModel}}',
         ], [
             $modelName,
-            $activeModelTraits->whenNotEmpty(fn ($t) => 'use ' . $t->join(', ') . ';'),
+            $activeModelTraits->whenNotEmpty(fn ($t) => 'use ' . $t->join(', ') . ';', fn () => ''),
             $activeModelTraitsImports->join("\n"),
             $activeModelImplements,
             $this->namespace('models', 'Models'),


### PR DESCRIPTION
<!--
  Thanks for opening a PR! Your contribution is much appreciated.
  Do you have any questions? Check out the contributing docs at https://github.com/area17/twill/blob/3.x/CONTRIBUTING.md, or ask in this Pull Request and a Twill maintainer will be happy to help :)
-->

## Description

This makes the `modelTraits` value fallback to an empty string when `$activeModelTraits` is empty.

<!-- Write a description of the changes introduced by this PR -->
<!-- If this is introducing a new feature, it would be great if you can create a stub for documentation including bullet points for how to use the feature, code snippets, etc. -->

## Related Issues

Fixes #2731
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
