### PR TITLE
fix duplicate key error when duplicating module with files attached

### DIFF
--- a/src/Repositories/Behaviors/HandleFiles.php
+++ b/src/Repositories/Behaviors/HandleFiles.php
@@ -120,7 +120,8 @@ trait HandleFiles
                 return [
                     $file->id => Collection::make($object->files()->getPivotColumns())->mapWithKeys(
                         function ($attribute) use ($file) {
-                            return [$attribute => $file->pivot->$attribute];
+                            $value = $attribute == 'id' ? null : $file->pivot->$attribute;
+                            return [$attribute => $value];
                         }
                     )->toArray(),
                 ];


### PR DESCRIPTION
## Description

Sets the ID of the duplicated file attachments to `null` to allow it to be set correctly to the current auto-increment value on insert to the DB.

## Related Issues

Fixes #2835 