### PR TITLE
Fix publish/unpublish for users listing (#2703)

### DIFF
--- a/src/Http/Controllers/Admin/ModuleController.php
+++ b/src/Http/Controllers/Admin/ModuleController.php
@@ -1922,7 +1922,7 @@ abstract class ModuleController extends Controller
                     'editInModal' => $this->getModuleRoute($itemId, 'edit'),
                     'updateUrl' => $this->getModuleRoute($itemId, 'update'),
                 ] : []) + ($this->getIndexOption('publish') && ($item->canPublish ?? true) ? [
-                    'published' => $publishable ? $item->published : null,
+                    'published' => $item->isFillable('published') ? $item->published : null,
                 ] : []) + ($this->getIndexOption('feature', $item) && ($item->canFeature ?? true) ? [
                     'featured' => $item->{$this->featureField},
                 ] : []) + (($this->getIndexOption('restore', $item) && $itemIsTrashed) ? [

--- a/tests/integration/Users/UsersTest.php
+++ b/tests/integration/Users/UsersTest.php
@@ -48,6 +48,35 @@ class UsersTest extends TestCase
         $this->assertJson($this->content());
     }
 
+    public function testCanPublishUser(): void
+    {
+        $user = $this->createUser();
+
+        $user->published = true;
+        $user->registered_at = now();
+        $user->save();
+
+        $listing = json_decode(
+            $this->ajax(
+                '/twill/users?sortKey=email&sortDir=asc&page=1&offset=20&columns[]=bulk&columns[]=published&columns[]=name&columns[]=email&columns[]=role_value&filter=%7B%22status%22:%22activated%22%7D'
+            )->content(),
+            true
+        );
+
+        $row = collect($listing['tableData'])->firstWhere('id', $user->id);
+
+        $this->assertTrue($row['published']);
+
+        $this->ajax('/twill/users/publish', 'PUT', [
+            'id' => $user->id,
+            'active' => $row['published'],
+        ])->assertStatus(200);
+
+        $user->refresh();
+
+        $this->assertFalse((bool) $user->published);
+    }
+
     public function testCanUpdateUser(): void
     {
         $user = $this->createUser(


### PR DESCRIPTION
## Description

`ModuleController::getIndexTableData()` only exposes the `published` key when the item is an instance of `TwillSchedulableModel`. `User` doesn't implement that interface (it has no scheduling, no `publish_start_date`/`publish_end_date`), even though it has a real, fillable `published` column. So the users listing always sends `published: null` for every row: the dropdown shows "Publish" regardless of actual state, and clicking it sends `active: null` to the publish endpoint, which fails `bool|required` validation and returns "Something wrong happened!".

Swapped the `TwillSchedulableModel` check for `$item->isFillable('published')` on that one key — the same condition the base `Model` class already uses for its own `published` scope — so any model with a `published` column reports the right state in listings, whether or not it also supports scheduling. `publish_start_date`/`publish_end_date` still gate on `TwillSchedulableModel` since those really are scheduling-only fields.

Added an integration test that creates and activates a user, reads the listing response, and confirms the publish endpoint actually toggles `published` instead of erroring. Ran it red against the unpatched code (fails on `assertTrue($row['published'])`) and green after the fix, plus the rest of `UsersTest` and phpcs/phpstan on the touched file.

Used AI assistance (Claude) to write and test this; reviewed the diff and the test run before opening.

## Related Issues

Fixes #2703
