### PR TITLE
applies filters to nested module browser field

### DIFF
--- a/src/Http/Controllers/Admin/ModuleController.php
+++ b/src/Http/Controllers/Admin/ModuleController.php
@@ -1841,8 +1841,23 @@ abstract class ModuleController extends Controller
             $scopes += ['accessible' => true];
         }
 
-        $appliedFilters = [];
+        $appliedFilters = $this->getIndexFilters();
 
+        return $this->transformIndexItems(
+            $this->repository->get(
+                with: $this->indexWith,
+                scopes: $scopes,
+                orders: $this->orderScope(),
+                perPage: $this->request->get('offset') ?? $this->perPage ?? 50,
+                forcePagination: $forcePagination,
+                appliedFilters: $appliedFilters
+            )
+        );
+    }
+
+    protected function getIndexFilters(): array
+    {
+        $appliedFilters = [];
         $requestFilters = $this->getRequestFilters();
 
         // Get the applied quick filter..
@@ -1874,16 +1889,7 @@ abstract class ModuleController extends Controller
             }
         }
 
-        return $this->transformIndexItems(
-            $this->repository->get(
-                with: $this->indexWith,
-                scopes: $scopes,
-                orders: $this->orderScope(),
-                perPage: $this->request->get('offset') ?? $this->perPage ?? 50,
-                forcePagination: $forcePagination,
-                appliedFilters: $appliedFilters
-            )
-        );
+        return $appliedFilters;
     }
 
     protected function transformIndexItems(Collection|LengthAwarePaginator $items): Collection|LengthAwarePaginator

--- a/src/Http/Controllers/Admin/NestedModuleController.php
+++ b/src/Http/Controllers/Admin/NestedModuleController.php
@@ -48,12 +48,15 @@ abstract class NestedModuleController extends ModuleController
             return $this->getIndexItems($scopes, true);
         }
 
+        $appliedFilters = $this->getIndexFilters();
+
         return $this->repository->get(
             $this->indexWith,
             $scopes,
             $this->orderScope(),
             request('offset') ?? $this->perPage ?? 50,
-            true
+            true,
+            $appliedFilters
         );
     }
 }


### PR DESCRIPTION
## Description

Applies filtering to browser fields for nested modules with `$showOnlyParentItemsInBrowsers` set to `false`.

## Related Issues

Fixes #2837 
