### PR TITLE
Add support for repeaters crops configuration

### DIFF
--- a/docs/content/1_docs/4_form-fields/11_repeater.md
+++ b/docs/content/1_docs/4_form-fields/11_repeater.md
@@ -162,6 +162,32 @@ class ProjectController extends BaseModuleController
     }
 }
 ```
+### Medias
+
+If your json repeater contains media formField, you need to define the
+`mediasParams` at `config/twill.php` under `repeaters.crops` or `block_editor.crops`.
+
+```
+'repeaters' => [
+  'crops' => [
+     ‘your-media-field-name’ => [
+       …
+     ]
+  ],
+]
+```
+
+OR
+```
+'block_editor' => [
+  'crops' => [
+     ‘your-media-field-name’ => [
+       …
+     ]
+  ],
+]
+
+```
 
 | Option         | Description                                  | Type    | Default value    |
 |:---------------|:---------------------------------------------|:--------|:-----------------|

--- a/src/TwillBlocks.php
+++ b/src/TwillBlocks.php
@@ -311,7 +311,8 @@ class TwillBlocks
     public function getAllCropConfigs($prefixKey = false): array
     {
         if (! $this->cropConfigs) {
-            $this->cropConfigs = config()->get('twill.block_editor.crops');
+            $this->cropConfigs = config()->get('twill.block_editor.crops')
+                + (config()->get('twill.repeaters.crops') ?? []);
 
             /** @var Block $block */
             foreach ($this->getBlockCollection() as $block) {


### PR DESCRIPTION


## Description
This PR enhances the way crop configurations are handled for media fields in JSON repeaters. It updates the logic to merge in crops defined under `twill.repeaters.crops` along with the existing `twill.block_editor.crops`, enabling more flexibility and scoping for media field crops in repeaters.


