### PR TITLE
Fix DatePicker timezone handling for non-UTC app.timezone

### DIFF
--- a/frontend/js/components/DatePicker.vue
+++ b/frontend/js/components/DatePicker.vue
@@ -15,7 +15,6 @@
 <script>
   import 'flatpickr/dist/flatpickr.css'
 
-  import parse from 'date-fns/parse'
   import FlatPickr from 'flatpickr'
 
   import FormStoreMixin from '@/mixins/formStore'
@@ -147,26 +146,54 @@
           altInputClass: 'flatpickr-input form-control',
           maxDate: self.maxDate,
           parseDate: function (date, format) {
-            const fullFormat = 'yyyy-MM-dd HH:mm:ss';
-            if (date.length === fullFormat.length) {
-              return parse(date + 'Z', fullFormat + 'X', Date.UTC());
-            }
-            const fullFormatNoSeconds = 'yyyy-MM-dd HH:mm';
-            if (date.length === fullFormatNoSeconds.length) {
-              return parse(date + 'Z', fullFormat + 'X', Date.UTC());
-            }
-            const fullFormatNoTime = 'yyyy-MM-dd';
-            if (date.length === fullFormatNoTime.length) {
-              return parse(date, fullFormatNoTime, Date.UTC());
+            // 1. ISO 8601 with timezone: "2026-01-15T13:00:00+00:00" or "2026-01-15T13:00:00Z"
+            if (/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[Z+-]/.test(date)) {
+              return new Date(date)
             }
 
+            // 2. ISO without timezone: "yyyy-MM-dd HH:mm:ss" or "yyyy-MM-dd HH:mm" → treat as UTC
+            if (/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}(:\d{2})?$/.test(date)) {
+              return new Date(date.replace(' ', 'T') + 'Z')
+            }
+
+            // 3. Date only ISO: "yyyy-MM-dd"
+            if (/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+              return new Date(date + 'T00:00:00Z')
+            }
+
+            // 4. European dot-separated: "dd.MM.yyyy HH:mm:ss" / "dd.MM.yyyy HH:mm" / "dd.MM.yyyy"
+            //    Used by: de, fr, it, pl, cs, sl, bs, no, ru, tr, uk
+            const euroMatch = date.match(/^(\d{2})\.(\d{2})\.(\d{4})(?:\s+(\d{2}):(\d{2})(?::(\d{2}))?)?$/)
+            if (euroMatch) {
+              const day = parseInt(euroMatch[1], 10)
+              const month = parseInt(euroMatch[2], 10) - 1
+              const year = parseInt(euroMatch[3], 10)
+              if (euroMatch[4] !== undefined) {
+                return new Date(year, month, day, parseInt(euroMatch[4], 10), parseInt(euroMatch[5], 10), parseInt(euroMatch[6] || '0', 10))
+              }
+              return new Date(year, month, day)
+            }
+
+            // 5. US slash-separated: "MM/dd/yyyy HH:mm" / "MM/dd/yyyy"
+            const usMatch = date.match(/^(\d{1,2})\/(\d{1,2})\/(\d{4})(?:\s+(\d{2}):(\d{2})(?::(\d{2}))?)?$/)
+            if (usMatch) {
+              const usMonth = parseInt(usMatch[1], 10) - 1
+              const usDay = parseInt(usMatch[2], 10)
+              const usYear = parseInt(usMatch[3], 10)
+              if (usMatch[4] !== undefined) {
+                return new Date(usYear, usMonth, usDay, parseInt(usMatch[4], 10), parseInt(usMatch[5], 10), parseInt(usMatch[6] || '0', 10))
+              }
+              return new Date(usYear, usMonth, usDay)
+            }
+
+            // 6. Time only (for timeOnly mode)
             if (self.isValidTime(date)) {
-              const currentDate = new Date();
-              date = `${currentDate.toDateString()} ${date}`;
+              const currentDate = new Date()
+              date = currentDate.toDateString() + ' ' + date
             }
 
-            // Hope for the best..
-            return new Date(date);
+            // 7. Fallback
+            return new Date(date)
           },
           onOpen: function () {
             setTimeout(function () {

--- a/frontend/js/components/PubAccordion.vue
+++ b/frontend/js/components/PubAccordion.vue
@@ -44,7 +44,6 @@
 </template>
 
 <script>
-  import parseJson from 'date-fns/parse'
   import { mapState } from 'vuex'
 
   import VisibilityMixin from '@/mixins/toggleVisibility'
@@ -90,8 +89,12 @@
         startDate: state => state.publication.startDate,
         endDate: state => state.publication.endDate
       }),
-      startDateForDisplay() {
-        return parseJson(this.startDate + 'Z').toISOString()
+      startDateForDisplay () {
+        const dateStr = this.startDate
+        if (/T.*[Z+-]/.test(dateStr)) {
+          return new Date(dateStr).toISOString()
+        }
+        return new Date(dateStr + 'Z').toISOString()
       },
       localizedDateDisplayFormat() {
         if (this.dateDisplayFormat) {

--- a/views/layouts/form.blade.php
+++ b/views/layouts/form.blade.php
@@ -192,8 +192,8 @@
     expiredLabel: '{{twillTrans('twill::lang.publisher.expired')}}',
     scheduledLabel: '{{twillTrans('twill::lang.publisher.scheduled')}}',
     submitDisableMessage: '{{ $submitDisableMessage ?? '' }}',
-    startDate: '{{ $item?->publish_start_date ?? '' }}',
-    endDate: '{{ $item?->publish_end_date ?? '' }}',
+    startDate: '{{ ($item?->publish_start_date instanceof \Carbon\Carbon) ? $item->publish_start_date->utc()->toIso8601String() : ($item?->publish_start_date ?? '') }}',
+    endDate: '{{ ($item?->publish_end_date instanceof \Carbon\Carbon) ? $item->publish_end_date->utc()->toIso8601String() : ($item?->publish_end_date ?? '') }}',
     visibility: '{{ $item?->isFillable('public') ? ($item?->public ? 'public' : 'private') : false }}',
     reviewProcess: {!! isset($reviewProcess) ? json_encode($reviewProcess) : '[]' !!},
     submitOptions: {!! isset($submitOptions) ? json_encode($submitOptions) : 'null' !!}

--- a/views/partials/form/_date_picker.blade.php
+++ b/views/partials/form/_date_picker.blade.php
@@ -21,9 +21,15 @@
 
 @unless($renderForBlocks || $renderForModal || (!isset($item->$name) && is_null($formFieldsValue = getFormFieldsValue($form_fields, $name))))
 @push('vuexStore')
+    @php
+        $dateValue = $item->$name ?? $formFieldsValue;
+        if ($dateValue instanceof \Carbon\Carbon) {
+            $dateValue = $dateValue->utc()->toIso8601String();
+        }
+    @endphp
     window['{{ config('twill.js_namespace') }}'].STORE.form.fields.push({
         name: '{{ $name }}',
-        value: {!! json_encode(e($item->$name ?? $formFieldsValue)) !!}
+        value: {!! json_encode($dateValue) !!}
     })
 @endpush
 @endunless


### PR DESCRIPTION
## Description

When `app.timezone` is set to a non-UTC timezone (e.g. `Europe/Berlin`), the DatePicker applies timezone offsets incorrectly, causing a double-offset when loading dates. This happens because the backend stores dates in `app.timezone` but the frontend always assumes UTC.

This PR fixes the issue by:

- **Always storing UTC in the database** — `HandleDates::prepareDatesField()` now calls `->utc()` after `Carbon::parse()`, ensuring dates are converted to UTC before Eloquent writes them
- **Outputting UTC ISO 8601 to the frontend** — Both `_date_picker.blade.php` and `form.blade.php` (publication dates) now format Carbon instances as `->utc()->toIso8601String()`, giving the browser an unambiguous timestamp
- **Robust `parseDate` in DatePicker.vue** — Replaced length-based format detection with regex-based matching that correctly handles ISO 8601 with timezone, ISO without timezone, date-only, European dot-separated (`dd.MM.yyyy`), and US slash-separated (`MM/dd/yyyy`) formats
- **Fixed `PubAccordion.vue`** — `startDateForDisplay` now detects ISO 8601 strings with timezone info instead of blindly appending `Z`
- **Added non-UTC timezone browser tests** — New `FrontendDateConversionNonUtcTest` and `ScheduleDatesNonUtcTest` verify correct behavior with `app.timezone=Europe/Berlin`

## Related Issues

Fixes #2798