### PR TITLE
Update PHP_CodeSniffer repository link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,7 @@ For PHP auto-formatting on save, you can use the [phpcsfixer](https://marketplac
 },
 ```
 
-For PHP contextual linting, you can use the [phpcs](https://marketplace.visualstudio.com/items?itemName=ikappas.phpcs) extension and then install [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) globally.
+For PHP contextual linting, you can use the [phpcs](https://marketplace.visualstudio.com/items?itemName=ikappas.phpcs) extension and then install [PHP_CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer) globally.
 
 ```
 composer global require "squizlabs/php_codesniffer=*"


### PR DESCRIPTION
PHP_CodeSniffer has moved to a new GitHub organization. The `squizlabs/PHP_CodeSniffer` repository is now archived and the project is actively maintained at https://github.com/PHPCSStandards/PHP_CodeSniffer.

See: https://github.com/squizlabs/PHP_CodeSniffer/issues/3932