### PR TITLE
Give a 404 status when a file does not exist

### DIFF
--- a/src/Http/Controllers/Front/GlideController.php
+++ b/src/Http/Controllers/Front/GlideController.php
@@ -7,6 +7,7 @@ use Illuminate\Config\Repository as Config;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
+use League\Glide\Filesystem\FileNotFoundException;
 
 class GlideController
 {
@@ -23,6 +24,10 @@ class GlideController
             return Storage::disk($disk)->response($path);
         }
 
-        return $app->make(Glide::class)->render($path);
+        try {
+            return $app->make(Glide::class)->render($path);
+        } catch (FileNotFoundException) {
+            abort(404);
+        }
     }
 }


### PR DESCRIPTION
When a visitor requests a non-existent image, a 500 server error is given because the Glide package throws a FileNotFoundException. We see this a lot in our error reports.

This change will convert this exception into a 404 HTTP status code.