### PR TITLE
Add `array` as the return type for `rulesForCreate` and `rulesForUpdate` methods.

### DIFF
--- a/src/Commands/stubs/request.stub
+++ b/src/Commands/stubs/request.stub
@@ -6,12 +6,12 @@ use {{baseRequest}};
 
 class {{requestClassName}} extends Request
 {
-    public function rulesForCreate()
+    public function rulesForCreate(): array
     {
         return [];
     }
 
-    public function rulesForUpdate()
+    public function rulesForUpdate(): array
     {
         return [];
     }


### PR DESCRIPTION
<!--
  Thanks for opening a PR! Your contribution is much appreciated.
  Do you have any questions? Check out the contributing docs at https://github.com/area17/twill/blob/3.x/CONTRIBUTING.md, or ask in this Pull Request and a Twill maintainer will be happy to help :)
-->

## Description

This pull request contains minor changes for generating classes that inherit from `Request`. It is recommended to specify the return types for the `rulesForCreate` and `rulesForUpdate` methods.
As Twill CMS supports PHP versions 8 and above, it would be beneficial to improve typing.

## Related Issues

There is no related issues, this is a suggestion.