### PR TITLE
Mitigate Axios supply-chain compromise (#2822)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@tiptap/starter-kit": "^2.2.1",
         "@tiptap/vue-2": "^2.2.1",
         "alpinejs": "^3.13.5",
-        "axios": "^0.30.2",
+        "axios": "0.30.3",
         "core-js": "^3.35.1",
         "cropperjs": "^1.6.1",
         "date-fns": "1.30.1",
@@ -4398,9 +4398,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "0.30.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.30.2.tgz",
-      "integrity": "sha512-0pE4RQ4UQi1jKY6p7u6i1Tkzqmu+d+/tHS7Q7rKunWLB9WyilBTpHHpXzPNMDj5hTbK0B0PTLSz07yqMBiF6xg==",
+      "version": "0.30.3",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.30.3.tgz",
+      "integrity": "sha512-5/tmEb6TmE/ax3mdXBc/Mi6YdPGxQsv+0p5YlciXWt3PHIn0VamqCXhRMtScnwY3lbgSXLneOuXAKUhgmSRpwg==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.4",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@tiptap/starter-kit": "^2.2.1",
     "@tiptap/vue-2": "^2.2.1",
     "alpinejs": "^3.13.5",
-    "axios": "^0.30.2",
+    "axios": "0.30.3",
     "core-js": "^3.35.1",
     "cropperjs": "^1.6.1",
     "date-fns": "1.30.1",
@@ -73,5 +73,8 @@
     "vue-template-compiler": "^2.7.16",
     "webpack-assets-manifest": "^5.1.0",
     "webpack-bundle-analyzer": "^4.10.1"
+  },
+  "overrides": {
+    "axios": "0.30.3"
   }
 }


### PR DESCRIPTION
Set the specified version of axios to a known safe version and do not allow transient dependencies to override this version.

See https://github.com/axios/axios/issues/10611


Fixes #2822 