### PR TITLE
Make admin email login case-insensitive

### DIFF
--- a/src/Http/Controllers/Admin/LoginController.php
+++ b/src/Http/Controllers/Admin/LoginController.php
@@ -306,7 +306,17 @@ class LoginController extends Controller
      */
     protected function credentials(Request $request): array
     {
-        return array_merge($request->only($this->username(), 'password'), ['published' => 1]);
+        $credentials = $request->only($this->username(), 'password');
+
+        $email = $credentials[$this->username()] ?? null;
+
+        if ($this->username() === 'email' && is_string($email)) {
+            $credentials[$this->username()] = function ($query) use ($email) {
+                $query->whereRaw('LOWER(email) = ?', [mb_strtolower($email)]);
+            };
+        }
+
+        return array_merge($credentials, ['published' => 1]);
     }
 
     protected function autologin(): bool

--- a/tests/integration/LoginTest.php
+++ b/tests/integration/LoginTest.php
@@ -3,6 +3,7 @@
 namespace A17\Twill\Tests\Integration;
 
 use A17\Twill\Models\User;
+use Illuminate\Support\Facades\DB;
 use PragmaRX\Google2FA\Google2FA;
 
 class LoginTest extends TestCase
@@ -27,6 +28,39 @@ class LoginTest extends TestCase
         $this->assertSee('Settings');
 
         $this->assertSee('Logout');
+    }
+
+    public function testCanLoginWithDifferentEmailCase(): void
+    {
+        // Force a case-sensitive collation so this test doesn't pass by
+        // accident on a DB whose default collation already happens to be
+        // case-insensitive (e.g. MySQL's utf8mb4_0900_ai_ci).
+        $usersTable = (new User())->getTable();
+        $passwordResetsTable = config('twill.password_resets_table', 'twill_password_resets');
+
+        $originalCollation = DB::selectOne(
+            'SELECT COLLATION_NAME FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND COLUMN_NAME = ?',
+            [$usersTable, 'email']
+        )->COLLATION_NAME;
+
+        DB::statement('SET FOREIGN_KEY_CHECKS=0');
+        DB::statement("ALTER TABLE {$usersTable} MODIFY email VARCHAR(255) COLLATE utf8mb4_bin");
+        DB::statement("ALTER TABLE {$passwordResetsTable} MODIFY email VARCHAR(255) COLLATE utf8mb4_bin");
+        DB::statement('SET FOREIGN_KEY_CHECKS=1');
+
+        try {
+            $this->loginAs(
+                strtoupper($this->superAdmin()->email),
+                $this->superAdmin()->unencrypted_password
+            );
+
+            $this->assertAuthenticated();
+        } finally {
+            DB::statement('SET FOREIGN_KEY_CHECKS=0');
+            DB::statement("ALTER TABLE {$usersTable} MODIFY email VARCHAR(255) COLLATE {$originalCollation}");
+            DB::statement("ALTER TABLE {$passwordResetsTable} MODIFY email VARCHAR(255) COLLATE {$originalCollation}");
+            DB::statement('SET FOREIGN_KEY_CHECKS=1');
+        }
     }
 
     public function testCannotLoginWhenUserDisabled(): void


### PR DESCRIPTION
## Description

`LoginController::credentials()` passes the raw email input straight to the auth guard, so login is case-sensitive whenever the `email` column's collation is case-sensitive (e.g. Postgres, or MySQL with a `_bin`/case-sensitive collation) — a user created as `User@example.com` can't log in as `user@example.com`. Changed `credentials()` to match on `LOWER(email)` via a closure credential (Laravel's `EloquentUserProvider` has supported closures for custom query building since Laravel 8), so the match no longer depends on collation. Added an integration test that forces a case-sensitive collation on `email` for the duration of the test and restores it after — the default collation in this repo's own MySQL test DB is already case-insensitive, so a plain "log in with different case" test wouldn't have actually caught the regression.

Used AI assistance (Claude) to write and test this; reviewed the diff and ran the full LoginTest suite plus php-cs-fixer before opening.

## Related Issues

Fixes #2789
