### PR TITLE
Properly set search string in Global Search

### DIFF
--- a/src/Repositories/ModuleRepository.php
+++ b/src/Repositories/ModuleRepository.php
@@ -156,7 +156,6 @@ abstract class ModuleRepository
     public function cmsSearch(string $search, array $fields = [], callable $query = null): Collection
     {
         $searchFilter = new FreeTextSearch();
-        $searchFilter->queryString($search);
         $searchFilter->searchFor($search);
         $searchFilter->searchColumns($fields);
         $searchFilter->searchQuery($query);

--- a/src/Repositories/ModuleRepository.php
+++ b/src/Repositories/ModuleRepository.php
@@ -157,6 +157,7 @@ abstract class ModuleRepository
     {
         $searchFilter = new FreeTextSearch();
         $searchFilter->queryString($search);
+        $searchFilter->searchFor($search);
         $searchFilter->searchColumns($fields);
         $searchFilter->searchQuery($query);
 


### PR DESCRIPTION
## Description

The [`cmsSearch()`](https://github.com/area17/twill/blob/3.x/src/Repositories/ModuleRepository.php#L156-L168) method in ModuleController uses the FreeTextSearch model and sets:

```
        $searchFilter->queryString($search);
        $searchFilter->searchColumns($fields);
        $searchFilter->searchQuery($query);
```

The FreeTextSearch model, however, has a condition that requires `searchString` to not be empty, and that value is never set in cmsSearch(). It gets set by the `searchFor()` method which never gets called.

Adding:

```
        $searchFilter->searchFor($search);
```

Makes global search work as expected for me.

## Related Issues

Fixes #2762

