### PR TITLE
fix: Checkboxes not working

### DIFF
--- a/views/partials/form/_checkboxes.blade.php
+++ b/views/partials/form/_checkboxes.blade.php
@@ -23,7 +23,7 @@
 @push('vuexStore')
     window['{{ config('twill.js_namespace') }}'].STORE.form.fields.push({
         name: '{{ $name }}',
-        value: {!! json_encode(isset($item) && isset($item->$name) ? (is_string($item->$name) ? json_decode($item->$name) : Arr::pluck($item->$name, 'id')) : $formFieldsValue) !!}
+        value: {!! json_encode(isset($item) && isset($item->$name) ? (is_string($item->$name) ? json_decode($item->$name) : Arr::pluck($item->$name, 'id')) : []) !!}
     })
 @endpush
 @endunless


### PR DESCRIPTION
<!--
  Thanks for opening a PR! Your contribution is much appreciated.
  Do you have any questions? Check out the contributing docs at https://github.com/area17/twill/blob/3.x/CONTRIBUTING.md, or ask in this Pull Request and a Twill maintainer will be happy to help :)
-->

## Description

<!-- Write a description of the changes introduced by this PR -->
<!-- If this is introducing a new feature, it would be great if you can create a stub for documentation including bullet points for how to use the feature, code snippets, etc. -->
This PR fixes an issue where checkboxes would break if the corresponding field was not set on the model. Previously, when the field was missing, its value defaulted to an empty string (`''`). This led to a `TypeError: i.push is not a function` when interacting with the checkbox, since JavaScript cannot push values into a string.

The fix ensures the default value is an empty array instead, allowing checkboxes to function correctly even when the model field is unset.
## Related Issues
Fixes #2758 
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
